### PR TITLE
B5.1: Context-aware site identity validation

### DIFF
--- a/ansible/inventory/hosts.yml.example
+++ b/ansible/inventory/hosts.yml.example
@@ -32,6 +32,15 @@ all:
         ansible_ssh_private_key_file: "{{ lookup('env', 'HOME') }}/.ssh/termux_key"
         stayturgid_device_id: "{{ inventory_hostname }}"
         stayturgid_automation_mode: autojs6
+        # Generic control-node placeholders (RFC 5737 / example Tailscale).
+        # Site overlays replace these with real peer identity.
+        stayturgid_control_ssh_user: operator
+        stayturgid_mac_peer:
+          user: operator
+          lan: 192.0.2.1
+          tailscale: 100.0.0.1
+        stayturgid_hermes_telegram_allowed_users: ""
+        stayturgid_hermes_telegram_home_channel: ""
 
     android_16:
       hosts: { oneui-device: {}, stock-android-device: {} }

--- a/control/bin/validate_site_identity.py
+++ b/control/bin/validate_site_identity.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python3
 """Validate the stayturgid site identity and check for configuration drift.
 
-Operators: run after editing ``ansible/inventory/hosts.yml`` or before
-any fleet deploy to catch divergence between declared and hard-coded
-identity.
+Operators: run after editing site inventory or before any fleet deploy to catch
+divergence between declared and hard-coded identity.
+
+Inventory resolution reuses ``control/lib/ansible_context.py``:
+
+* ``ANSIBLE_CONFIG`` wins when set
+* else the site overlay (``STAYTURGID_SITE_DIR``, default ``~/ops/site-djbclark``)
+* else the upstream generic/example inventory
 
     python3 control/bin/validate_site_identity.py
     python3 control/bin/validate_site_identity.py --check-drift
     python3 control/bin/validate_site_identity.py --check-secrets
-    python3 control/bin/validate_site_identity.py --host s24
+    python3 control/bin/validate_site_identity.py --host oneui-device
     python3 control/bin/validate_site_identity.py --json
 
 Exit codes:
@@ -20,6 +25,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import ipaddress
 import json
 import re
 import sys
@@ -57,6 +63,45 @@ def _load_si():
 
 
 # ---------------------------------------------------------------------------
+# Generic fixture recognition (multi-site-topology §4.1 + RFC 5737)
+# ---------------------------------------------------------------------------
+
+# Platform-describing example aliases — intentional in generic docs/tools.
+_GENERIC_ALIASES = frozenset(
+    {
+        "oneui-device",
+        "stock-android-device",
+        "fireos-device",
+    }
+)
+
+_GENERIC_NETWORKS = tuple(
+    ipaddress.ip_network(n)
+    for n in (
+        "192.0.2.0/24",  # TEST-NET-1
+        "198.51.100.0/24",  # TEST-NET-2
+        "203.0.113.0/24",  # TEST-NET-3
+        "100.0.0.0/24",  # example Tailscale range used in §4.1
+    )
+)
+
+
+def is_generic_fixture(value: str) -> bool:
+    """Return True when *value* is reserved documentation/example identity."""
+    if not value or value == "-":
+        return True
+    if value in _GENERIC_ALIASES:
+        return True
+    if value.startswith("EXAMPLE-") or value.startswith("example-"):
+        return True
+    try:
+        addr = ipaddress.ip_address(value)
+    except ValueError:
+        return False
+    return any(addr in net for net in _GENERIC_NETWORKS)
+
+
+# ---------------------------------------------------------------------------
 # Drift scanner
 # ---------------------------------------------------------------------------
 
@@ -67,7 +112,7 @@ _SCAN_EXTS = {".py", ".sh", ".yml", ".yaml", ".json", ".toml", ".j2", ".conf", "
 _SKIP_PREFIXES = (
     "ansible/inventory/",  # SSOT — literals here are correct
     "tests/",  # test fixtures intentionally use literals
-    "docs/",  # documentation
+    "docs/",  # documentation (historical banners / architecture examples)
     "examples/",  # example configs
     ".ansible/",  # downloaded collections
     "node_modules/",
@@ -87,20 +132,21 @@ def _should_skip(rel: str) -> bool:
 
 
 def _build_drift_patterns(site) -> list[tuple[str, str]]:
-    """Return (pattern, description) pairs for every production literal."""
+    """Return (pattern, description) pairs for every non-generic production literal."""
     patterns: list[tuple[str, str]] = []
 
     for alias, dev in site.devices.items():
         # Device alias as a standalone word (not part of e.g. "s24ultra")
-        patterns.append((rf"\b{re.escape(alias)}\b", f"device alias '{alias}'"))
+        if not is_generic_fixture(alias):
+            patterns.append((rf"\b{re.escape(alias)}\b", f"device alias '{alias}'"))
 
         # Tailscale / management IP
-        if dev.ansible_host and dev.ansible_host != "-":
+        if dev.ansible_host and dev.ansible_host != "-" and not is_generic_fixture(dev.ansible_host):
             ip_esc = re.escape(dev.ansible_host)
             patterns.append((ip_esc, f"ansible_host IP '{dev.ansible_host}' ({alias})"))
 
         # USB serial
-        if dev.device_usb_serial and dev.device_usb_serial != "-":
+        if dev.device_usb_serial and dev.device_usb_serial != "-" and not is_generic_fixture(dev.device_usb_serial):
             patterns.append(
                 (
                     re.escape(dev.device_usb_serial),
@@ -109,15 +155,15 @@ def _build_drift_patterns(site) -> list[tuple[str, str]]:
             )
 
         # LAN IP
-        if dev.device_lan_ip and dev.device_lan_ip != "-":
+        if dev.device_lan_ip and dev.device_lan_ip != "-" and not is_generic_fixture(dev.device_lan_ip):
             ip_esc = re.escape(dev.device_lan_ip)
             patterns.append((ip_esc, f"LAN IP '{dev.device_lan_ip}' ({alias})"))
 
     # Control node
     cn = site.control_node
-    if cn.lan_ip:
+    if cn.lan_ip and not is_generic_fixture(cn.lan_ip):
         patterns.append((re.escape(cn.lan_ip), f"control node LAN IP '{cn.lan_ip}'"))
-    if cn.tailscale_ip:
+    if cn.tailscale_ip and not is_generic_fixture(cn.tailscale_ip):
         patterns.append((re.escape(cn.tailscale_ip), f"control node Tailscale IP '{cn.tailscale_ip}'"))
 
     return patterns
@@ -130,6 +176,8 @@ def check_drift(site, root: Path) -> list[dict]:
         {file, line, pattern_desc, excerpt}
     """
     compiled = [(re.compile(pat), desc) for pat, desc in _build_drift_patterns(site)]
+    if not compiled:
+        return []
     violations: list[dict] = []
 
     # Use git ls-files for tracked files only (fast, honours .gitignore)
@@ -304,7 +352,7 @@ def main() -> int:
     parser.add_argument(
         "--check-secrets",
         action="store_true",
-        help="Scan hosts.yml for secret-shaped strings.",
+        help="Scan inventory for secret-shaped strings.",
     )
     parser.add_argument(
         "--force-refresh",
@@ -314,7 +362,7 @@ def main() -> int:
     parser.add_argument(
         "--warn-only",
         action="store_true",
-        help="Print violations but always exit 0 (advisory / pre-Phase-2 mode).",
+        help="Print violations but always exit 0 (advisory / migration mode).",
     )
     parser.add_argument(
         "--json",
@@ -332,7 +380,15 @@ def main() -> int:
 
     si = _load_si()
 
-    inventory_path = root / "ansible" / "inventory" / "hosts.yml"
+    # ---- Resolve inventory via shared Ansible context ----
+    try:
+        inventory_path = si.resolve_inventory_path(repo_root=root)
+    except FileNotFoundError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        if args.warn_only:
+            print("identity: WARN — inventory is unavailable (warn-only mode)")
+            return 0
+        return 2
 
     # ---- Load site identity ----
     try:
@@ -397,6 +453,7 @@ def main() -> int:
         output = {
             "valid": exit_code == 0,
             "warn_only": args.warn_only,
+            "inventory_path": str(inventory_path),
             "site": {
                 "devices": {a: asdict(d) for a, d in site.devices.items()},
                 "control_node": asdict(site.control_node),
@@ -412,6 +469,7 @@ def main() -> int:
         return 0 if args.warn_only else exit_code
 
     # Human-readable output
+    print(f"inventory: {inventory_path}")
     _print_site_summary(site, None)
     if args.check_drift:
         _print_drift(drift_violations, args.json_out)
@@ -423,10 +481,7 @@ def main() -> int:
 
     if exit_code != 0 and args.warn_only:
         n = len(drift_violations) + len(secret_findings)
-        print(
-            f"identity: WARN — {n} violation(s) found (warn-only mode; "
-            "run without --warn-only for hard exit — Phase 2 will fix these)"
-        )
+        print(f"identity: WARN — {n} violation(s) found (warn-only mode; run without --warn-only for hard exit)")
         return 0
 
     return exit_code

--- a/control/lib/site_identity.py
+++ b/control/lib/site_identity.py
@@ -12,13 +12,15 @@ Usage::
     for alias, device in site.devices.items():
         print(alias, device.ansible_host)
 
-The module calls ``ansible-inventory --list`` to export the inventory as JSON,
-validates the schema, and caches the result to
-``~/.config/stayturgid/.identity_cache.json``.  The cache is invalidated
-whenever ``ansible/inventory/hosts.yml`` is newer than the cache file.
+The module resolves the active inventory via :mod:`ansible_context`
+(explicit ``ANSIBLE_CONFIG``, site overlay, or upstream fallback), calls
+``ansible-inventory --list`` to export JSON, validates the schema, and caches
+the result to ``~/.config/stayturgid/.identity_cache.json``.  The cache is
+keyed by inventory path and invalidated when the inventory is newer than the
+cache file.
 
-Uses only the Python standard library: ``dataclasses``, ``ipaddress``,
-``json``, ``pathlib``, ``re``, ``subprocess``.
+Uses only the Python standard library plus the sibling ``ansible_context``
+module.
 """
 
 from __future__ import annotations
@@ -29,6 +31,9 @@ import re
 import subprocess
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Mapping
+
+import ansible_context as ac
 
 # ---------------------------------------------------------------------------
 # Cache location
@@ -246,10 +251,11 @@ def _parse_inventory(data: dict) -> Site:
 # ---------------------------------------------------------------------------
 
 
-def _write_cache(site: Site) -> None:
+def _write_cache(site: Site, inventory_path: Path) -> None:
     try:
         _CACHE_DIR.mkdir(parents=True, exist_ok=True)
         payload = {
+            "inventory_path": str(inventory_path.resolve()),
             "telegram_allowed_users": list(site.telegram_allowed_users),
             "telegram_home_channel": site.telegram_home_channel,
             "devices": {alias: asdict(dev) for alias, dev in site.devices.items()},
@@ -261,9 +267,12 @@ def _write_cache(site: Site) -> None:
         pass
 
 
-def _read_cache() -> Site | None:
+def _read_cache(expected_inventory: Path) -> Site | None:
     try:
         payload = json.loads(_CACHE_FILE.read_text(encoding="utf-8"))
+        cached_path = payload.get("inventory_path")
+        if cached_path is None or Path(cached_path).resolve() != expected_inventory.resolve():
+            return None
         devices = {alias: Device(**dev) for alias, dev in payload["devices"].items()}
         control_node = ControlNode(**payload["control_node"])
         return Site(
@@ -280,7 +289,78 @@ def _cache_fresh(hosts_yml: Path) -> bool:
     """Return True if the cache is newer than the inventory source file."""
     if not _CACHE_FILE.is_file():
         return False
-    return _CACHE_FILE.stat().st_mtime > hosts_yml.stat().st_mtime
+    try:
+        return _CACHE_FILE.stat().st_mtime > hosts_yml.stat().st_mtime
+    except OSError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Inventory resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_inventory_path(
+    repo_root: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+    inventory_path: Path | None = None,
+) -> Path:
+    """Return the inventory file used for identity loading.
+
+    Order:
+    1. Explicit ``inventory_path`` argument (tests / callers).
+    2. Inventory from :func:`ansible_context.resolve_ansible_context`.
+    3. When that path is missing, the committed generic example
+       (``ansible/inventory/hosts.yml.example``), which is always present on a
+       fresh clone.  Ansible only auto-detects ``.yml``; the example is
+       materialised to a temporary path by the loader when needed.
+    """
+    if inventory_path is not None:
+        return inventory_path
+
+    root = repo_root if repo_root is not None else _find_repo_root()
+    try:
+        context = ac.resolve_ansible_context(root, environ)
+        if context.inventory.is_file():
+            return context.inventory
+    except ac.AnsibleConfigError:
+        pass
+
+    example = root / "ansible" / "inventory" / "hosts.yml.example"
+    if example.is_file():
+        return example
+    raise FileNotFoundError(
+        "No inventory available: set ANSIBLE_CONFIG or STAYTURGID_SITE_DIR to a "
+        "site overlay, or ensure ansible/inventory/hosts.yml.example exists"
+    )
+
+
+def _ansible_listable_path(inventory_path: Path, tmp_dir: Path | None = None) -> Path:
+    """Return a path ansible-inventory will accept as YAML inventory.
+
+    Ansible's yaml inventory plugin declines non-``.yml``/``.yaml`` suffixes, so
+    ``hosts.yml.example`` must be materialised to a ``.yml`` path first.
+    """
+    if inventory_path.suffix in {".yml", ".yaml"} and inventory_path.name != "hosts.yml.example":
+        return inventory_path
+    if inventory_path.name.endswith(".yml.example") or inventory_path.suffix == ".example":
+        import tempfile
+
+        target_dir = tmp_dir if tmp_dir is not None else Path(tempfile.mkdtemp(prefix="stayturgid-inv-"))
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target = target_dir / "hosts.yml"
+        target.write_text(inventory_path.read_text(encoding="utf-8"), encoding="utf-8")
+        # Copy sibling group_vars when present so ansible-inventory expands them.
+        src_gv = inventory_path.parent / "group_vars"
+        if src_gv.is_dir():
+            import shutil
+
+            dest_gv = target_dir / "group_vars"
+            if dest_gv.exists():
+                shutil.rmtree(dest_gv)
+            shutil.copytree(src_gv, dest_gv)
+        return target
+    return inventory_path
 
 
 # ---------------------------------------------------------------------------
@@ -291,40 +371,50 @@ def _cache_fresh(hosts_yml: Path) -> bool:
 def load_site_identity(
     force_refresh: bool = False,
     inventory_path: Path | None = None,
+    environ: Mapping[str, str] | None = None,
+    repo_root: Path | None = None,
 ) -> Site:
     """Return the current site identity from the Ansible inventory.
 
     Args:
         force_refresh: Skip the cache and re-run ``ansible-inventory``.
-        inventory_path: Override the default inventory path (for testing).
+        inventory_path: Override the resolved inventory path (for testing).
+        environ: Optional environment mapping for Ansible context resolution.
+        repo_root: Optional repository root (defaults to discovery from this file).
 
     Returns:
         A validated, immutable :class:`Site` dataclass.
 
     Raises:
-        FileNotFoundError: If the inventory file does not exist.
+        FileNotFoundError: If no inventory file can be resolved.
         RuntimeError: If ``ansible-inventory`` fails or returns invalid JSON.
         ValueError: If the inventory fails schema validation.
     """
-    if inventory_path is None:
-        root = _find_repo_root()
-        inventory_path = root / "ansible" / "inventory" / "hosts.yml"
+    root = repo_root if repo_root is not None else _find_repo_root()
+    inventory_path = resolve_inventory_path(
+        repo_root=root,
+        environ=environ,
+        inventory_path=inventory_path,
+    )
 
     if not inventory_path.is_file():
         raise FileNotFoundError(f"Authoritative inventory not found at: {inventory_path}")
 
-    # Serve from cache when fresh
+    # Serve from cache when fresh for this inventory path
     if not force_refresh and _cache_fresh(inventory_path):
-        cached = _read_cache()
+        cached = _read_cache(inventory_path)
         if cached is not None:
             return cached
 
+    listable = _ansible_listable_path(inventory_path)
+
     # Export inventory to JSON via ansible-inventory
     result = subprocess.run(
-        ["ansible-inventory", "-i", str(inventory_path), "--list"],
+        ["ansible-inventory", "-i", str(listable), "--list"],
         capture_output=True,
         text=True,
         check=False,
+        cwd=str(listable.parent),
     )
     if result.returncode != 0:
         raise RuntimeError(f"ansible-inventory failed:\nstdout: {result.stdout}\nstderr: {result.stderr}")
@@ -337,5 +427,5 @@ def load_site_identity(
         ) from exc
 
     site = _parse_inventory(inventory_data)
-    _write_cache(site)
+    _write_cache(site, inventory_path)
     return site

--- a/tests/python/test_site_identity.py
+++ b/tests/python/test_site_identity.py
@@ -2,6 +2,7 @@
 
 All tests use synthetic ansible-inventory JSON payloads injected via
 ``monkeypatch``; no real ``ansible-inventory`` binary is needed.
+Fixtures use §4.1 example aliases and RFC 5737 addresses only.
 """
 
 from __future__ import annotations
@@ -15,63 +16,63 @@ import pytest
 import site_identity as si
 
 # ---------------------------------------------------------------------------
-# Fixture helpers
+# Fixture helpers — generic example identity only
 # ---------------------------------------------------------------------------
 
 _GOOD_INVENTORY = {
     "stayturgid": {
-        "hosts": ["s24", "p7a", "hd8"],
+        "hosts": ["oneui-device", "stock-android-device", "fireos-device"],
     },
     "_meta": {
         "hostvars": {
-            "s24": {
-                "ansible_host": "100.123.218.30",
+            "oneui-device": {
+                "ansible_host": "100.0.0.11",
                 "ansible_port": 8022,
-                "ansible_user": "mobile",
-                "device_usb_serial": "RFCX219CHKA",
-                "device_lan_ip": "192.168.68.60",
-                "device_label": "Samsung S24",
+                "ansible_user": "termux",
+                "device_usb_serial": "EXAMPLE-SERIAL-ONEUI",
+                "device_lan_ip": "192.0.2.11",
+                "device_label": "Example One UI phone",
                 "stayturgid_automation_mode": "full",
                 "stayturgid_mac_peer": {
-                    "user": "djbclark",
-                    "lan": "192.168.68.1",
-                    "tailscale": "100.100.100.1",
+                    "user": "operator",
+                    "lan": "192.0.2.1",
+                    "tailscale": "100.0.0.1",
                 },
-                "stayturgid_control_ssh_user": "djbclark",
+                "stayturgid_control_ssh_user": "operator",
                 "stayturgid_hermes_telegram_allowed_users": "alice,bob",
                 "stayturgid_hermes_telegram_home_channel": "-1001234567890",
             },
-            "p7a": {
-                "ansible_host": "100.65.230.108",
+            "stock-android-device": {
+                "ansible_host": "100.0.0.12",
                 "ansible_port": 8022,
-                "ansible_user": "mobile",
-                "device_usb_serial": "35261JEHN12374",
-                "device_lan_ip": "192.168.68.65",
-                "device_label": "Pixel 7a",
+                "ansible_user": "termux",
+                "device_usb_serial": "EXAMPLE-SERIAL-STOCK",
+                "device_lan_ip": "192.0.2.12",
+                "device_label": "Example stock Android phone",
                 "stayturgid_automation_mode": "full",
                 "stayturgid_mac_peer": {
-                    "user": "djbclark",
-                    "lan": "192.168.68.1",
-                    "tailscale": "100.100.100.1",
+                    "user": "operator",
+                    "lan": "192.0.2.1",
+                    "tailscale": "100.0.0.1",
                 },
-                "stayturgid_control_ssh_user": "djbclark",
+                "stayturgid_control_ssh_user": "operator",
                 "stayturgid_hermes_telegram_allowed_users": "alice,bob",
                 "stayturgid_hermes_telegram_home_channel": "-1001234567890",
             },
-            "hd8": {
-                "ansible_host": "100.124.55.39",
+            "fireos-device": {
+                "ansible_host": "100.0.0.13",
                 "ansible_port": 2222,
-                "ansible_user": "mobile",
-                "device_usb_serial": "GN43T503430603PS",
-                "device_lan_ip": "192.168.1.157",
-                "device_label": "Fire HD 8",
+                "ansible_user": "termux",
+                "device_usb_serial": "EXAMPLE-SERIAL-FIRE",
+                "device_lan_ip": "192.0.2.13",
+                "device_label": "Example Fire OS tablet",
                 "stayturgid_automation_mode": "screen",
                 "stayturgid_mac_peer": {
-                    "user": "djbclark",
-                    "lan": "192.168.68.1",
-                    "tailscale": "100.100.100.1",
+                    "user": "operator",
+                    "lan": "192.0.2.1",
+                    "tailscale": "100.0.0.1",
                 },
-                "stayturgid_control_ssh_user": "djbclark",
+                "stayturgid_control_ssh_user": "operator",
                 "stayturgid_hermes_telegram_allowed_users": "alice,bob",
                 "stayturgid_hermes_telegram_home_channel": "-1001234567890",
             },
@@ -113,27 +114,27 @@ def fake_inventory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 def test_site_has_three_devices(fake_inventory: Path) -> None:
     site = si.load_site_identity(inventory_path=fake_inventory)
-    assert set(site.devices.keys()) == {"s24", "p7a", "hd8"}
+    assert set(site.devices.keys()) == {"oneui-device", "stock-android-device", "fireos-device"}
 
 
 def test_device_fields_correct(fake_inventory: Path) -> None:
     site = si.load_site_identity(inventory_path=fake_inventory)
-    s24 = site.devices["s24"]
-    assert s24.alias == "s24"
-    assert s24.ansible_host == "100.123.218.30"
-    assert s24.device_usb_serial == "RFCX219CHKA"
-    assert s24.device_lan_ip == "192.168.68.60"
-    assert s24.ansible_port == 8022
-    assert s24.ansible_user == "mobile"
-    assert s24.stayturgid_automation_mode == "full"
+    oneui = site.devices["oneui-device"]
+    assert oneui.alias == "oneui-device"
+    assert oneui.ansible_host == "100.0.0.11"
+    assert oneui.device_usb_serial == "EXAMPLE-SERIAL-ONEUI"
+    assert oneui.device_lan_ip == "192.0.2.11"
+    assert oneui.ansible_port == 8022
+    assert oneui.ansible_user == "termux"
+    assert oneui.stayturgid_automation_mode == "full"
 
 
 def test_control_node_parsed(fake_inventory: Path) -> None:
     site = si.load_site_identity(inventory_path=fake_inventory)
     cn = site.control_node
-    assert cn.ssh_user == "djbclark"
-    assert cn.lan_ip == "192.168.68.1"
-    assert cn.tailscale_ip == "100.100.100.1"
+    assert cn.ssh_user == "operator"
+    assert cn.lan_ip == "192.0.2.1"
+    assert cn.tailscale_ip == "100.0.0.1"
 
 
 def test_telegram_users_tuple(fake_inventory: Path) -> None:
@@ -155,27 +156,27 @@ def test_device_order_deterministic(fake_inventory: Path) -> None:
 def test_optional_usb_serial_dash(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """device_usb_serial missing → stored as '-'."""
     data = json.loads(json.dumps(_GOOD_INVENTORY))
-    del data["_meta"]["hostvars"]["hd8"]["device_usb_serial"]
+    del data["_meta"]["hostvars"]["fireos-device"]["device_usb_serial"]
     hosts_yml = tmp_path / "hosts.yml"
     hosts_yml.write_text("# dummy\n", encoding="utf-8")
     monkeypatch.setattr(subprocess, "run", lambda *_a, **_kw: _make_run_result(data))
     monkeypatch.setattr(si, "_CACHE_FILE", tmp_path / ".identity_cache.json")
     monkeypatch.setattr(si, "_CACHE_DIR", tmp_path)
     site = si.load_site_identity(inventory_path=hosts_yml)
-    assert site.devices["hd8"].device_usb_serial == "-"
+    assert site.devices["fireos-device"].device_usb_serial == "-"
 
 
 def test_optional_lan_ip_dash(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """device_lan_ip missing → stored as '-'."""
     data = json.loads(json.dumps(_GOOD_INVENTORY))
-    del data["_meta"]["hostvars"]["hd8"]["device_lan_ip"]
+    del data["_meta"]["hostvars"]["fireos-device"]["device_lan_ip"]
     hosts_yml = tmp_path / "hosts.yml"
     hosts_yml.write_text("# dummy\n", encoding="utf-8")
     monkeypatch.setattr(subprocess, "run", lambda *_a, **_kw: _make_run_result(data))
     monkeypatch.setattr(si, "_CACHE_FILE", tmp_path / ".identity_cache.json")
     monkeypatch.setattr(si, "_CACHE_DIR", tmp_path)
     site = si.load_site_identity(inventory_path=hosts_yml)
-    assert site.devices["hd8"].device_lan_ip == "-"
+    assert site.devices["fireos-device"].device_lan_ip == "-"
 
 
 # ---------------------------------------------------------------------------
@@ -255,6 +256,108 @@ def test_force_refresh_bypasses_cache(fake_inventory: Path, tmp_path: Path, monk
     assert call_count["n"] == 1
 
 
+def test_cache_not_reused_for_different_inventory(
+    fake_inventory: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cache is keyed by inventory path — a different inventory must re-export."""
+    cache_path = tmp_path / ".identity_cache.json"
+    monkeypatch.setattr(si, "_CACHE_FILE", cache_path)
+    monkeypatch.setattr(si, "_CACHE_DIR", tmp_path)
+
+    si.load_site_identity(inventory_path=fake_inventory)
+
+    other = tmp_path / "other-hosts.yml"
+    other.write_text("# other\n", encoding="utf-8")
+    future = time.time() + 9999
+    import os
+
+    os.utime(cache_path, (future, future))
+
+    call_count = {"n": 0}
+
+    def counting_run(*_a, **_kw):
+        call_count["n"] += 1
+        return _make_run_result(_GOOD_INVENTORY)
+
+    monkeypatch.setattr(subprocess, "run", counting_run)
+    si.load_site_identity(inventory_path=other)
+    assert call_count["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Context-aware resolution
+# ---------------------------------------------------------------------------
+
+
+def _write_ansible_cfg(root: Path, inventory_rel: str = "inventory/hosts.yml") -> Path:
+    cfg = root / "ansible.cfg"
+    cfg.write_text(
+        f"[defaults]\ninventory = {inventory_rel}\ncollections_path = collections\n",
+        encoding="utf-8",
+    )
+    return cfg
+
+
+def test_resolve_inventory_explicit_ansible_config(tmp_path: Path) -> None:
+    product = tmp_path / "product"
+    (product / "ansible").mkdir(parents=True)
+    _write_ansible_cfg(product / "ansible")
+    explicit = tmp_path / "site"
+    explicit.mkdir()
+    _write_ansible_cfg(explicit, "inventory/live.yml")
+    (explicit / "inventory").mkdir()
+    inv = explicit / "inventory" / "live.yml"
+    inv.write_text("all: {}\n", encoding="utf-8")
+
+    resolved = si.resolve_inventory_path(
+        repo_root=product,
+        environ={"ANSIBLE_CONFIG": str(explicit / "ansible.cfg")},
+    )
+    assert resolved == inv.resolve()
+
+
+def test_resolve_inventory_site_overlay_default(tmp_path: Path) -> None:
+    product = tmp_path / "product"
+    (product / "ansible").mkdir(parents=True)
+    _write_ansible_cfg(product / "ansible")
+    site = tmp_path / "site-overlay"
+    site.mkdir()
+    _write_ansible_cfg(site)
+    (site / "inventory").mkdir()
+    inv = site / "inventory" / "hosts.yml"
+    inv.write_text("all: {}\n", encoding="utf-8")
+
+    resolved = si.resolve_inventory_path(
+        repo_root=product,
+        environ={"STAYTURGID_SITE_DIR": str(site)},
+    )
+    assert resolved == inv.resolve()
+
+
+def test_resolve_inventory_upstream_example_fallback(tmp_path: Path) -> None:
+    product = tmp_path / "product"
+    inv_dir = product / "ansible" / "inventory"
+    inv_dir.mkdir(parents=True)
+    _write_ansible_cfg(product / "ansible")
+    example = inv_dir / "hosts.yml.example"
+    example.write_text("all: {}\n", encoding="utf-8")
+    # No live hosts.yml, no site overlay
+    resolved = si.resolve_inventory_path(
+        repo_root=product,
+        environ={"STAYTURGID_SITE_DIR": str(tmp_path / "missing-site")},
+    )
+    assert resolved == example
+
+
+def test_ansible_listable_path_materialises_example(tmp_path: Path) -> None:
+    example = tmp_path / "hosts.yml.example"
+    example.write_text("all:\n  children: {}\n", encoding="utf-8")
+    listable = si._ansible_listable_path(example, tmp_dir=tmp_path / "mat")
+    assert listable.name == "hosts.yml"
+    assert listable.is_file()
+    assert listable.read_text(encoding="utf-8") == example.read_text(encoding="utf-8")
+
+
 # ---------------------------------------------------------------------------
 # Error-path / validation tests
 # ---------------------------------------------------------------------------
@@ -306,7 +409,7 @@ def test_missing_stayturgid_group(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
 
 def test_duplicate_usb_serial_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     data = json.loads(json.dumps(_GOOD_INVENTORY))
-    data["_meta"]["hostvars"]["p7a"]["device_usb_serial"] = "RFCX219CHKA"  # same as s24
+    data["_meta"]["hostvars"]["stock-android-device"]["device_usb_serial"] = "EXAMPLE-SERIAL-ONEUI"
     hosts_yml = tmp_path / "hosts.yml"
     hosts_yml.write_text("# dummy\n", encoding="utf-8")
     monkeypatch.setattr(subprocess, "run", lambda *_a, **_kw: _make_run_result(data))
@@ -318,7 +421,7 @@ def test_duplicate_usb_serial_rejected(tmp_path: Path, monkeypatch: pytest.Monke
 
 def test_duplicate_tailscale_ip_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     data = json.loads(json.dumps(_GOOD_INVENTORY))
-    data["_meta"]["hostvars"]["p7a"]["ansible_host"] = "100.123.218.30"  # same as s24
+    data["_meta"]["hostvars"]["stock-android-device"]["ansible_host"] = "100.0.0.11"
     hosts_yml = tmp_path / "hosts.yml"
     hosts_yml.write_text("# dummy\n", encoding="utf-8")
     monkeypatch.setattr(subprocess, "run", lambda *_a, **_kw: _make_run_result(data))
@@ -330,7 +433,7 @@ def test_duplicate_tailscale_ip_rejected(tmp_path: Path, monkeypatch: pytest.Mon
 
 def test_invalid_lan_ip_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     data = json.loads(json.dumps(_GOOD_INVENTORY))
-    data["_meta"]["hostvars"]["s24"]["device_lan_ip"] = "not-an-ip"
+    data["_meta"]["hostvars"]["oneui-device"]["device_lan_ip"] = "not-an-ip"
     hosts_yml = tmp_path / "hosts.yml"
     hosts_yml.write_text("# dummy\n", encoding="utf-8")
     monkeypatch.setattr(subprocess, "run", lambda *_a, **_kw: _make_run_result(data))
@@ -342,7 +445,7 @@ def test_invalid_lan_ip_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 
 def test_missing_device_label_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     data = json.loads(json.dumps(_GOOD_INVENTORY))
-    del data["_meta"]["hostvars"]["s24"]["device_label"]
+    del data["_meta"]["hostvars"]["oneui-device"]["device_label"]
     hosts_yml = tmp_path / "hosts.yml"
     hosts_yml.write_text("# dummy\n", encoding="utf-8")
     monkeypatch.setattr(subprocess, "run", lambda *_a, **_kw: _make_run_result(data))
@@ -354,9 +457,9 @@ def test_missing_device_label_rejected(tmp_path: Path, monkeypatch: pytest.Monke
 
 def test_invalid_alias_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     data = json.loads(json.dumps(_GOOD_INVENTORY))
-    data["stayturgid"]["hosts"] = ["BAD_HOST", "p7a", "hd8"]
-    data["_meta"]["hostvars"]["BAD_HOST"] = data["_meta"]["hostvars"]["s24"]
-    del data["_meta"]["hostvars"]["s24"]
+    data["stayturgid"]["hosts"] = ["BAD_HOST", "stock-android-device", "fireos-device"]
+    data["_meta"]["hostvars"]["BAD_HOST"] = data["_meta"]["hostvars"]["oneui-device"]
+    del data["_meta"]["hostvars"]["oneui-device"]
     hosts_yml = tmp_path / "hosts.yml"
     hosts_yml.write_text("# dummy\n", encoding="utf-8")
     monkeypatch.setattr(subprocess, "run", lambda *_a, **_kw: _make_run_result(data))
@@ -372,4 +475,4 @@ def test_site_is_immutable(fake_inventory: Path) -> None:
     with pytest.raises((AttributeError, TypeError)):
         site.telegram_home_channel = "mutated"  # type: ignore[misc]
     with pytest.raises((AttributeError, TypeError)):
-        site.devices["s24"].alias = "mutated"  # type: ignore[misc]
+        site.devices["oneui-device"].alias = "mutated"  # type: ignore[misc]

--- a/tests/python/test_validate_site_identity.py
+++ b/tests/python/test_validate_site_identity.py
@@ -1,0 +1,167 @@
+"""Unit tests for control/bin/validate_site_identity.py drift helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_LIB = _ROOT / "control" / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+
+def _load_validator():
+    path = _ROOT / "control" / "bin" / "validate_site_identity.py"
+    spec = importlib.util.spec_from_file_location("validate_site_identity", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    mod.__file__ = str(path)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+v = _load_validator()
+
+
+@dataclass(frozen=True)
+class _Dev:
+    alias: str
+    ansible_host: str
+    device_usb_serial: str
+    device_lan_ip: str
+    device_label: str = "label"
+    ansible_port: int = 8022
+    ansible_user: str = "termux"
+    stayturgid_automation_mode: str = "autojs6"
+
+
+@dataclass(frozen=True)
+class _Ctrl:
+    ssh_user: str = "operator"
+    lan_ip: str = "192.0.2.1"
+    tailscale_ip: str = "100.0.0.1"
+
+
+@dataclass(frozen=True)
+class _Site:
+    telegram_allowed_users: tuple[str, ...]
+    telegram_home_channel: str
+    devices: dict
+    control_node: _Ctrl
+
+
+def test_is_generic_fixture_aliases_and_rfc5737() -> None:
+    assert v.is_generic_fixture("oneui-device")
+    assert v.is_generic_fixture("stock-android-device")
+    assert v.is_generic_fixture("fireos-device")
+    assert v.is_generic_fixture("192.0.2.11")
+    assert v.is_generic_fixture("100.0.0.11")
+    assert v.is_generic_fixture("EXAMPLE-SERIAL-ONEUI")
+    assert not v.is_generic_fixture("prod-phone")
+    assert not v.is_generic_fixture("198.18.0.1")  # not TEST-NET
+
+
+def test_build_drift_patterns_skips_generic_identity() -> None:
+    site = _Site(
+        telegram_allowed_users=(),
+        telegram_home_channel="",
+        devices={
+            "oneui-device": _Dev(
+                "oneui-device",
+                "100.0.0.11",
+                "EXAMPLE-SERIAL-ONEUI",
+                "192.0.2.11",
+            )
+        },
+        control_node=_Ctrl(),
+    )
+    patterns = v._build_drift_patterns(site)
+    assert patterns == []
+
+
+def test_build_drift_patterns_includes_production_identity() -> None:
+    site = _Site(
+        telegram_allowed_users=(),
+        telegram_home_channel="",
+        devices={
+            "prod-phone": _Dev(
+                "prod-phone",
+                "198.18.0.50",
+                "REALSERIAL001",
+                "10.0.0.50",
+            )
+        },
+        control_node=_Ctrl(lan_ip="10.0.0.1", tailscale_ip="198.18.0.1"),
+    )
+    patterns = v._build_drift_patterns(site)
+    descs = [d for _, d in patterns]
+    assert any("device alias 'prod-phone'" in d for d in descs)
+    assert any("ansible_host IP" in d for d in descs)
+    assert any("USB serial" in d for d in descs)
+    assert any("LAN IP" in d for d in descs)
+    assert any("control node LAN IP" in d for d in descs)
+    assert any("control node Tailscale IP" in d for d in descs)
+
+
+def test_check_drift_finds_hardcoded_alias(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    site = _Site(
+        telegram_allowed_users=(),
+        telegram_home_channel="",
+        devices={
+            "prod-phone": _Dev(
+                "prod-phone",
+                "198.18.0.50",
+                "REALSERIAL001",
+                "10.0.0.50",
+            )
+        },
+        control_node=_Ctrl(lan_ip="10.0.0.1", tailscale_ip="198.18.0.1"),
+    )
+    src = tmp_path / "tool.py"
+    src.write_text('HOST = "prod-phone"\n', encoding="utf-8")
+    # Pretend tmp_path is a git repo root with one tracked file
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *_a, **_kw: type(
+            "R",
+            (),
+            {"returncode": 0, "stdout": "tool.py\n", "stderr": ""},
+        )(),
+    )
+    # Make Path.suffix check work: root is tmp_path
+    violations = v.check_drift(site, tmp_path)
+    assert len(violations) == 1
+    assert violations[0]["file"] == "tool.py"
+    assert "prod-phone" in violations[0]["pattern"]
+
+
+def test_check_drift_clean_when_no_matches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    site = _Site(
+        telegram_allowed_users=(),
+        telegram_home_channel="",
+        devices={
+            "prod-phone": _Dev(
+                "prod-phone",
+                "198.18.0.50",
+                "REALSERIAL001",
+                "10.0.0.50",
+            )
+        },
+        control_node=_Ctrl(lan_ip="10.0.0.1", tailscale_ip="198.18.0.1"),
+    )
+    src = tmp_path / "tool.py"
+    src.write_text('HOST = "oneui-device"\n', encoding="utf-8")
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *_a, **_kw: type(
+            "R",
+            (),
+            {"returncode": 0, "stdout": "tool.py\n", "stderr": ""},
+        )(),
+    )
+    assert v.check_drift(site, tmp_path) == []


### PR DESCRIPTION
## Summary

- Resolve inventory through `ansible_context` (explicit config → site overlay → upstream example).
- Cache is keyed by inventory path; example `hosts.yml.example` materialises for `ansible-inventory`.
- Example inventory includes generic control-node placeholders so schema validation succeeds.
- Drift patterns skip §4.1 / RFC 5737 generic fixtures.
- Focused tests for context, cache, and validator helpers; existing fixtures scrubbed to example identity.

## Test plan

- [x] `pytest tests/python/test_site_identity.py tests/python/test_validate_site_identity.py tests/python/test_ansible_context.py`
- [x] Resolve paths: explicit site config, site default, upstream example fallback
- [x] Load example inventory successfully with control node
- [ ] CI green (generic inventory copy still used for ansible syntax)

Part of B5; warn-only remains until the scrub PR lands.