### PR TITLE
feat(site-contract): site-init CLI apply/dry-run/docs (C2)

### DIFF
--- a/control/site_contract/README.md
+++ b/control/site_contract/README.md
@@ -1,22 +1,45 @@
 # Site-contract scaffolding
 
-This directory contains the Phase C1 scaffold inputs for the site contract in
+This directory implements Phase C of the site contract in
 `docs/architecture/site-contract.md`.
 
-- `templates/` mirrors the files that a later `site-init` implementation will
-  create. Files ending in `.j2` are Jinja2 templates; other files are copied
-  without rendering.
+- `templates/` mirrors the files `site-init` creates. Files ending in `.j2` are
+  Jinja2 templates; other files are copied without rendering.
 - `registry_sources.yml` maps product-owned claims to their authoritative role
   defaults or other checked-in product declarations. It deliberately contains
   no port numbers or path literals.
 - `generate_registry_seeds.py` resolves that source map and writes the
   committed `templates/registry/{ports,paths}.yml` seeds.
+- `site_init.py` is the `site-init` CLI (apply / dry-run / docs).
+
+## site-init
+
+From the product checkout:
+
+```bash
+just site-init sitename=<name> [dir=<path>] [map=<site-map.yml>] [mode=apply|dry-run|docs]
+# or:
+python3 -m control.site_contract.site_init --sitename <name> [--dir <path>] [--mode apply|dry-run|docs]
+```
+
+- Default destination: `$OPS_ROOT/site-<name>` (`OPS_ROOT` defaults to `~/ops`).
+- `mode=apply` (default): create the §3 scaffold; never overwrite differing
+  user-owned files (exit 2); identical re-apply is a no-op.
+- `mode=dry-run`: print per-file `create` / `skip` / `overwrite` actions; no writes.
+- `mode=docs`: emit self-contained Markdown with generic example values only.
+- Exit codes: `0` success/no-op; `1` precondition/input failure; `2` would overwrite.
+- `map=` is reserved for Phase C4 and is rejected until then.
+- A destination nested inside this product checkout is rejected (ADR 005).
+
+## Registry seeds
 
 Regenerate the registry templates from the repository root after changing a
 mapped product default:
 
 ```bash
 python3 -m control.site_contract.generate_registry_seeds
+# or check for drift:
+python3 -m control.site_contract.generate_registry_seeds --check
 ```
 
 The focused tests compare generated output with the committed seeds, so a

--- a/control/site_contract/__init__.py
+++ b/control/site_contract/__init__.py
@@ -1,6 +1,6 @@
-"""Site-contract scaffold support.
+"""Site-contract scaffold and tooling.
 
-Phase C1 only provides templates and reproducible registry seeds. The
-``site-init`` and ``site-sync`` command surfaces are implemented in later
-phases.
+Phase C1 provides templates and reproducible registry seeds. Phase C2 provides
+``site-init`` (apply / dry-run / docs). ``site-sync`` and related surfaces land
+in later phases.
 """

--- a/control/site_contract/site_init.py
+++ b/control/site_contract/site_init.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+"""Initialize a private site overlay from product site-contract templates.
+
+Implements Site Contract v1 ``site-init`` (apply / dry-run / docs). See
+``docs/architecture/site-contract.md`` §§2–3 and acceptance tests 1, 2, and 6.
+
+Exit codes:
+    0  success / no-op
+    1  precondition or input failure
+    2  would overwrite a user-owned file (no writes performed)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Sequence
+
+from jinja2 import Environment, StrictUndefined
+
+PRODUCT = "stayturgid"
+CONTRACT_DIR = Path(__file__).resolve().parent
+TEMPLATE_DIR = CONTRACT_DIR / "templates"
+REPO_ROOT = CONTRACT_DIR.parents[1]
+
+EXIT_OK = 0
+EXIT_PRECONDITION = 1
+EXIT_WOULD_OVERWRITE = 2
+
+Mode = Literal["apply", "dry-run", "docs"]
+ActionKind = Literal["create", "skip", "overwrite"]
+
+# Bare site name: lowercase letter, then lowercase alphanumerics or hyphens.
+_SITE_NAME_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+
+# Generic paths/names only — docs mode must never emit operator identity.
+_DOCS_SITE_NAME = "example"
+_DOCS_PRODUCT_ROOT = f"/srv/products/{PRODUCT}"
+_DOCS_SITE_DIR = f"/srv/sites/site-{_DOCS_SITE_NAME}"
+
+
+class SiteInitError(Exception):
+    """Precondition or input failure for site-init."""
+
+    def __init__(self, message: str, *, exit_code: int = EXIT_PRECONDITION) -> None:
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+@dataclass(frozen=True)
+class PlannedFile:
+    """One planned file write under the destination site dir."""
+
+    relative_path: str
+    content: bytes
+    action: ActionKind
+
+
+@dataclass(frozen=True)
+class InitPlan:
+    """Fully computed site-init plan (no side effects)."""
+
+    site_name: str
+    destination: Path
+    product_root: Path
+    files: tuple[PlannedFile, ...]
+
+    @property
+    def conflicts(self) -> list[PlannedFile]:
+        return [item for item in self.files if item.action == "overwrite"]
+
+
+def _ops_root(env: dict[str, str] | None = None) -> Path:
+    environ = env if env is not None else os.environ
+    raw = environ.get("OPS_ROOT", "").strip()
+    if raw:
+        return Path(raw).expanduser().resolve()
+    return (Path.home() / "ops").resolve()
+
+
+def validate_site_name(site_name: str) -> str:
+    """Return a validated bare site name or raise SiteInitError."""
+    name = site_name.strip()
+    if not name:
+        raise SiteInitError("sitename is required (e.g. just site-init sitename=example)")
+    if name.startswith("site-"):
+        raise SiteInitError(
+            f"sitename must be the bare name without the 'site-' prefix "
+            f"(got {site_name!r}; use {name.removeprefix('site-')!r})"
+        )
+    if "/" in name or "\\" in name or name in {".", ".."}:
+        raise SiteInitError(f"sitename must not contain path separators: {site_name!r}")
+    if not _SITE_NAME_RE.fullmatch(name):
+        raise SiteInitError(
+            f"sitename must match {_SITE_NAME_RE.pattern} (lowercase letter, then [a-z0-9-]*); got {site_name!r}"
+        )
+    if len(name) > 63:
+        raise SiteInitError(f"sitename is too long ({len(name)} > 63): {site_name!r}")
+    return name
+
+
+def resolve_destination(
+    site_name: str,
+    *,
+    dir_path: str | None = None,
+    product_root: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> Path:
+    """Resolve the site directory and enforce public/private separation."""
+    name = validate_site_name(site_name)
+    product = (product_root or REPO_ROOT).resolve()
+    if dir_path and dir_path.strip():
+        destination = Path(dir_path).expanduser()
+        if not destination.is_absolute():
+            destination = (Path.cwd() / destination).resolve()
+        else:
+            destination = destination.resolve()
+    else:
+        destination = (_ops_root(env) / f"site-{name}").resolve()
+
+    _reject_nested_in_product(destination, product)
+    return destination
+
+
+def _reject_nested_in_product(destination: Path, product_root: Path) -> None:
+    product = product_root.resolve()
+    dest = destination.resolve()
+    if dest == product:
+        raise SiteInitError(
+            f"destination {dest} is the product checkout; a private site dir "
+            "must not live inside (or as) the public product tree (ADR 005)"
+        )
+    try:
+        dest.relative_to(product)
+    except ValueError:
+        return
+    raise SiteInitError(
+        f"destination {dest} is nested inside the product checkout {product}; "
+        "a private site dir must never live inside a public product working tree (ADR 005)"
+    )
+
+
+def _template_files() -> list[Path]:
+    if not TEMPLATE_DIR.is_dir():
+        raise SiteInitError(f"template directory missing: {TEMPLATE_DIR}")
+    files = sorted(path for path in TEMPLATE_DIR.rglob("*") if path.is_file())
+    if not files:
+        raise SiteInitError(f"no template files under {TEMPLATE_DIR}")
+    return files
+
+
+def _destination_relative(template_path: Path) -> str:
+    relative = template_path.relative_to(TEMPLATE_DIR).as_posix()
+    if relative.endswith(".j2"):
+        return relative[: -len(".j2")]
+    return relative
+
+
+def _render_context(
+    *,
+    site_name: str,
+    product_root: Path,
+    site_dir: Path,
+) -> dict[str, str]:
+    product = str(product_root.resolve())
+    return {
+        "site_name": site_name,
+        "product_root": product,
+        "stayturgid_root": product,
+        "site_dir": str(site_dir.resolve()),
+    }
+
+
+def _render_template(template_path: Path, context: dict[str, str]) -> bytes:
+    environment = Environment(
+        undefined=StrictUndefined,
+        keep_trailing_newline=True,
+        autoescape=False,
+    )
+    text = template_path.read_text(encoding="utf-8")
+    rendered = environment.from_string(text).render(**context)
+    return rendered.encode("utf-8")
+
+
+def _load_payload(template_path: Path, context: dict[str, str]) -> bytes:
+    if template_path.suffix == ".j2" or template_path.name.endswith(".j2"):
+        return _render_template(template_path, context)
+    return template_path.read_bytes()
+
+
+def build_plan(
+    site_name: str,
+    *,
+    dir_path: str | None = None,
+    product_root: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> InitPlan:
+    """Compute the full init plan without writing anything."""
+    name = validate_site_name(site_name)
+    product = (product_root or REPO_ROOT).resolve()
+    destination = resolve_destination(name, dir_path=dir_path, product_root=product, env=env)
+    context = _render_context(site_name=name, product_root=product, site_dir=destination)
+
+    planned: list[PlannedFile] = []
+    for template_path in _template_files():
+        relative = _destination_relative(template_path)
+        content = _load_payload(template_path, context)
+        target = destination / relative
+        if target.exists():
+            if target.is_dir():
+                raise SiteInitError(f"destination path {target} exists as a directory; expected a file")
+            existing = target.read_bytes()
+            action: ActionKind = "skip" if existing == content else "overwrite"
+        else:
+            action = "create"
+        planned.append(PlannedFile(relative_path=relative, content=content, action=action))
+
+    return InitPlan(
+        site_name=name,
+        destination=destination,
+        product_root=product,
+        files=tuple(planned),
+    )
+
+
+def format_action_list(plan: InitPlan) -> str:
+    """Exact per-file action list for dry-run (and conflict reporting)."""
+    lines = [f"{item.action:9} {item.relative_path}" for item in plan.files]
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def apply_plan(plan: InitPlan) -> None:
+    """Write planned creates. Refuses if any overwrite would occur."""
+    if plan.conflicts:
+        paths = ", ".join(item.relative_path for item in plan.conflicts)
+        raise SiteInitError(
+            f"refusing to overwrite user-owned file(s): {paths}",
+            exit_code=EXIT_WOULD_OVERWRITE,
+        )
+    plan.destination.mkdir(parents=True, exist_ok=True)
+    for item in plan.files:
+        if item.action == "skip":
+            continue
+        target = plan.destination / item.relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(item.content)
+
+
+def _docs_markdown() -> str:
+    """Self-contained Markdown for mode=docs (generic values only)."""
+    context = _render_context(
+        site_name=_DOCS_SITE_NAME,
+        product_root=Path(_DOCS_PRODUCT_ROOT),
+        site_dir=Path(_DOCS_SITE_DIR),
+    )
+    rows: list[tuple[str, str, str]] = []
+    for template_path in _template_files():
+        relative = _destination_relative(template_path)
+        if template_path.name.endswith(".j2"):
+            kind = "Jinja2 render"
+            note = (
+                f"Render `{template_path.relative_to(CONTRACT_DIR).as_posix()}` with "
+                f"`site_name={_DOCS_SITE_NAME!r}`, `product_root={_DOCS_PRODUCT_ROOT!r}`, "
+                f"`stayturgid_root={_DOCS_PRODUCT_ROOT!r}`, `site_dir={_DOCS_SITE_DIR!r}`."
+            )
+            # Ensure templates still render under docs context (StrictUndefined).
+            _load_payload(template_path, context)
+        else:
+            kind = "byte-for-byte copy"
+            note = f"Copy `{template_path.relative_to(CONTRACT_DIR).as_posix()}` unchanged to `{relative}`."
+        rows.append((relative, kind, note))
+
+    lines = [
+        "# site-init — manual equivalent (Site Contract v1)",
+        "",
+        "This document is produced by `just site-init mode=docs`. It describes every",
+        "filesystem step `site-init` performs so an operator can reproduce the scaffold",
+        "by hand. Values below are **generic only** (RFC 5737 / example inventory names);",
+        "they are not taken from any private site overlay.",
+        "",
+        "## Preconditions",
+        "",
+        f"1. Public product checkout available (example path: `{_DOCS_PRODUCT_ROOT}`).",
+        "2. Destination site directory does not nest inside the product tree (ADR 005).",
+        f"3. Default destination is `$OPS_ROOT/site-<name>` (example: `{_DOCS_SITE_DIR}`).",
+        "4. Bare sitename matches `^[a-z][a-z0-9-]*$` (no `site-` prefix).",
+        "5. Existing destination files with **different** content block initialization",
+        "   (exit code 2); identical content is skipped (idempotent no-op).",
+        "",
+        "## CLI",
+        "",
+        "```text",
+        "just site-init sitename=<name> [dir=<path>] [map=<site-map.yml>] [mode=apply|dry-run|docs]",
+        "```",
+        "",
+        "- `mode=apply` (default): create missing files; never overwrite user content.",
+        "- `mode=dry-run`: print per-file `create` / `skip` / `overwrite` actions; no writes.",
+        "- `mode=docs`: emit this document; no writes.",
+        "- Exit codes: `0` success/no-op; `1` bad input/precondition; `2` would overwrite.",
+        "- `map=` is reserved for Phase C4 (`site-map.yml`); providing it fails closed today.",
+        "",
+        "## Scaffold layout",
+        "",
+        "```text",
+        f"site-{_DOCS_SITE_NAME}/",
+        "  README.md",
+        "  ansible.cfg",
+        "  justfile",
+        "  .gitignore",
+        "  inventory/",
+        "    hosts.yml          # product example inventory (RFC 5737 / §4.1 names)",
+        "    group_vars/",
+        "  registry/",
+        "    ports.yml          # product port defaults (derived seeds)",
+        "    paths.yml          # product path defaults (derived seeds)",
+        "  secretspec.toml",
+        f"  generated/{PRODUCT}/",
+        "  docs/",
+        "```",
+        "",
+        "## Per-file steps",
+        "",
+        "| Destination | Action | Manual equivalent |",
+        "| --- | --- | --- |",
+    ]
+    for relative, kind, note in rows:
+        safe_note = note.replace("|", "\\|")
+        lines.append(f"| `{relative}` | {kind} | {safe_note} |")
+
+    lines.extend(
+        [
+            "",
+            "## After initialization",
+            "",
+            "1. Edit `inventory/hosts.yml`: replace example aliases, RFC 5737 addresses,",
+            "   and placeholder serials with this site's values.",
+            "2. Reconcile `registry/ports.yml` and `registry/paths.yml` with local allocations.",
+            "3. Provide secret *values* via a secretspec provider (never commit them).",
+            "4. Point product tooling at the site via `STAYTURGID_SITE_DIR` or `ANSIBLE_CONFIG`,",
+            "   or place the site as the sole `site-*` checkout under `$OPS_ROOT`.",
+            "5. Later product upgrades use `site-sync` (Phase C3) for `generated/<product>/` only.",
+            "",
+            "## Invariants",
+            "",
+            f"- Everything outside `generated/{PRODUCT}/` is user-owned after creation.",
+            "- `site-init` never overwrites a differing user file.",
+            "- A second identical `apply` is a no-op (all files `skip`).",
+            "- Private site data must never nest inside the public product working tree.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _parse_mode(value: str) -> Mode:
+    mode = value.strip().lower()
+    if mode not in {"apply", "dry-run", "docs"}:
+        raise SiteInitError(f"mode must be apply, dry-run, or docs; got {value!r}")
+    return mode  # type: ignore[return-value]
+
+
+def run_site_init(
+    *,
+    sitename: str,
+    dir_path: str | None = None,
+    map_path: str | None = None,
+    mode: str = "apply",
+    product_root: Path | None = None,
+    env: dict[str, str] | None = None,
+    stdout: object | None = None,
+    stderr: object | None = None,
+) -> int:
+    """Programmatic entry point used by tests and ``main``."""
+    out = stdout if stdout is not None else sys.stdout
+    err = stderr if stderr is not None else sys.stderr
+    try:
+        if map_path and str(map_path).strip():
+            raise SiteInitError(
+                "site-map.yml support is not implemented in this phase (Phase C4); omit map= until then"
+            )
+        parsed_mode = _parse_mode(mode)
+        if parsed_mode == "docs":
+            print(_docs_markdown(), end="", file=out)
+            return EXIT_OK
+
+        plan = build_plan(
+            sitename,
+            dir_path=dir_path,
+            product_root=product_root,
+            env=env,
+        )
+        action_list = format_action_list(plan)
+        if parsed_mode == "dry-run":
+            print(action_list, end="", file=out)
+            if plan.conflicts:
+                conflict_paths = ", ".join(item.relative_path for item in plan.conflicts)
+                print(
+                    f"error: would overwrite user-owned file(s): {conflict_paths}",
+                    file=err,
+                )
+                return EXIT_WOULD_OVERWRITE
+            return EXIT_OK
+
+        # apply
+        if plan.conflicts:
+            conflict_paths = ", ".join(item.relative_path for item in plan.conflicts)
+            print(action_list, end="", file=out)
+            print(
+                f"error: refusing to overwrite user-owned file(s): {conflict_paths}",
+                file=err,
+            )
+            return EXIT_WOULD_OVERWRITE
+        apply_plan(plan)
+        # Quiet success: optional summary on stderr for operators.
+        created = sum(1 for item in plan.files if item.action == "create")
+        skipped = sum(1 for item in plan.files if item.action == "skip")
+        print(
+            f"site-init: {plan.destination} (created={created}, skipped={skipped}, site_name={plan.site_name})",
+            file=err,
+        )
+        return EXIT_OK
+    except SiteInitError as exc:
+        print(f"error: {exc}", file=err)
+        return exc.exit_code
+    except OSError as exc:
+        print(f"error: {exc}", file=err)
+        return EXIT_PRECONDITION
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Initialize a private stayturgid site overlay (Site Contract v1).",
+    )
+    parser.add_argument("--sitename", default="", help="bare site name (e.g. example → site-example)")
+    parser.add_argument("--dir", dest="dir_path", default="", help="explicit destination directory")
+    parser.add_argument(
+        "--map",
+        dest="map_path",
+        default="",
+        help="optional site-map.yml (Phase C4; rejected until then)",
+    )
+    parser.add_argument(
+        "--mode",
+        default="apply",
+        help="apply (default), dry-run, or docs",
+    )
+    parser.add_argument(
+        "assignments",
+        nargs="*",
+        help="optional KEY=VALUE assignments: sitename=, dir=, map=, mode=",
+    )
+    return parser
+
+
+def _merge_assignments(
+    *,
+    sitename: str,
+    dir_path: str,
+    map_path: str,
+    mode: str,
+    assignments: Sequence[str],
+) -> tuple[str, str, str, str]:
+    """Merge KEY=VALUE tokens (from the just wrapper) into flag values."""
+    allowed = {"sitename", "dir", "map", "mode"}
+    values = {
+        "sitename": sitename,
+        "dir": dir_path,
+        "map": map_path,
+        "mode": mode,
+    }
+    for token in assignments:
+        if "=" not in token:
+            raise SiteInitError(
+                f"unknown argument {token!r}; expected sitename= / dir= / map= / mode= or the matching --flag forms"
+            )
+        key, value = token.split("=", 1)
+        if key not in allowed:
+            raise SiteInitError(f"unknown assignment {key!r}; expected one of: {', '.join(sorted(allowed))}")
+        values[key] = value
+    return values["sitename"], values["dir"], values["map"], values["mode"]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    try:
+        sitename, dir_path, map_path, mode = _merge_assignments(
+            sitename=args.sitename,
+            dir_path=args.dir_path,
+            map_path=args.map_path,
+            mode=args.mode,
+            assignments=args.assignments,
+        )
+    except SiteInitError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return exc.exit_code
+    if not sitename.strip():
+        print(
+            "error: sitename is required (e.g. just site-init sitename=example  or  --sitename example)",
+            file=sys.stderr,
+        )
+        return EXIT_PRECONDITION
+    return run_site_init(
+        sitename=sitename,
+        dir_path=dir_path or None,
+        map_path=map_path or None,
+        mode=mode,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/control/site_contract/site_init.py
+++ b/control/site_contract/site_init.py
@@ -20,7 +20,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Sequence
 
-from jinja2 import Environment, StrictUndefined
+try:
+    from jinja2 import Environment, StrictUndefined
+except ModuleNotFoundError as exc:  # pragma: no cover - exercised when deps missing
+    raise SystemExit(
+        "error: jinja2 is required for site-init (install ansible-core, or use the project test venv: just test-venv)"
+    ) from exc
 
 PRODUCT = "stayturgid"
 CONTRACT_DIR = Path(__file__).resolve().parent

--- a/just/site.just
+++ b/just/site.just
@@ -1,0 +1,18 @@
+# Site-contract CLI surfaces (docs/architecture/site-contract.md §2).
+#
+# Usage:
+#   just site-init sitename=<name> [dir=<path>] [map=<site-map.yml>] [mode=apply|dry-run|docs]
+#
+# The recipe is a thin wrapper: named KEY=VALUE tokens are forwarded to the
+# Python entry point. mode defaults to apply inside Python when omitted.
+
+# Initialize a private site overlay (apply | dry-run | docs).
+site-init *args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ {{ if args == "" { "1" } else { "0" } }} -eq 1 ]]; then
+      echo "usage: just site-init sitename=<name> [dir=<path>] [map=<site-map.yml>] [mode=apply|dry-run|docs]" >&2
+      exit 1
+    fi
+    cd "{{ repo }}"
+    python3 -m control.site_contract.site_init {{ args }}

--- a/just/site.just
+++ b/just/site.just
@@ -5,6 +5,7 @@
 #
 # The recipe is a thin wrapper: named KEY=VALUE tokens are forwarded to the
 # Python entry point. mode defaults to apply inside Python when omitted.
+# Prefers the project test venv (has Jinja2 via ansible-core) when present.
 
 # Initialize a private site overlay (apply | dry-run | docs).
 site-init *args:
@@ -15,4 +16,11 @@ site-init *args:
       exit 1
     fi
     cd "{{ repo }}"
-    python3 -m control.site_contract.site_init {{ args }}
+    if [[ -n "${SITE_INIT_PYTHON:-}" ]]; then
+      py="${SITE_INIT_PYTHON}"
+    elif [[ -x "{{ repo }}/.venv-test/bin/python" ]]; then
+      py="{{ repo }}/.venv-test/bin/python"
+    else
+      py="python3"
+    fi
+    exec "$py" -m control.site_contract.site_init {{ args }}

--- a/justfile
+++ b/justfile
@@ -31,6 +31,7 @@ import "just/fleet.just"
 import "just/services.just"
 import "just/tests.just"
 import "just/cfengine.just"
+import "just/site.just"
 
 # Show available recipes (default).
 help:

--- a/tests/python/requirements.txt
+++ b/tests/python/requirements.txt
@@ -2,6 +2,7 @@
 # Install: uv venv .venv-test && uv pip install -r tests/python/requirements.txt
 # Or:     uv sync
 ansible-core>=2.16
+jinja2>=3.1
 pytest>=7
 pytest-mock>=3
 pytest-ansible>=2

--- a/tests/python/test_site_init.py
+++ b/tests/python/test_site_init.py
@@ -1,0 +1,418 @@
+"""Focused tests for site-init (Site Contract v1 acceptance tests 1, 2, 6)."""
+
+from __future__ import annotations
+
+import configparser
+import filecmp
+import io
+import os
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from control.site_contract import site_init as si  # noqa: E402
+
+TEMPLATES = ROOT / "control" / "site_contract" / "templates"
+
+EXPECTED_RELATIVE = {
+    ".gitignore",
+    "README.md",
+    "ansible.cfg",
+    "docs/.gitkeep",
+    "generated/stayturgid/.gitkeep",
+    "inventory/group_vars/.gitkeep",
+    "inventory/hosts.yml",
+    "justfile",
+    "registry/paths.yml",
+    "registry/ports.yml",
+    "secretspec.toml",
+}
+
+
+def _snapshot(path: Path) -> dict[str, bytes | None]:
+    """Map relative posix paths → file bytes; directories as None."""
+    if not path.exists():
+        return {}
+    out: dict[str, bytes | None] = {}
+    for item in sorted(path.rglob("*")):
+        rel = item.relative_to(path).as_posix()
+        if item.is_dir():
+            out[rel + "/"] = None
+        else:
+            out[rel] = item.read_bytes()
+    return out
+
+
+def _run_cli(args: list[str], *, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    full_env = os.environ.copy()
+    if env:
+        full_env.update(env)
+    return subprocess.run(
+        [sys.executable, "-m", "control.site_contract.site_init", *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=full_env,
+    )
+
+
+def _run_api(
+    *,
+    sitename: str,
+    dir_path: str | None = None,
+    map_path: str | None = None,
+    mode: str = "apply",
+    env: dict[str, str] | None = None,
+) -> tuple[int, str, str]:
+    out = io.StringIO()
+    err = io.StringIO()
+    code = si.run_site_init(
+        sitename=sitename,
+        dir_path=dir_path,
+        map_path=map_path,
+        mode=mode,
+        product_root=ROOT,
+        env=env if env is not None else {},
+        stdout=out,
+        stderr=err,
+    )
+    return code, out.getvalue(), err.getvalue()
+
+
+# --- Acceptance test 1: dry-run, no writes ---------------------------------
+
+
+def test_dry_run_empty_destination_lists_actions_and_writes_nothing(tmp_path: Path) -> None:
+    dest = tmp_path / "site-example"
+    assert not dest.exists()
+    before_parent = _snapshot(tmp_path)
+
+    code, stdout, stderr = _run_api(
+        sitename="example",
+        dir_path=str(dest),
+        mode="dry-run",
+    )
+    assert code == si.EXIT_OK, stderr
+    assert not dest.exists()
+    assert _snapshot(tmp_path) == before_parent
+
+    lines = [line for line in stdout.splitlines() if line.strip()]
+    assert lines
+    actions = {line.split(maxsplit=1)[0] for line in lines}
+    assert actions == {"create"}
+    listed = {line.split(maxsplit=1)[1] for line in lines}
+    assert listed == EXPECTED_RELATIVE
+
+
+def test_dry_run_via_cli_module(tmp_path: Path) -> None:
+    dest = tmp_path / "empty-site"
+    before = _snapshot(tmp_path)
+    result = _run_cli(["--sitename", "example", "--dir", str(dest), "--mode", "dry-run"])
+    assert result.returncode == 0, result.stderr
+    assert "create" in result.stdout
+    assert not dest.exists()
+    assert _snapshot(tmp_path) == before
+
+
+# --- Acceptance test 2: apply scaffold + second apply no-op ----------------
+
+
+def test_apply_creates_section3_scaffold_and_second_apply_is_noop(tmp_path: Path) -> None:
+    dest = tmp_path / "site-example"
+    code, _stdout, stderr = _run_api(sitename="example", dir_path=str(dest), mode="apply")
+    assert code == si.EXIT_OK, stderr
+
+    actual = {p.relative_to(dest).as_posix() for p in dest.rglob("*") if p.is_file()}
+    assert actual == EXPECTED_RELATIVE
+
+    # Structured files parse; registries are the complete derived seeds.
+    ports = yaml.safe_load((dest / "registry/ports.yml").read_text(encoding="utf-8"))
+    paths = yaml.safe_load((dest / "registry/paths.yml").read_text(encoding="utf-8"))
+    assert ports["product"] == "stayturgid"
+    claims = [claim for scope in ports["product_defaults"].values() for claim in scope]
+    assert len(claims) >= 10
+    assert all(claim.get("port") for claim in claims)
+    assert paths["prefixes"]["stayturgid"]
+
+    assert (dest / "registry/ports.yml").read_bytes() == (TEMPLATES / "registry/ports.yml").read_bytes()
+    assert (dest / "registry/paths.yml").read_bytes() == (TEMPLATES / "registry/paths.yml").read_bytes()
+    assert (dest / "inventory/hosts.yml").read_bytes() == (TEMPLATES / "inventory/hosts.yml").read_bytes()
+    assert (dest / ".gitignore").read_bytes() == (TEMPLATES / ".gitignore").read_bytes()
+
+    ansible_config = configparser.ConfigParser(interpolation=None)
+    ansible_config.read_string((dest / "ansible.cfg").read_text(encoding="utf-8"))
+    assert ansible_config["defaults"]["inventory"] == "inventory/hosts.yml"
+    assert ansible_config["defaults"]["roles_path"] == f"{ROOT}/ansible/roles"
+
+    secret_spec = tomllib.loads((dest / "secretspec.toml").read_text(encoding="utf-8"))
+    assert secret_spec["project"]["name"] == "site-example"
+    assert "OPENOBSERVE_ROOT_PASSWORD" in secret_spec["profiles"]["default"]
+
+    readme = (dest / "README.md").read_text(encoding="utf-8")
+    assert "site-example" in readme
+    assert "generated/stayturgid/" in readme
+
+    just_result = subprocess.run(
+        ["just", "--summary", "--justfile", str(dest / "justfile")],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert just_result.returncode == 0, just_result.stderr
+
+    after_first = _snapshot(dest)
+    code2, _stdout2, stderr2 = _run_api(sitename="example", dir_path=str(dest), mode="apply")
+    assert code2 == si.EXIT_OK, stderr2
+    assert _snapshot(dest) == after_first
+
+    code3, dry_out, dry_err = _run_api(sitename="example", dir_path=str(dest), mode="dry-run")
+    assert code3 == si.EXIT_OK, dry_err
+    dry_actions = {line.split(maxsplit=1)[0] for line in dry_out.splitlines() if line.strip()}
+    assert dry_actions == {"skip"}
+
+
+def test_apply_via_just_wrapper(tmp_path: Path) -> None:
+    dest = tmp_path / "from-just"
+    result = subprocess.run(
+        [
+            "just",
+            "--justfile",
+            str(ROOT / "justfile"),
+            "--working-directory",
+            str(ROOT),
+            "site-init",
+            "sitename=example",
+            f"dir={dest}",
+            "mode=apply",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=ROOT,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert (dest / "registry/ports.yml").is_file()
+    assert (dest / "inventory/hosts.yml").is_file()
+
+
+def test_just_wrapper_dry_run_and_docs_exit_codes(tmp_path: Path) -> None:
+    dest = tmp_path / "via-just"
+    dry = subprocess.run(
+        ["just", "site-init", "sitename=example", f"dir={dest}", "mode=dry-run"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=ROOT,
+    )
+    assert dry.returncode == 0, dry.stderr
+    assert "create" in dry.stdout
+    assert not dest.exists()
+
+    docs = subprocess.run(
+        ["just", "site-init", "sitename=example", "mode=docs"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=ROOT,
+    )
+    assert docs.returncode == 0, docs.stderr
+    assert docs.stdout.lstrip().startswith("#")
+    assert not dest.exists()
+
+
+# --- Exit 2: conflicting user-owned file, no partial writes ----------------
+
+
+def test_conflicting_user_file_exits_2_without_partial_writes(tmp_path: Path) -> None:
+    dest = tmp_path / "site-conflict"
+    code, _, stderr = _run_api(sitename="example", dir_path=str(dest), mode="apply")
+    assert code == si.EXIT_OK, stderr
+
+    conflict = dest / "README.md"
+    conflict.write_text("# user edited this\n", encoding="utf-8")
+    # Also leave a marker that must not be deleted and no new files from a half-write.
+    marker = dest / "docs" / "operator-note.md"
+    marker.write_text("keep me\n", encoding="utf-8")
+    before = _snapshot(dest)
+
+    code2, stdout, stderr2 = _run_api(sitename="example", dir_path=str(dest), mode="apply")
+    assert code2 == si.EXIT_WOULD_OVERWRITE
+    assert "README.md" in stderr2
+    assert _snapshot(dest) == before
+    assert marker.read_text(encoding="utf-8") == "keep me\n"
+    assert conflict.read_text(encoding="utf-8") == "# user edited this\n"
+
+    code3, dry_out, dry_err = _run_api(sitename="example", dir_path=str(dest), mode="dry-run")
+    assert code3 == si.EXIT_WOULD_OVERWRITE
+    assert any(line.startswith("overwrite") and "README.md" in line for line in dry_out.splitlines())
+    assert "README.md" in dry_err
+    assert _snapshot(dest) == before
+
+
+# --- Exit 1: bad input / preconditions -------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sitename",
+    ["", "Example", "site-example", "has/slash", "has space", "-leading", "UPPER", "a_b"],
+)
+def test_bad_sitename_exits_1(sitename: str, tmp_path: Path) -> None:
+    code, _, stderr = _run_api(sitename=sitename, dir_path=str(tmp_path / "x"), mode="dry-run")
+    assert code == si.EXIT_PRECONDITION
+    assert stderr.strip()
+    assert "error:" in stderr.lower()
+
+
+def test_empty_sitename_via_just_exits_1() -> None:
+    result = subprocess.run(
+        ["just", "--justfile", str(ROOT / "justfile"), "--working-directory", str(ROOT), "site-init"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=ROOT,
+    )
+    assert result.returncode == 1
+    assert "usage:" in result.stderr.lower() or "sitename" in result.stderr.lower()
+
+
+def test_map_argument_rejected_until_c4(tmp_path: Path) -> None:
+    code, _, stderr = _run_api(
+        sitename="example",
+        dir_path=str(tmp_path / "site-example"),
+        map_path=str(tmp_path / "site-map.yml"),
+        mode="dry-run",
+    )
+    assert code == si.EXIT_PRECONDITION
+    assert "site-map" in stderr.lower() or "c4" in stderr.lower() or "phase" in stderr.lower()
+    assert not (tmp_path / "site-example").exists()
+
+
+def test_invalid_mode_exits_1(tmp_path: Path) -> None:
+    code, _, stderr = _run_api(sitename="example", dir_path=str(tmp_path / "x"), mode="explode")
+    assert code == si.EXIT_PRECONDITION
+    assert "mode" in stderr.lower()
+
+
+# --- Nested destination rejected before write ------------------------------
+
+
+def test_destination_nested_in_product_rejected(tmp_path: Path) -> None:
+    nested = ROOT / ".tmp-site-init-nested-test"
+    try:
+        if nested.exists():
+            shutil.rmtree(nested)
+        code, _, stderr = _run_api(sitename="example", dir_path=str(nested), mode="apply")
+        assert code == si.EXIT_PRECONDITION
+        assert "nested" in stderr.lower() or "product" in stderr.lower()
+        assert not nested.exists()
+    finally:
+        if nested.exists():
+            shutil.rmtree(nested)
+
+
+def test_destination_equals_product_rejected() -> None:
+    code, _, stderr = _run_api(sitename="example", dir_path=str(ROOT), mode="dry-run")
+    assert code == si.EXIT_PRECONDITION
+    assert "product" in stderr.lower()
+
+
+def test_default_destination_under_ops_root(tmp_path: Path) -> None:
+    code, stdout, stderr = _run_api(
+        sitename="example",
+        mode="dry-run",
+        env={"OPS_ROOT": str(tmp_path)},
+    )
+    assert code == si.EXIT_OK, stderr
+    # No dir= → plan targets OPS_ROOT/site-example; dry-run must not create it.
+    assert not (tmp_path / "site-example").exists()
+    plan = si.build_plan("example", env={"OPS_ROOT": str(tmp_path)}, product_root=ROOT)
+    assert plan.destination == (tmp_path / "site-example").resolve()
+
+
+# --- Acceptance test 6: docs mode ------------------------------------------
+
+
+def test_docs_mode_is_deterministic_markdown_without_site_identity(tmp_path: Path) -> None:
+    before = _snapshot(tmp_path)
+    code1, out1, err1 = _run_api(sitename="example", dir_path=str(tmp_path / "ignored"), mode="docs")
+    code2, out2, err2 = _run_api(sitename="othername", dir_path=str(tmp_path / "also-ignored"), mode="docs")
+    assert code1 == si.EXIT_OK, err1
+    assert code2 == si.EXIT_OK, err2
+    assert out1 == out2
+    assert _snapshot(tmp_path) == before
+    assert not (tmp_path / "ignored").exists()
+
+    assert out1.lstrip().startswith("# ")
+    assert "site-init" in out1.lower()
+    assert "```" in out1
+    assert "inventory/hosts.yml" in out1
+    assert "registry/ports.yml" in out1
+    assert "mode=docs" in out1 or "`docs`" in out1
+
+    # Generic only — no private reference-site identity or operator home path.
+    forbidden = [
+        "djbclark",
+        "site-djbclark",
+        str(Path.home()),
+        str(ROOT),
+        "192.168.",
+        "100.64.",
+        "100.65.",
+        "EXAMPLE-SERIAL-LIVE",
+    ]
+    lowered = out1.lower()
+    for token in forbidden:
+        assert token.lower() not in lowered, f"docs leaked {token!r}"
+
+    # Allowed generic fixtures from the contract / topology docs.
+    assert "example" in lowered
+    assert "192.0.2." in out1 or "RFC 5737" in out1 or "rfc 5737" in lowered
+
+
+def test_docs_mode_via_cli_no_writes(tmp_path: Path) -> None:
+    before = _snapshot(tmp_path)
+    result = _run_cli(["--sitename", "example", "--dir", str(tmp_path / "x"), "--mode", "docs"])
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.lstrip().startswith("#")
+    assert _snapshot(tmp_path) == before
+
+
+# --- Exit codes via CLI for all three modes --------------------------------
+
+
+def test_cli_exit_codes_matrix(tmp_path: Path) -> None:
+    dest = tmp_path / "site-matrix"
+    assert _run_cli(["--sitename", "example", "--dir", str(dest), "--mode", "dry-run"]).returncode == 0
+    assert _run_cli(["--sitename", "example", "--dir", str(dest), "--mode", "docs"]).returncode == 0
+    assert _run_cli(["--sitename", "example", "--dir", str(dest), "--mode", "apply"]).returncode == 0
+    assert _run_cli(["--sitename", "example", "--dir", str(dest), "--mode", "apply"]).returncode == 0
+
+    (dest / "ansible.cfg").write_text("broken\n", encoding="utf-8")
+    conflict = _run_cli(["--sitename", "example", "--dir", str(dest), "--mode", "apply"])
+    assert conflict.returncode == 2
+    assert "ansible.cfg" in conflict.stderr
+
+    bad = _run_cli(["--sitename", "NOT_VALID", "--dir", str(dest), "--mode", "dry-run"])
+    assert bad.returncode == 1
+
+
+def test_two_isolated_applies_are_byte_identical(tmp_path: Path) -> None:
+    """Sanity: apply output matches a second isolated apply byte-for-byte."""
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    assert _run_api(sitename="example", dir_path=str(a), mode="apply")[0] == 0
+    assert _run_api(sitename="example", dir_path=str(b), mode="apply")[0] == 0
+    assert _snapshot(a) == _snapshot(b)
+    comparison = filecmp.dircmp(a, b)
+    assert not comparison.left_only
+    assert not comparison.right_only
+    assert not comparison.diff_files


### PR DESCRIPTION
## Summary

Implements **Phase C2** of the site contract: the `site-init` CLI surface with `apply` / `dry-run` / `docs` modes and exit codes from Site Contract v1 §2.

- **Python:** `python3 -m control.site_contract.site_init` under `control/site_contract/site_init.py`
- **Just wrapper:** `just site-init sitename=<name> [dir=<path>] [map=<site-map.yml>] [mode=apply|dry-run|docs]`
- Renders/copies the C1 template tree; never overwrites user-owned files (exit 2); identical re-apply is a no-op
- Rejects destinations nested in the product checkout (ADR 005)
- Docs mode emits generic Markdown only (RFC 5737 / example names)
- `map=` is rejected until C4 (no partial remapping); no `site-sync`/lockfile (C3)

## Acceptance tests (site-contract §8)

1. dry-run on empty destination → action list, no writes
2. apply → §3 scaffold + complete registry seeds; second apply no-op
6. docs mode → no site-specific identity

## Test plan

- [x] Focused suite: `tests/python/test_site_init.py` + `test_site_contract_templates.py` (30 passed)
- [x] `python3 -m control.site_contract.generate_registry_seeds --check`
- [x] Manual: all three modes + exit codes 0/1/2 via `just site-init` and Python entry point
- [x] `STAYTURGID_SITE_DIR=…/site-djbclark just check`
- [x] Strict identity: overlay + upstream-only (zero drift, no secret-shaped strings)
- [x] `git diff --check`, pre-commit on changed files
- [ ] Hosted CI green

## Out of scope (later steps)

- C3: `site-sync` + `.lockfile.yml` semantics
- C4: `site-map.yml` remapping
- C5: Entangled literate contract
- Serverapp adapters, brew/Ansible bootstrap, secrets materialization