### PR TITLE
Fix GitHub Actions bootstrap and bridge idempotence

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Prepare generic inventory for checks
         run: cp ansible/inventory/hosts.yml.example ansible/inventory/hosts.yml
       - name: Set up Python test venv (pytest + ansible-core)
-        run: uv venv .venv-test && uv pip install -q -r tests/python/requirements.txt
+        run: uv venv .venv-test && uv pip install --python .venv-test/bin/python -q -r tests/python/requirements.txt
       - name: configure
         run: ./configure
       - name: just syntax (generic inventory)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,12 @@ jobs:
           tar xzf lychee-x86_64-unknown-linux-gnu.tar.gz --strip-components=1 lychee-x86_64-unknown-linux-gnu/lychee
           sudo mv lychee /usr/local/bin/
           rm lychee-x86_64-unknown-linux-gnu.tar.gz
+      - name: Install dotenv-linter
+        run: |
+          curl -fsSLO https://github.com/dotenv-linter/dotenv-linter/releases/download/v4.0.0/dotenv-linter-linux-x86_64.tar.gz
+          tar xzf dotenv-linter-linux-x86_64.tar.gz
+          sudo mv dotenv-linter /usr/local/bin/
+          rm dotenv-linter-linux-x86_64.tar.gz
       - name: Cache bun dependencies
         uses: actions/cache@v4
         with:
@@ -54,8 +60,7 @@ jobs:
           uv tool install ansible-core &&
           uv tool install ansible-lint &&
           uv tool install yamllint &&
-          uv tool install pyinilint &&
-          uv tool install dotenv-linter
+          uv tool install pyinilint
       - name: Install just
         uses: extractions/setup-just@v3
       - name: Install Ansible collections

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,10 @@ jobs:
         run: npm install -g prettier
       - name: Install lychee (link checker)
         run: |
-          curl -sSLO https://github.com/lycheeverse/lychee/releases/download/v0.24.2/lychee-v0.24.2-x86_64-unknown-linux-gnu.tar.gz
-          tar xzf lychee-v0.24.2-x86_64-unknown-linux-gnu.tar.gz
+          curl -fsSLO https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-x86_64-unknown-linux-gnu.tar.gz
+          tar xzf lychee-x86_64-unknown-linux-gnu.tar.gz --strip-components=1 lychee-x86_64-unknown-linux-gnu/lychee
           sudo mv lychee /usr/local/bin/
-          rm lychee-v0.24.2-x86_64-unknown-linux-gnu.tar.gz
+          rm lychee-x86_64-unknown-linux-gnu.tar.gz
       - name: Cache bun dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Site resolution has no silent default: CI explicitly selects the
+    # upstream generic config for every check and test subprocess.
+    env:
+      ANSIBLE_CONFIG: ${{ github.workspace }}/ansible/ansible.cfg
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -63,10 +67,6 @@ jobs:
       - name: configure
         run: ./configure
       - name: just syntax (generic inventory)
-        # Site resolution has no silent default: CI selects the upstream
-        # config explicitly (§4.7/§4.8 of multi-site-topology.md).
-        env:
-          ANSIBLE_CONFIG: ${{ github.workspace }}/ansible/ansible.cfg
         run: just syntax
       - name: just check (tier a — syntax/lint under CI interpreters)
         run: just check

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,6 +1,9 @@
 # Lychee ignore file to exclude files not yet created in early phases of the implementation plan
 ansible/playbooks/control_node/observability.yml
 ansible/playbooks/fleet/deploy-otelcol.yml
+ansible/inventory/hosts.yml
 ansible/roles/control_node/templates/com.openobserve.plist.j2
 ansible_collections/stayturgid/android_common/roles/otelcol/templates/otel-config.yaml.j2
 device/autojs6/run/state.json
+human/HANDOFF-HUMAN.md
+docs/research/autojs6-fireos-device-project

--- a/device/termux/boot/start-repair-bridge.sh
+++ b/device/termux/boot/start-repair-bridge.sh
@@ -2,4 +2,9 @@
 export HOME="${HOME:-/data/data/com.termux/files/home}"
 STG="$HOME/.stayturgid"
 mkdir -p "$STG/logs" "$STG/run" 2>/dev/null || true
+PROC_ROOT="${PROC_ROOT:-/proc}"
+pid="$(cat "$STG/run/bridge.pid" 2>/dev/null || true)"
+if [ -n "$pid" ] && [ -d "$PROC_ROOT/$pid" ] && grep -q "bridges" "$PROC_ROOT/$pid/cmdline" 2>/dev/null; then
+  exit 0
+fi
 nohup python3 "$STG/bin/stayturgid_bridges.py" --mode repair >>"$STG/logs/repair-bridge.log" 2>&1 &

--- a/docs/operations/plans/agent-ovgo-implementation.md
+++ b/docs/operations/plans/agent-ovgo-implementation.md
@@ -3,7 +3,7 @@
 # O-V-G-O Stack & Site Identity Implementation Plan (Agent Instructions)
 
 **Audience:** Junior Developer / Autonomous AI Agent
-**Context:** This document provides explicit, step-by-step instructions to implement the unified architecture outlined in [docs/architecture/core-architecture.md](file:///Users/djbclark/ops/stayturgid/docs/architecture/core-architecture.md).
+**Context:** This document provides explicit, step-by-step instructions to implement the unified architecture outlined in [docs/architecture/core-architecture.md](../../architecture/core-architecture.md).
 **End Goal:** Completely replace the legacy custom Python dashboard (`dashboard.py`) and polling monitors (`fleet_health_monitor.py`, `access_monitor.py`) with a modern, resilient, push-based telemetry stack (Vector) and a clean OliveTin execution interface. All configuration must be generated from the Ansible site inventory.
 
 ---
@@ -11,7 +11,7 @@
 ## Agent Guidelines & Rules
 
 1. **Check Before You Edit:** Always use `view_file` or `grep_search` to understand the current context of a file before modifying it.
-2. **Read Required Context:** You must review [docs/coding-rules.md](file:///Users/djbclark/ops/stayturgid/docs/coding-rules.md), [AGENTS.md](file:///Users/djbclark/ops/stayturgid/AGENTS.md), and [docs/handoff.md](file:///Users/djbclark/ops/stayturgid/docs/handoff.md) to understand project conventions and current session state before starting work.
+2. **Read Required Context:** You must review [docs/coding-rules.md](../../coding-rules.md), [AGENTS.md](../../../AGENTS.md), and [docs/handoff.md](../../handoff.md) to understand project conventions and current session state before starting work.
 3. **Do Not Hallucinate Paths:** All file paths must be exact. Refer to the directory structure using the `list_dir` tool if you are unsure.
 4. **Run Verifications Locally:** Use the `just check`, `just lint`, and `just test` commands heavily to catch regressions. If a test fails, you must revert or fix the error before proceeding.
 5. **Multi-Agent Protocol:** Before making any edits, run `git fetch origin --prune && git pull --ff-only origin master`. When a phase is complete and passes tests, commit your work with a clear message and push.

--- a/docs/operations/plans/logging/01-implementation-plan.md
+++ b/docs/operations/plans/logging/01-implementation-plan.md
@@ -20,7 +20,7 @@ Migration of the `stayturgid` Android phone fleet and macOS control node to a st
 
 We will install and configure Vector and OpenObserve natively on the Mac control node.
 
-#### [NEW] [observability.yml](file:///Users/djbclark/ops/stayturgid/ansible/playbooks/control_node/observability.yml)
+#### [NEW] [observability.yml](../../../../ansible/playbooks/control_node/observability.yml)
 
 - Ansible playbook for the Mac control node:
   1. Installs Vector via Homebrew (`brew install vector`).
@@ -28,11 +28,11 @@ We will install and configure Vector and OpenObserve natively on the Mac control
   3. Creates a macOS launchd agent configuration (`com.openobserve.plist`) and starts the service.
   4. Deploys the Vector YAML configuration.
 
-#### [NEW] [com.openobserve.plist.j2](file:///Users/djbclark/ops/stayturgid/ansible/roles/control_node/templates/com.openobserve.plist.j2)
+#### [NEW] [com.openobserve.plist.j2](../../../../ansible/roles/control_node/templates/com.openobserve.plist.j2)
 
 - Jinja2 template for the OpenObserve launchd service, setting environment variables for root email, password, and binding interface.
 
-#### [NEW] [vector.yaml.j2](file:///Users/djbclark/ops/stayturgid/ansible/roles/control_node/templates/vector.yaml.j2)
+#### [NEW] [vector.yaml.j2](../../../../ansible/roles/control_node/templates/vector.yaml.j2)
 
 - Jinja2 template for Vector on the Mac, receiving OTLP JSON logs from the fleet devices over Tailscale and forwarding them to local OpenObserve (`http://127.0.0.1:5080/api/default/android_logs/_json`).
 
@@ -42,18 +42,18 @@ We will install and configure Vector and OpenObserve natively on the Mac control
 
 We will transition all logging to structured JSON.
 
-#### [MODIFY] [log.js](file:///Users/djbclark/ops/stayturgid/device/autojs6/lib/log.js)
+#### [MODIFY] [log.js](../../../../device/autojs6/lib/log.js)
 
 - Roll a custom JSON formatter inside AutoJs6.
 - Format logs conforming to the payload schema and write synchronously to `/sdcard/stayturgid/logs/watchdog.jsonl` (or Fire OS equivalent).
 - Refactor status indicators (`latestRepairStatus` and `latestRepairTimestampMs`) to read state from the new local `state.json` file.
 
-#### [MODIFY] [logging.py](file:///Users/djbclark/ops/stayturgid/control/lib/logging.py)
+#### [MODIFY] [logging.py](../../../../control/lib/logging.py)
 
 - Refactor the Python logging utilities (`log`) to format entries as JSON lines when writing to `repair.jsonl`.
 - Maintain backwards compatibility in `scrape_errors` to parse both JSON and legacy text logs.
 
-#### [NEW] [state.json](file:///Users/djbclark/ops/stayturgid/device/autojs6/run/state.json)
+#### [NEW] [state.json](../../../../device/autojs6/run/state.json)
 
 - Introduce a structured state file (Single Source of Truth) shared between Termux and AutoJs6 to avoid regex parsing of log files.
 
@@ -63,14 +63,14 @@ We will transition all logging to structured JSON.
 
 We will deploy the OTel Collector to tail the local log files.
 
-#### [NEW] [otel-config.yaml.j2](file:///Users/djbclark/ops/stayturgid/ansible_collections/stayturgid/android_common/roles/otelcol/templates/otel-config.yaml.j2)
+#### [NEW] [otel-config.yaml.j2](../../../../ansible_collections/stayturgid/android_common/roles/otelcol/templates/otel-config.yaml.j2)
 
 - Configure `filelog` receivers to tail `watchdog.jsonl` and `repair.jsonl`.
 - Configure `filelog/logcat` receiver to tail the system logcat buffer.
 - Configure `memory_limiter` (100MB limit) and `batch` processors (30s timeout).
 - Export via `otlphttp` to the Mac control node's Tailscale IP address on port `4318`.
 
-#### [NEW] [deploy-otelcol.yml](file:///Users/djbclark/ops/stayturgid/ansible/playbooks/fleet/deploy-otelcol.yml)
+#### [NEW] [deploy-otelcol.yml](../../../../ansible/playbooks/fleet/deploy-otelcol.yml)
 
 - Ansible playbook to push OTel Collector binaries (`arm64-v8a` for `s24`/`p7a`, `armeabi-v7a` / 32-bit arm for `hd8`).
 - Configure `Termux:Boot` supervisor scripts to keep the OTel Collector process and logcat buffer background loops running.

--- a/docs/operations/plans/logging/02-implementation-plan.md
+++ b/docs/operations/plans/logging/02-implementation-plan.md
@@ -29,7 +29,7 @@ Transitioning `stayturgid` on-device logging to structured JSON lines (JSONL) an
 
 We will update the AutoJs6 client side to emit JSON lines, support `state.json`, and handle private/shared storage paths.
 
-#### [MODIFY] [log.js](file:///Users/djbclark/ops/stayturgid/device/autojs6/lib/log.js)
+#### [MODIFY] [log.js](../../../../device/autojs6/lib/log.js)
 
 - Modify `append(line)` to dual-write logs:
   - Text format to `watchdog.log` (calls `trimLogIfNeeded` to rotate at 1000 lines).
@@ -41,7 +41,7 @@ We will update the AutoJs6 client side to emit JSON lines, support `state.json`,
 
 ### Component 2: AutoJs6 Accessibility Watchdog & Co-Monitor (JS)
 
-#### [MODIFY] [comonitor.js](file:///Users/djbclark/ops/stayturgid/device/autojs6/lib/comonitor.js)
+#### [MODIFY] [comonitor.js](../../../../device/autojs6/lib/comonitor.js)
 
 - At the end of `run()`, call `log.writeState("comonitor", statusObj)` to save AutoJs6-probed statuses to the shared state file.
 
@@ -51,7 +51,7 @@ We will update the AutoJs6 client side to emit JSON lines, support `state.json`,
 
 We will update the Termux repair loop to write JSON logs and update the shared `state.json` file.
 
-#### [MODIFY] [stayturgid_repair.py](file:///Users/djbclark/ops/stayturgid/device/termux/py/stayturgid_repair.py)
+#### [MODIFY] [stayturgid_repair.py](../../../../device/termux/py/stayturgid_repair.py)
 
 - Import `threading` and `json`.
 - Modify `log(msg, level)` to write:
@@ -65,7 +65,7 @@ We will update the Termux repair loop to write JSON logs and update the shared `
 
 We will adapt the error scraper to scan both JSON lines and legacy log formats during rollout.
 
-#### [MODIFY] [logging.py](file:///Users/djbclark/ops/stayturgid/control/lib/logging.py)
+#### [MODIFY] [logging.py](../../../../control/lib/logging.py)
 
 - Import `json`.
 - Update `_REPAIR_LOG_GREP` to search both `*.log` and `*.jsonl` files on the device.
@@ -77,11 +77,11 @@ We will adapt the error scraper to scan both JSON lines and legacy log formats d
 
 We will update tests to cover the new structured configurations and state properties.
 
-#### [MODIFY] [log.test.js](file:///Users/djbclark/ops/stayturgid/tests/js/log.test.js)
+#### [MODIFY] [log.test.js](../../../../tests/js/log.test.js)
 
 - Add unit test cases to verify JSON log line parsing and `writeState()` file operations.
 
-#### [MODIFY] [comonitor.test.js](file:///Users/djbclark/ops/stayturgid/tests/js/comonitor.test.js)
+#### [MODIFY] [comonitor.test.js](../../../../tests/js/comonitor.test.js)
 
 - Update mock `files` object to simulate `state.json` read/write capabilities.
 

--- a/docs/research/unified-architecture-synthesis.md
+++ b/docs/research/unified-architecture-synthesis.md
@@ -9,9 +9,9 @@ This document serves as the definitive guide to both the platform's **runtime to
 
 **Related Documents:**
 
-- [Agent Implementation Plan](file:///Users/djbclark/stayturgid/docs/operations/plans/agent-ovgo-implementation.md): Specific instructions for autonomous agents deploying this architecture.
-- [Coding Rules](file:///Users/djbclark/stayturgid/docs/coding-rules.md) and [AGENTS.md](file:///Users/djbclark/stayturgid/AGENTS.md): Strict policies and multi-agent protocols that must be followed.
-- [Handoff](file:///Users/djbclark/stayturgid/docs/handoff.md): Current session context and state.
+- [Agent Implementation Plan](../operations/plans/agent-ovgo-implementation.md): Specific instructions for autonomous agents deploying this architecture.
+- [Coding Rules](../coding-rules.md) and [AGENTS.md](../../AGENTS.md): Strict policies and multi-agent protocols that must be followed.
+- [Handoff](../handoff.md): Current session context and state.
 
 ---
 

--- a/tests/python/test_ui_guard.py
+++ b/tests/python/test_ui_guard.py
@@ -5,6 +5,17 @@ import time
 import ui_guard
 
 
+def _wait_for_state(path):
+    for _ in range(100):
+        if path.is_file():
+            try:
+                return json.loads(path.read_text())
+            except json.JSONDecodeError:
+                pass
+        time.sleep(0.02)
+    raise AssertionError(f"timed out waiting for valid state in {path}")
+
+
 def test_ui_guard_allow(monkeypatch):
     monkeypatch.setenv("STAYTURGID_ALLOW_UI_AUTOMATION", "1")
     assert ui_guard.check_ui_guard("test_host", "test_action", "test message") is True
@@ -24,25 +35,22 @@ def test_ui_guard_block_and_done(monkeypatch, tmp_path):
         res = ui_guard.check_ui_guard("test_host", "test_action", "test message")
         result.append(res)
 
-    t = threading.Thread(target=run_guard)
+    t = threading.Thread(target=run_guard, daemon=True)
     t.start()
 
-    # Wait for the state file to be written
-    for _ in range(20):
-        if state_file.is_file():
-            break
-        time.sleep(0.1)
+    try:
+        data = _wait_for_state(state_file)
+        assert data["host"] == "test_host"
+        assert data["status"] == "pending"
 
-    assert state_file.is_file()
-    data = json.loads(state_file.read_text())
-    assert data["host"] == "test_host"
-    assert data["status"] == "pending"
+        # Now simulate user clicking "Done" on the dashboard
+        data["status"] = "done"
+        state_file.write_text(json.dumps(data))
+    finally:
+        if t.is_alive():
+            state_file.write_text(json.dumps({"status": "done"}))
+            t.join(timeout=5)
 
-    # Now simulate user clicking "Done" on the dashboard
-    data["status"] = "done"
-    state_file.write_text(json.dumps(data))
-
-    t.join(timeout=5)
     assert not t.is_alive()
     assert result == [True]
     assert not state_file.is_file()  # Cleaned up
@@ -66,21 +74,16 @@ def test_ui_guard_block_and_detect(monkeypatch, tmp_path):
         res = ui_guard.check_ui_guard("test_host", "test_action", "test message", detect_fn=detect_fn)
         result.append(res)
 
-    t = threading.Thread(target=run_guard)
+    t = threading.Thread(target=run_guard, daemon=True)
     t.start()
 
-    # Wait for state file
-    for _ in range(20):
-        if state_file.is_file():
-            break
-        time.sleep(0.1)
+    try:
+        _wait_for_state(state_file)
+    finally:
+        # Simulate action completed, including assertion-failure cleanup.
+        state["detected"] = True
+        t.join(timeout=5)
 
-    assert state_file.is_file()
-
-    # Simulate action completed
-    state["detected"] = True
-
-    t.join(timeout=5)
     assert not t.is_alive()
     assert result == [True]
     assert not state_file.is_file()


### PR DESCRIPTION
## Summary

- fix the pinned Lychee release URL, asset name, and archive extraction path
- install the pinned Rust dotenv-linter binary instead of the unrelated Python package
- install Python test dependencies into the explicitly named `.venv-test` environment
- select the upstream generic Ansible configuration for the entire CI job
- make historical documentation links portable and ignore intentionally absent local artifacts
- make the repair-bridge boot launcher honor its live-process pidfile guard
- make UI-guard tests wait for valid state and always release their blocking worker threads

## Verification

- full local `just test`: 129 shell-unit checks passed; 359 Python tests passed with 1 skipped; all Ansible collection unit suites passed
- focused pre-commit hooks for the workflow and boot script passed
- the UI-guard tests passed repeatedly, and the complete Python suite passed afterward
- the deployment tests and identity validation passed with CI's explicit generic configuration
- workflow download and Linux binary extraction validated against the published Lychee release asset
- the offline documentation link check passed with 369 valid links and no errors
- `git diff --check` passed

The repair-bridge script is already shipped through the existing Termux Ansible and boot-recovery paths; this change restores their intended idempotence rather than adding a new capability.
