### PR TITLE
Support external site Ansible configuration

### DIFF
--- a/ansible/roles/control_node/templates/termux-pkg-nightly.plist.j2
+++ b/ansible/roles/control_node/templates/termux-pkg-nightly.plist.j2
@@ -19,7 +19,9 @@
         <key>HOME</key>
         <string>{{ lookup('env', 'HOME') }}</string>
         <key>ANSIBLE_CONFIG</key>
-        <string>{{ stayturgid_repo_root | realpath }}/ansible/ansible.cfg</string>
+        <string>{{ ansible_config_file | realpath }}</string>
+        <key>STAYTURGID_ROOT</key>
+        <string>{{ stayturgid_repo_root | realpath }}</string>
     </dict>
     <key>StartCalendarInterval</key>
     <dict>

--- a/control/bin/ansible_exec.py
+++ b/control/bin/ansible_exec.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Run an Ansible playbook with the active site-overlay configuration.
+
+This is the small bridge used by direct ``just`` recipes.  It gives those
+recipes the same ANSIBLE_CONFIG precedence as ``deploy_fleet.py`` while still
+pinning product assets to this checkout.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from control.lib.ansible_context import AnsibleConfigError, require_inventory, resolve_ansible_context
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args or args[0] != "ansible-playbook":
+        print("Usage: ansible_exec.py ansible-playbook <playbook> [arguments...]", file=sys.stderr)
+        return 2
+
+    try:
+        context = resolve_ansible_context(REPO_ROOT)
+        require_inventory(context)
+    except AnsibleConfigError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    env = os.environ.copy()
+    env["ANSIBLE_CONFIG"] = str(context.config)
+    env["STAYTURGID_ROOT"] = str(REPO_ROOT)
+    command = ["ansible-playbook", "-e", f"stayturgid_repo_root={REPO_ROOT}", *args[1:]]
+    try:
+        return subprocess.run(command, cwd=REPO_ROOT, env=env).returncode
+    except FileNotFoundError:
+        print("ERROR: ansible-playbook not found (brew install ansible)", file=sys.stderr)
+        return 127
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/control/bin/deploy_fleet.py
+++ b/control/bin/deploy_fleet.py
@@ -30,12 +30,14 @@ from enum import Enum
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-ANSIBLE_CFG = REPO_ROOT / "ansible" / "ansible.cfg"
-INVENTORY = REPO_ROOT / "ansible" / "inventory" / "hosts.yml"
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from control.lib.ansible_context import AnsibleConfigError, require_inventory, resolve_ansible_context
+
 SITE_PLAYBOOK = REPO_ROOT / "ansible" / "playbooks" / "site.yml"
 MAC_SITE_PLAYBOOK = REPO_ROOT / "ansible" / "playbooks" / "control_node" / "site.yml"
 REQUIREMENTS = REPO_ROOT / "ansible" / "requirements.yml"
-COLLECTIONS_PATH = REPO_ROOT / ".ansible" / "collections"
 
 
 class Scope(str, Enum):
@@ -79,7 +81,11 @@ def load_play_env(env: dict[str, str]) -> None:
 
 def repo_env() -> dict[str, str]:
     env = os.environ.copy()
-    env["ANSIBLE_CONFIG"] = str(ANSIBLE_CFG)
+    context = resolve_ansible_context(REPO_ROOT, env)
+    # Canonicalizing the selected path preserves the caller's choice while
+    # making relative ANSIBLE_CONFIG values reliable from any product recipe.
+    env["ANSIBLE_CONFIG"] = str(context.config)
+    env["STAYTURGID_ROOT"] = str(REPO_ROOT)
     load_play_env(env)
     return env
 
@@ -96,8 +102,10 @@ def parse_inventory_hosts(data: dict, group: str = "stayturgid") -> list[str]:
 
 
 def inventory_hosts(group: str = "stayturgid") -> list[str]:
+    context = resolve_ansible_context(REPO_ROOT)
+    require_inventory(context)
     result = subprocess.run(
-        ["ansible-inventory", "-i", str(INVENTORY), "--list"],
+        ["ansible-inventory", "-i", str(context.inventory), "--list"],
         capture_output=True,
         text=True,
         check=True,
@@ -118,6 +126,7 @@ def require_ansible() -> None:
 
 
 def install_collections() -> None:
+    context = resolve_ansible_context(REPO_ROOT)
     subprocess.run(
         [
             "ansible-galaxy",
@@ -126,7 +135,7 @@ def install_collections() -> None:
             "-r",
             str(REQUIREMENTS),
             "-p",
-            str(COLLECTIONS_PATH),
+            str(context.collections_path),
         ],
         check=True,
         stdout=subprocess.DEVNULL,
@@ -167,7 +176,15 @@ def run_playbook(
     extra_vars: list[str] | None = None,
     verbose: int = 0,
 ) -> int:
-    cmd = ["ansible-playbook", str(playbook)]
+    # Inventory belongs to the active site config, while product files always
+    # belong to this checkout. Passing the latter explicitly prevents roles
+    # from inferring the product root from an overlay's ansible.cfg path.
+    cmd = [
+        "ansible-playbook",
+        str(playbook),
+        "-e",
+        f"stayturgid_repo_root={REPO_ROOT}",
+    ]
     if limit:
         cmd.extend(["--limit", ",".join(limit)])
     if check:
@@ -195,6 +212,7 @@ def deploy_mac(*, check: bool, tags: str = "mac", verbose: int = 0) -> int:
 
 def deploy(scope: Scope, hosts: list[str], *, check: bool, verbose: int = 0) -> int:
     require_ansible()
+    require_inventory(resolve_ansible_context(REPO_ROOT))
     warn_prerequisites(scope)
     install_collections()
 
@@ -270,6 +288,9 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         print("interrupted", file=sys.stderr)
         sys.exit(130)
+    except AnsibleConfigError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(2)
     except subprocess.CalledProcessError as exc:
         print(f"ERROR: command failed: {exc}", file=sys.stderr)
         sys.exit(exc.returncode or 1)

--- a/control/bin/termux_pkg_nightly.py
+++ b/control/bin/termux_pkg_nightly.py
@@ -24,7 +24,11 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-ANSIBLE_CFG = REPO_ROOT / "ansible" / "ansible.cfg"
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from control.lib.ansible_context import AnsibleConfigError, require_inventory, resolve_ansible_context
+
 PLAYBOOK = REPO_ROOT / "ansible" / "playbooks" / "fleet" / "termux-pkg-upgrade.yml"
 LOG_DIR = Path.home() / ".config" / "stayturgid" / "logs"
 LOG = LOG_DIR / "termux-pkg-nightly.log"
@@ -73,13 +77,18 @@ def main(argv: list[str] | None = None) -> int:
     if not PLAYBOOK.is_file():
         log("ERROR: missing playbook %s" % PLAYBOOK)
         return 2
-    if not ANSIBLE_CFG.is_file():
-        log("ERROR: missing %s" % ANSIBLE_CFG)
+    try:
+        context = resolve_ansible_context(REPO_ROOT)
+        require_inventory(context)
+    except AnsibleConfigError as exc:
+        log("ERROR: %s" % exc)
         return 2
 
     cmd = [
         "ansible-playbook",
         str(PLAYBOOK),
+        "-e",
+        "stayturgid_repo_root=%s" % REPO_ROOT,
     ]
     if args.limit:
         cmd.extend(["--limit", args.limit])
@@ -87,11 +96,13 @@ def main(argv: list[str] | None = None) -> int:
         cmd.extend(["--check", "--diff"])
 
     env = os.environ.copy()
-    env["ANSIBLE_CONFIG"] = str(ANSIBLE_CFG)
+    env["ANSIBLE_CONFIG"] = str(context.config)
+    env["STAYTURGID_ROOT"] = str(REPO_ROOT)
     # launchd has a minimal PATH; prefer Homebrew ansible.
     homebrew = "/opt/homebrew/bin:/usr/local/bin"
     env["PATH"] = homebrew + ":" + env.get("PATH", "/usr/bin:/bin")
 
+    log("start: config=%s (%s) inventory=%s" % (context.config, context.source, context.inventory))
     log("start: %s" % " ".join(cmd))
     try:
         r = subprocess.run(

--- a/control/lib/ansible_context.py
+++ b/control/lib/ansible_context.py
@@ -1,0 +1,106 @@
+"""Resolve the Ansible site overlay used by product-side entry points.
+
+The public checkout ships only a generic inventory example.  Real deployments
+therefore select a private site's ``ansible.cfg`` by explicit ``ANSIBLE_CONFIG``
+or, when unset, by the conventional ``STAYTURGID_SITE_DIR`` overlay.
+"""
+
+from __future__ import annotations
+
+import configparser
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+
+class AnsibleConfigError(RuntimeError):
+    """The selected Ansible configuration cannot be used for a deployment."""
+
+
+@dataclass(frozen=True)
+class AnsibleContext:
+    """Resolved configuration paths for one product invocation."""
+
+    config: Path
+    inventory: Path
+    collections_path: Path
+    source: str
+
+
+def _expand_path(value: str, *, base: Path) -> Path:
+    path = Path(value).expanduser()
+    return path if path.is_absolute() else base / path
+
+
+def _config_value(config: Path, name: str) -> str:
+    parser = configparser.ConfigParser(interpolation=None)
+    try:
+        with config.open(encoding="utf-8") as stream:
+            parser.read_file(stream)
+    except (OSError, configparser.Error) as exc:
+        raise AnsibleConfigError(f"Cannot read Ansible config {config}: {exc}") from exc
+    return parser.get("defaults", name, fallback="").strip()
+
+
+def resolve_ansible_context(
+    repo_root: Path,
+    environ: Mapping[str, str] | None = None,
+) -> AnsibleContext:
+    """Return the explicit, site-default, or generic-upstream Ansible context.
+
+    ``ANSIBLE_CONFIG`` always wins.  When it is absent, the private overlay
+    directory can be set with ``STAYTURGID_SITE_DIR``; its default is kept out
+    of the public inventory and is only a conventional local checkout path.
+    """
+
+    env = os.environ if environ is None else environ
+    explicit = env.get("ANSIBLE_CONFIG", "").strip()
+    if explicit:
+        config = _expand_path(explicit, base=Path.cwd()).resolve()
+        source = "ANSIBLE_CONFIG"
+    else:
+        site_dir = Path(env.get("STAYTURGID_SITE_DIR", "~/ops/site-djbclark")).expanduser()
+        site_config = site_dir / "ansible.cfg"
+        if site_config.is_file():
+            config = site_config.resolve()
+            source = "site overlay"
+        else:
+            config = (repo_root / "ansible" / "ansible.cfg").resolve()
+            source = "upstream fallback"
+
+    if not config.is_file():
+        if source == "ANSIBLE_CONFIG":
+            raise AnsibleConfigError(f"ANSIBLE_CONFIG points to a missing file: {config}")
+        raise AnsibleConfigError(f"Selected {source} Ansible config is missing: {config}")
+
+    inventory_value = _config_value(config, "inventory")
+    if not inventory_value:
+        raise AnsibleConfigError(f"Selected Ansible config has no [defaults] inventory: {config}")
+    inventory = _expand_path(inventory_value, base=config.parent).resolve()
+
+    collections_value = _config_value(config, "collections_path")
+    if collections_value:
+        first_collection_path = collections_value.split(os.pathsep, 1)[0]
+        collections_path = _expand_path(first_collection_path, base=config.parent).resolve()
+    else:
+        collections_path = (repo_root / ".ansible" / "collections").resolve()
+
+    return AnsibleContext(
+        config=config,
+        inventory=inventory,
+        collections_path=collections_path,
+        source=source,
+    )
+
+
+def require_inventory(context: AnsibleContext) -> None:
+    """Fail before a real invocation when the selected inventory is absent."""
+
+    if context.inventory.exists():
+        return
+    raise AnsibleConfigError(
+        f"Selected {context.source} config {context.config} refers to missing inventory "
+        f"{context.inventory}. Live deploys require a site overlay; set ANSIBLE_CONFIG "
+        "or STAYTURGID_SITE_DIR."
+    )

--- a/just/fleet.just
+++ b/just/fleet.just
@@ -11,7 +11,7 @@ deploy-legacy:
     @just _deploy_impl
 
 deploy host="":
-    @just _deploy_impl {{ if host == "" { "" } else { "--limit " + host } }}
+    @just _deploy_impl {{ host }}
 
 # ---------- Deploy Check (dry‑run) ----------
 _deploy_check_impl:
@@ -21,11 +21,11 @@ deploy-check-legacy:
     @just _deploy_check_impl
 
 deploy-check host="":
-    @just _deploy_check_impl {{ if host == "" { "" } else { "--limit " + host } }}
+    @just _deploy_check_impl {{ host }}
 
 # ---------- Mac Workstation ----------
 _deploy_mac_impl:
-    ansible-playbook {{ mac_site }} --tags mac
+    {{ ansible_playbook }} {{ mac_site }} --tags mac
 
 deploy-mac-legacy:
     @just _deploy_mac_impl
@@ -55,7 +55,7 @@ bootstrap-ssh host="":
 
 # ---------- Bootstrap APKs ----------
 _bootstrap_apks_impl:
-    ansible-playbook ansible/playbooks/fleet/ensure-bootstrap-apks.yml {{ limit_flag }}
+    {{ ansible_playbook }} ansible/playbooks/fleet/ensure-bootstrap-apks.yml {{ limit_flag }}
 
 bootstrap-apks-legacy:
     @just _bootstrap_apks_impl
@@ -65,7 +65,7 @@ bootstrap-apks:
 
 # ---------- Verify Bootstrap APKs ----------
 _verify_bootstrap_apks_impl:
-    ansible-playbook ansible/playbooks/fleet/verify-bootstrap-apks.yml {{ limit_flag }}
+    {{ ansible_playbook }} ansible/playbooks/fleet/verify-bootstrap-apks.yml {{ limit_flag }}
 
 verify-bootstrap-apks-legacy:
     @just _verify_bootstrap_apks_impl
@@ -75,7 +75,7 @@ verify-bootstrap-apks host="":
 
 # ---------- Ensure Shizuku ----------
 _ensure_shizuku_impl:
-    ansible-playbook ansible/playbooks/fleet/ensure-shizuku.yml {{ limit_flag }}
+    {{ ansible_playbook }} ansible/playbooks/fleet/ensure-shizuku.yml {{ limit_flag }}
 
 ensure-shizuku-legacy:
     @just _ensure_shizuku_impl
@@ -175,9 +175,9 @@ collections:
 
 # ---------- Syntax Check ----------
 _syntax_impl:
-    ansible-playbook ansible/playbooks/site.yml --syntax-check
-    ansible-playbook {{ mac_site }} --syntax-check
-    ansible-playbook ansible/playbooks/fleet/termux-pkg-upgrade.yml --syntax-check
+    {{ ansible_playbook }} ansible/playbooks/site.yml --syntax-check
+    {{ ansible_playbook }} {{ mac_site }} --syntax-check
+    {{ ansible_playbook }} ansible/playbooks/fleet/termux-pkg-upgrade.yml --syntax-check
 
 syntax-legacy:
     @just _syntax_impl
@@ -214,7 +214,7 @@ dryrun: deploy-check-legacy
 
 # ---------- Dryrun Termux ----------
 _dryrun_termux_impl:
-    ansible-playbook ansible/playbooks/fleet/termux-userland.yml --check --diff {{ limit_flag }}
+    {{ ansible_playbook }} ansible/playbooks/fleet/termux-userland.yml --check --diff {{ limit_flag }}
 
 dryrun-termux-legacy:
     @just _dryrun_termux_impl
@@ -255,12 +255,12 @@ ca-status: _ca_status_impl
 # Sign all device host keys + deploy certs.
 ca-sign:
     @mkdir -p "{{ env_var("HOME") }}/.ssh/host-certs"
-    @ansible-playbook ansible/playbooks/fleet/termux-userland.yml --tags ca 2>&1 || true
+    @{{ ansible_playbook }} ansible/playbooks/fleet/termux-userland.yml --tags ca 2>&1 || true
     @echo "Host certs signed. Run 'just deploy-mac' to update Mac known_hosts."
 
 # ---------- FIRERPA ----------
 _firerpa_deploy_impl:
-    ansible-playbook ansible/playbooks/fleet/firerpa.yml {{ limit_flag }} -e firerpa_enabled=true
+    {{ ansible_playbook }} ansible/playbooks/fleet/firerpa.yml {{ limit_flag }} -e firerpa_enabled=true
 
 firerpa-deploy-legacy:
     @just _firerpa_deploy_impl
@@ -269,7 +269,7 @@ firerpa-deploy:
     @just _firerpa_deploy_impl
 
 _firerpa_remove_impl:
-    ansible-playbook ansible/playbooks/fleet/firerpa.yml {{ limit_flag }} -e firerpa_enabled=false
+    {{ ansible_playbook }} ansible/playbooks/fleet/firerpa.yml {{ limit_flag }} -e firerpa_enabled=false
 
 firerpa-remove-legacy:
     @just _firerpa_remove_impl
@@ -308,4 +308,3 @@ verify-drift-legacy:
 
 verify-drift host="":
     @just _verify_drift_impl {{ if host == "" { "--all" } else { "--host " + host } }}
-

--- a/just/services.just
+++ b/just/services.just
@@ -15,7 +15,7 @@ system-homebrew-path-status:
 
 # Ansible: brew llama.cpp + download weights (~6GB).
 vlm-install:
-    ansible-playbook {{ mac_site }} -e stayturgid_vlm_enabled=true --tags vlm-models
+    {{ ansible_playbook }} {{ mac_site }} -e stayturgid_vlm_enabled=true --tags vlm-models
 
 # Manual foreground start (no launchd).
 vlm-server:
@@ -27,7 +27,7 @@ vlm-check:
 
 # Ansible: launchd agent.
 vlm-service-install:
-    ansible-playbook {{ mac_site }} -e stayturgid_vlm_enabled=true --tags vlm-service
+    {{ ansible_playbook }} {{ mac_site }} -e stayturgid_vlm_enabled=true --tags vlm-service
 
 # Health + launchctl summary.
 vlm-service-status:
@@ -90,11 +90,11 @@ hermes-doctor:
 
 # Ansible: install, configure, launchd plist.
 hermes-deploy:
-    ansible-playbook {{ mac_site }} --tags hermes
+    {{ ansible_playbook }} {{ mac_site }} --tags hermes
 
 # Ansible: remove plist + unload launchd.
 hermes-disable:
-    ansible-playbook {{ mac_site }} --tags agents -e stayturgid_hermes_enabled=false
+    {{ ansible_playbook }} {{ mac_site }} --tags agents -e stayturgid_hermes_enabled=false
 
 # Update hermes-agent package.
 hermes-update:
@@ -118,14 +118,14 @@ opencode-web-restart:
 
 # Ansible: install + load launchd agent.
 opencode-web-deploy:
-    ansible-playbook {{ mac_site }} --tags agents -e stayturgid_opencode_web_enabled=true
+    {{ ansible_playbook }} {{ mac_site }} --tags agents -e stayturgid_opencode_web_enabled=true
     @echo ""
     @-launchctl kickstart -k gui/$(id -u)/{{ opencode_web_label }} 2>/dev/null
     @echo "OpenCode web deployed. Verify: just opencode-web-status"
 
 # Ansible: remove plist + unload.
 opencode-web-disable:
-    ansible-playbook {{ mac_site }} --tags agents -e stayturgid_opencode_web_enabled=false
+    {{ ansible_playbook }} {{ mac_site }} --tags agents -e stayturgid_opencode_web_enabled=false
 
 # ── Fleet dashboard (Flask + HTMX, port 4097) ──────────────────────────────
 
@@ -144,14 +144,14 @@ dashboard-restart:
 
 # Ansible: install + load launchd agent.
 dashboard-deploy:
-    ansible-playbook {{ mac_site }} --tags agents -e stayturgid_dashboard_enabled=true
+    {{ ansible_playbook }} {{ mac_site }} --tags agents -e stayturgid_dashboard_enabled=true
     @echo ""
     @-launchctl kickstart -k gui/$(id -u)/{{ dashboard_label }} 2>/dev/null
     @echo "Dashboard deployed. Verify: just dashboard-status"
 
 # Ansible: remove plist + unload.
 dashboard-disable:
-    ansible-playbook {{ mac_site }} --tags agents -e stayturgid_dashboard_enabled=false
+    {{ ansible_playbook }} {{ mac_site }} --tags agents -e stayturgid_dashboard_enabled=false
 
 # tail -f dashboard.log.
 dashboard-logs:

--- a/justfile
+++ b/justfile
@@ -13,7 +13,8 @@
 set shell := ["bash", "-uc"]
 
 repo := justfile_directory()
-export ANSIBLE_CONFIG := repo + "/ansible/ansible.cfg"
+export STAYTURGID_ROOT := repo
+ansible_playbook := "python3 control/bin/ansible_exec.py ansible-playbook"
 
 hosts := env_var_or_default("hosts", "")
 scope := env_var_or_default("scope", "full")

--- a/tests/python/test_ansible_context.py
+++ b/tests/python/test_ansible_context.py
@@ -1,0 +1,74 @@
+"""Configuration precedence tests for the product/site Ansible boundary."""
+
+from pathlib import Path
+
+import ansible_context as ac
+import pytest
+
+
+def write_config(root: Path, inventory: str = "inventory/hosts.yml") -> Path:
+    config = root / "ansible.cfg"
+    config.write_text(
+        f"[defaults]\ninventory = {inventory}\ncollections_path = collections:product-collections\n",
+        encoding="utf-8",
+    )
+    return config
+
+
+def test_explicit_ansible_config_wins_over_site_overlay(tmp_path):
+    repo = tmp_path / "product"
+    (repo / "ansible").mkdir(parents=True)
+    write_config(repo / "ansible")
+    site = tmp_path / "site"
+    site.mkdir()
+    write_config(site)
+    explicit = tmp_path / "explicit"
+    explicit.mkdir()
+    config = write_config(explicit, "inventory/live.yml")
+    (explicit / "inventory").mkdir()
+    (explicit / "inventory" / "live.yml").write_text("all: {}\n", encoding="utf-8")
+
+    context = ac.resolve_ansible_context(
+        repo,
+        {"ANSIBLE_CONFIG": str(config), "STAYTURGID_SITE_DIR": str(site)},
+    )
+
+    assert context.source == "ANSIBLE_CONFIG"
+    assert context.config == config
+    assert context.inventory == explicit / "inventory" / "live.yml"
+    assert context.collections_path == explicit / "collections"
+
+
+def test_site_overlay_is_selected_when_no_config_is_supplied(tmp_path):
+    repo = tmp_path / "product"
+    (repo / "ansible").mkdir(parents=True)
+    write_config(repo / "ansible")
+    site = tmp_path / "site"
+    site.mkdir()
+    config = write_config(site)
+    (site / "inventory").mkdir()
+    (site / "inventory" / "hosts.yml").write_text("all: {}\n", encoding="utf-8")
+
+    context = ac.resolve_ansible_context(repo, {"STAYTURGID_SITE_DIR": str(site)})
+
+    assert context.source == "site overlay"
+    assert context.config == config
+    ac.require_inventory(context)
+
+
+def test_upstream_fallback_explains_missing_live_inventory(tmp_path):
+    repo = tmp_path / "product"
+    (repo / "ansible").mkdir(parents=True)
+    config = write_config(repo / "ansible")
+
+    context = ac.resolve_ansible_context(repo, {"STAYTURGID_SITE_DIR": str(tmp_path / "missing-site")})
+
+    assert context.source == "upstream fallback"
+    assert context.config == config
+    with pytest.raises(ac.AnsibleConfigError, match="Live deploys require a site overlay"):
+        ac.require_inventory(context)
+
+
+def test_missing_explicit_config_has_actionable_error(tmp_path):
+    with pytest.raises(ac.AnsibleConfigError, match="ANSIBLE_CONFIG points to a missing file"):
+        ac.resolve_ansible_context(tmp_path, {"ANSIBLE_CONFIG": str(tmp_path / "missing.cfg")})

--- a/tests/python/test_ansible_exec.py
+++ b/tests/python/test_ansible_exec.py
@@ -1,0 +1,41 @@
+"""Tests for direct just-recipe Ansible execution through the site resolver."""
+
+import ansible_exec as ae
+from ansible_context import AnsibleContext
+
+
+def test_ansible_exec_preserves_resolved_config_and_product_root(monkeypatch, tmp_path):
+    context = AnsibleContext(
+        config=tmp_path / "ansible.cfg",
+        inventory=tmp_path / "inventory" / "hosts.yml",
+        collections_path=tmp_path / "collections",
+        source="ANSIBLE_CONFIG",
+    )
+    seen = {}
+
+    monkeypatch.setattr(ae, "resolve_ansible_context", lambda repo: context)
+    monkeypatch.setattr(ae, "require_inventory", lambda selected: None)
+
+    def fake_run(command, **kwargs):
+        seen["command"] = command
+        seen["env"] = kwargs["env"]
+        seen["cwd"] = kwargs["cwd"]
+
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(ae.subprocess, "run", fake_run)
+
+    assert ae.main(["ansible-playbook", "ansible/playbooks/site.yml", "--syntax-check"]) == 0
+    assert seen["command"] == [
+        "ansible-playbook",
+        "-e",
+        f"stayturgid_repo_root={ae.REPO_ROOT}",
+        "ansible/playbooks/site.yml",
+        "--syntax-check",
+    ]
+    assert seen["env"]["ANSIBLE_CONFIG"] == str(context.config)
+    assert seen["env"]["STAYTURGID_ROOT"] == str(ae.REPO_ROOT)
+    assert seen["cwd"] == ae.REPO_ROOT

--- a/tests/python/test_deploy_fleet.py
+++ b/tests/python/test_deploy_fleet.py
@@ -35,6 +35,8 @@ def test_run_playbook_argv_full(monkeypatch):
     assert seen[0] == [
         "ansible-playbook",
         str(df.SITE_PLAYBOOK),
+        "-e",
+        f"stayturgid_repo_root={df.REPO_ROOT}",
         "--limit",
         "s24,hd8",
     ]
@@ -72,6 +74,8 @@ def test_run_playbook_argv_check_and_tags(monkeypatch):
     assert seen[0] == [
         "ansible-playbook",
         str(df.SITE_PLAYBOOK),
+        "-e",
+        f"stayturgid_repo_root={df.REPO_ROOT}",
         "--limit",
         "s24",
         "--check",
@@ -198,5 +202,7 @@ def test_load_play_env_missing_file(tmp_path, monkeypatch):
 def test_repo_env_includes_ansible_config(monkeypatch, tmp_path):
     monkeypatch.setattr(df.Path, "home", classmethod(lambda cls, _t=tmp_path: _t))
     monkeypatch.delenv("GPLAY_EMAIL", raising=False)
+    monkeypatch.setenv("STAYTURGID_SITE_DIR", str(tmp_path / "missing-site"))
     env = df.repo_env()
-    assert env["ANSIBLE_CONFIG"] == str(df.ANSIBLE_CFG)
+    assert env["ANSIBLE_CONFIG"] == str(df.REPO_ROOT / "ansible" / "ansible.cfg")
+    assert env["STAYTURGID_ROOT"] == str(df.REPO_ROOT)

--- a/tests/python/test_termux_pkg_nightly.py
+++ b/tests/python/test_termux_pkg_nightly.py
@@ -1,0 +1,47 @@
+"""The nightly launchd runner must use the same site-overlay precedence."""
+
+import termux_pkg_nightly as nightly
+from ansible_context import AnsibleContext
+
+
+def test_nightly_runner_uses_resolved_site_config(monkeypatch, tmp_path):
+    context = AnsibleContext(
+        config=tmp_path / "site" / "ansible.cfg",
+        inventory=tmp_path / "site" / "inventory" / "hosts.yml",
+        collections_path=tmp_path / "collections",
+        source="site overlay",
+    )
+    seen = {}
+
+    monkeypatch.setattr(nightly, "resolve_ansible_context", lambda repo: context)
+    monkeypatch.setattr(nightly, "require_inventory", lambda selected: None)
+    monkeypatch.setattr(nightly, "LOG_DIR", tmp_path / "logs")
+    monkeypatch.setattr(nightly, "LOG", tmp_path / "logs" / "nightly.log")
+    monkeypatch.setattr(nightly, "trim_log", lambda: None)
+
+    def fake_run(command, **kwargs):
+        seen["command"] = command
+        seen["env"] = kwargs["env"]
+
+        class Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr(nightly.subprocess, "run", fake_run)
+
+    assert nightly.main(["--check", "--limit", "oneui-device"]) == 0
+    assert seen["command"] == [
+        "ansible-playbook",
+        str(nightly.PLAYBOOK),
+        "-e",
+        f"stayturgid_repo_root={nightly.REPO_ROOT}",
+        "--limit",
+        "oneui-device",
+        "--check",
+        "--diff",
+    ]
+    assert seen["env"]["ANSIBLE_CONFIG"] == str(context.config)
+    assert seen["env"]["STAYTURGID_ROOT"] == str(nightly.REPO_ROOT)


### PR DESCRIPTION
## Summary
- resolve explicit or conventional site-overlay Ansible configuration for deploy tools and direct just recipes
- route the site wrapper and nightly launchd job through that configuration
- inject the product checkout separately so overlay configuration cannot redirect product assets

## Verification
- focused pytest (21 tests)
- `just check`
- site-config syntax checks
- nightly plist regenerated with the site config; the reachable-host dry run advanced under the overlay but exceeded a four-minute safety bound before recap

No real deployment was performed.