### PR TITLE
C4: support fail-closed site-map path remapping

### DIFF
--- a/control/site_contract/README.md
+++ b/control/site_contract/README.md
@@ -11,6 +11,8 @@ This directory implements Phase C of the site contract in
 - `generate_registry_seeds.py` resolves that source map and writes the
   committed `templates/registry/{ports,paths}.yml` seeds.
 - `site_init.py` is the `site-init` CLI (apply / dry-run / docs).
+- `site_map.py` loads and fail-closed validates optional Site Contract v1
+  `site-map.yml` files for `site-init` and `site-sync`.
 - `sync_manifest.yml` is the product sync manifest (files under
   `generated/<product>/` that `site-sync` owns).
 - `sync_templates/` holds Jinja2 sources for those generated files.
@@ -32,7 +34,14 @@ python3 -m control.site_contract.site_init --sitename <name> [--dir <path>] [--m
 - `mode=dry-run`: print per-file `create` / `skip` / `overwrite` actions; no writes.
 - `mode=docs`: emit self-contained Markdown with generic example values only.
 - Exit codes: `0` success/no-op; `1` precondition/input failure; `2` would overwrite.
-- `map=` is reserved for Phase C4 and is rejected until then.
+- `map=` loads an explicit Site Contract v1 map; otherwise a map at
+  `<site-dir>/site-map.yml` is auto-discovered. Supported C4 path keys are
+  `inventory`, `registry_ports`, and `registry_paths`.
+- Relative contract paths resolve from the site directory and may not escape
+  it or enter site-sync's `generated/stayturgid/` area. Unknown top-level,
+  path, serverapp, and per-app keys fail closed.
+- Serverapp mappings are validated for forward compatibility but no adapter
+  behavior or inject-mode writes occur in C4.
 - A destination nested inside this product checkout is rejected (ADR 005).
 
 ## site-sync
@@ -45,6 +54,9 @@ python3 -m control.site_contract.site_sync [--dir <path>] [--mode apply|dry-run|
 
 - Destination: explicit `dir=`, else `STAYTURGID_SITE_DIR`, else exactly one
   `site-*` under `$OPS_ROOT`. No hardcoded production-site fallback.
+- Auto-discovers `<site-dir>/site-map.yml` and reads inventory/registry facts
+  from mapped locations while keeping generated output under
+  `generated/stayturgid/`.
 - Re-renders every path in `sync_manifest.yml` into `generated/stayturgid/` and
   maintains `generated/stayturgid/.lockfile.yml` (spec §4).
 - Before overwriting, compares on-disk content hash to the lockfile hash. Drift

--- a/control/site_contract/__init__.py
+++ b/control/site_contract/__init__.py
@@ -3,5 +3,6 @@
 Phase C1: templates and reproducible registry seeds.
 Phase C2: ``site-init`` (apply / dry-run / docs).
 Phase C3: ``site-sync`` + lockfile under ``generated/<product>/``.
+Phase C4: optional fail-closed ``site-map.yml`` path remapping.
 Later: site-map (C4), Entangled (C5), adapters (Phase D).
 """

--- a/control/site_contract/site_init.py
+++ b/control/site_contract/site_init.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, Sequence
 
+from control.site_contract.site_map import SiteMap, SiteMapError, load_site_map
+
 try:
     from jinja2 import Environment, StrictUndefined
 except ModuleNotFoundError as exc:  # pragma: no cover - exercised when deps missing
@@ -170,6 +172,7 @@ def _render_context(
     site_name: str,
     product_root: Path,
     site_dir: Path,
+    site_map: SiteMap,
 ) -> dict[str, str]:
     product = str(product_root.resolve())
     return {
@@ -177,6 +180,9 @@ def _render_context(
         "product_root": product,
         "stayturgid_root": product,
         "site_dir": str(site_dir.resolve()),
+        "inventory_path": site_map.relative_path("inventory"),
+        "registry_ports_path": site_map.relative_path("registry_ports"),
+        "registry_paths_path": site_map.relative_path("registry_paths"),
     }
 
 
@@ -201,6 +207,7 @@ def build_plan(
     site_name: str,
     *,
     dir_path: str | None = None,
+    map_path: str | None = None,
     product_root: Path | None = None,
     env: dict[str, str] | None = None,
 ) -> InitPlan:
@@ -208,11 +215,20 @@ def build_plan(
     name = validate_site_name(site_name)
     product = (product_root or REPO_ROOT).resolve()
     destination = resolve_destination(name, dir_path=dir_path, product_root=product, env=env)
-    context = _render_context(site_name=name, product_root=product, site_dir=destination)
+    try:
+        site_map = load_site_map(site_dir=destination, product_root=product, map_path=map_path)
+    except SiteMapError as exc:
+        raise SiteInitError(str(exc)) from exc
+    context = _render_context(
+        site_name=name,
+        product_root=product,
+        site_dir=destination,
+        site_map=site_map,
+    )
 
     planned: list[PlannedFile] = []
     for template_path in _template_files():
-        relative = _destination_relative(template_path)
+        relative = _mapped_destination_relative(template_path, site_map)
         content = _load_payload(template_path, context)
         target = destination / relative
         if target.exists():
@@ -224,12 +240,32 @@ def build_plan(
             action = "create"
         planned.append(PlannedFile(relative_path=relative, content=content, action=action))
 
+    relative_paths = [item.relative_path for item in planned]
+    duplicate_paths = sorted({path for path in relative_paths if relative_paths.count(path) > 1})
+    if duplicate_paths:
+        raise SiteInitError("site map makes scaffold files collide at: " + ", ".join(duplicate_paths))
+
     return InitPlan(
         site_name=name,
         destination=destination,
         product_root=product,
         files=tuple(planned),
     )
+
+
+def _mapped_destination_relative(template_path: Path, site_map: SiteMap) -> str:
+    """Map contract-owned scaffold templates onto an existing site layout."""
+    default = _destination_relative(template_path)
+    if default == "inventory/hosts.yml":
+        return site_map.relative_path("inventory")
+    if default == "inventory/group_vars/.gitkeep":
+        inventory_parent = site_map.path("inventory").parent
+        return (inventory_parent / "group_vars/.gitkeep").relative_to(site_map.site_dir).as_posix()
+    if default == "registry/ports.yml":
+        return site_map.relative_path("registry_ports")
+    if default == "registry/paths.yml":
+        return site_map.relative_path("registry_paths")
+    return default
 
 
 def format_action_list(plan: InitPlan) -> str:
@@ -257,10 +293,16 @@ def apply_plan(plan: InitPlan) -> None:
 
 def _docs_markdown() -> str:
     """Self-contained Markdown for mode=docs (generic values only)."""
+    docs_site_dir = Path(_DOCS_SITE_DIR)
+    docs_site_map = load_site_map(
+        site_dir=docs_site_dir,
+        product_root=Path(_DOCS_PRODUCT_ROOT),
+    )
     context = _render_context(
         site_name=_DOCS_SITE_NAME,
         product_root=Path(_DOCS_PRODUCT_ROOT),
-        site_dir=Path(_DOCS_SITE_DIR),
+        site_dir=docs_site_dir,
+        site_map=docs_site_map,
     )
     rows: list[tuple[str, str, str]] = []
     for template_path in _template_files():
@@ -306,7 +348,12 @@ def _docs_markdown() -> str:
         "- `mode=dry-run`: print per-file `create` / `skip` / `overwrite` actions; no writes.",
         "- `mode=docs`: emit this document; no writes.",
         "- Exit codes: `0` success/no-op; `1` bad input/precondition; `2` would overwrite.",
-        "- `map=` is reserved for Phase C4 (`site-map.yml`); providing it fails closed today.",
+        "- `map=` loads an explicit Site Contract v1 map; otherwise `<site-dir>/site-map.yml`",
+        "  is auto-discovered before defaults are selected.",
+        "- Map keys fail closed. C4 path keys are `inventory`, `registry_ports`, and",
+        "  `registry_paths`; relative values resolve from the site directory and may not escape it.",
+        f"- Contract paths may not enter site-sync's owned `generated/{PRODUCT}/` area.",
+        "- `serverapps` entries are validated for Phase D but do not cause adapter writes in C4.",
         "",
         "## Scaffold layout",
         "",
@@ -352,6 +399,7 @@ def _docs_markdown() -> str:
             "## Invariants",
             "",
             f"- Everything outside `generated/{PRODUCT}/` is user-owned after creation.",
+            "- A site map redirects only declared contract files; unmapped files keep defaults.",
             "- `site-init` never overwrites a differing user file.",
             "- A second identical `apply` is a no-op (all files `skip`).",
             "- Private site data must never nest inside the public product working tree.",
@@ -383,10 +431,6 @@ def run_site_init(
     out = stdout if stdout is not None else sys.stdout
     err = stderr if stderr is not None else sys.stderr
     try:
-        if map_path and str(map_path).strip():
-            raise SiteInitError(
-                "site-map.yml support is not implemented in this phase (Phase C4); omit map= until then"
-            )
         parsed_mode = _parse_mode(mode)
         if parsed_mode == "docs":
             print(_docs_markdown(), end="", file=out)
@@ -395,6 +439,7 @@ def run_site_init(
         plan = build_plan(
             sitename,
             dir_path=dir_path,
+            map_path=map_path,
             product_root=product_root,
             env=env,
         )
@@ -446,7 +491,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--map",
         dest="map_path",
         default="",
-        help="optional site-map.yml (Phase C4; rejected until then)",
+        help="optional explicit Site Contract v1 site-map.yml",
     )
     parser.add_argument(
         "--mode",

--- a/control/site_contract/site_map.py
+++ b/control/site_contract/site_map.py
@@ -1,0 +1,243 @@
+"""Load and validate Site Contract v1 ``site-map.yml`` files.
+
+Phase C4 consumes only contract paths used by ``site-init`` and ``site-sync``.
+Serverapp mappings are validated and retained for Phase D, but never acted on
+here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ModuleNotFoundError as exc:  # pragma: no cover - dependency guard
+    raise SystemExit(
+        "error: PyYAML is required for site-map.yml support "
+        "(install ansible-core, or use the project test venv: just test-venv)"
+    ) from exc
+
+MAP_FILENAME = "site-map.yml"
+PRODUCT = "stayturgid"
+
+DEFAULT_PATHS = {
+    "inventory": "inventory/hosts.yml",
+    "registry_ports": "registry/ports.yml",
+    "registry_paths": "registry/paths.yml",
+}
+ALLOWED_TOP_LEVEL_KEYS = frozenset({"contract_version", "paths", "serverapps"})
+ALLOWED_PATH_KEYS = frozenset(DEFAULT_PATHS)
+ALLOWED_SERVERAPPS = frozenset(
+    {
+        "caddy",
+        "vector",
+        "openobserve",
+        "victoriametrics",
+        "grafana",
+        "olivetin",
+        "landing",
+    }
+)
+ALLOWED_SERVERAPP_KEYS = frozenset({"config", "fragment_dir", "mode"})
+ALLOWED_SERVERAPP_MODES = frozenset({"own", "inject", "off"})
+
+
+class SiteMapError(Exception):
+    """Invalid or unsafe ``site-map.yml`` input."""
+
+
+@dataclass(frozen=True)
+class ServerAppMap:
+    """Validated Phase D serverapp mapping (not acted on in C4)."""
+
+    config: Path | None = None
+    fragment_dir: Path | None = None
+    mode: str | None = None
+
+
+@dataclass(frozen=True)
+class SiteMap:
+    """Resolved Site Contract v1 mapping for one site directory."""
+
+    site_dir: Path
+    source: Path | None
+    paths: dict[str, Path]
+    serverapps: dict[str, ServerAppMap] = field(default_factory=dict)
+
+    def path(self, key: str) -> Path:
+        return self.paths[key]
+
+    def relative_path(self, key: str) -> str:
+        return self.path(key).relative_to(self.site_dir).as_posix()
+
+
+def _unknown_keys(raw: dict[Any, Any], allowed: frozenset[str], location: str) -> None:
+    unknown = sorted(str(key) for key in raw if key not in allowed)
+    if unknown:
+        raise SiteMapError(f"unknown {location} key(s): {', '.join(unknown)}")
+
+
+def _resolve_contract_path(*, key: str, value: Any, site_dir: Path, product_root: Path) -> Path:
+    if not isinstance(value, str) or not value.strip():
+        raise SiteMapError(f"paths.{key} must be a non-empty path string")
+    candidate = Path(value.strip()).expanduser()
+    if not candidate.is_absolute():
+        candidate = site_dir / candidate
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(site_dir)
+    except ValueError as exc:
+        raise SiteMapError(
+            f"paths.{key} escapes the site directory {site_dir}: {value!r} resolves to {resolved}"
+        ) from exc
+    generated_root = (site_dir / "generated" / PRODUCT).resolve()
+    try:
+        resolved.relative_to(generated_root)
+    except ValueError:
+        pass
+    else:
+        raise SiteMapError(f"paths.{key} resolves inside site-sync's owned generated/{PRODUCT}/ area: {resolved}")
+    try:
+        resolved.relative_to(product_root)
+    except ValueError:
+        pass
+    else:
+        raise SiteMapError(
+            f"paths.{key} resolves inside the public product checkout {product_root} (ADR 005): {resolved}"
+        )
+    return resolved
+
+
+def _resolve_serverapp_path(*, app: str, key: str, value: Any, site_dir: Path, product_root: Path) -> Path:
+    if not isinstance(value, str) or not value.strip():
+        raise SiteMapError(f"serverapps.{app}.{key} must be a non-empty path string")
+    candidate = Path(value.strip()).expanduser()
+    if not candidate.is_absolute():
+        candidate = site_dir / candidate
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(product_root)
+    except ValueError:
+        return resolved
+    raise SiteMapError(
+        f"serverapps.{app}.{key} resolves inside the public product checkout {product_root} (ADR 005): {resolved}"
+    )
+
+
+def _parse_serverapps(
+    raw: Any,
+    *,
+    site_dir: Path,
+    product_root: Path,
+) -> dict[str, ServerAppMap]:
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise SiteMapError("serverapps must be a mapping")
+    _unknown_keys(raw, ALLOWED_SERVERAPPS, "serverapps")
+    parsed: dict[str, ServerAppMap] = {}
+    for app, app_raw in raw.items():
+        if not isinstance(app_raw, dict):
+            raise SiteMapError(f"serverapps.{app} must be a mapping")
+        _unknown_keys(app_raw, ALLOWED_SERVERAPP_KEYS, f"serverapps.{app}")
+        config = None
+        fragment_dir = None
+        mode = app_raw.get("mode")
+        if "config" in app_raw:
+            config = _resolve_serverapp_path(
+                app=app,
+                key="config",
+                value=app_raw["config"],
+                site_dir=site_dir,
+                product_root=product_root,
+            )
+        if "fragment_dir" in app_raw:
+            fragment_dir = _resolve_serverapp_path(
+                app=app,
+                key="fragment_dir",
+                value=app_raw["fragment_dir"],
+                site_dir=site_dir,
+                product_root=product_root,
+            )
+        if mode is not None:
+            if not isinstance(mode, str) or mode not in ALLOWED_SERVERAPP_MODES:
+                allowed = ", ".join(sorted(ALLOWED_SERVERAPP_MODES))
+                raise SiteMapError(f"serverapps.{app}.mode must be one of: {allowed}; got {mode!r}")
+        parsed[app] = ServerAppMap(config=config, fragment_dir=fragment_dir, mode=mode)
+    return parsed
+
+
+def load_site_map(
+    *,
+    site_dir: Path,
+    product_root: Path,
+    map_path: str | Path | None = None,
+) -> SiteMap:
+    """Load an explicit map or auto-discover ``site-map.yml`` at the site root."""
+    site = site_dir.resolve()
+    product = product_root.resolve()
+    if map_path is not None and str(map_path).strip():
+        source = Path(map_path).expanduser()
+        if not source.is_absolute():
+            source = (Path.cwd() / source).resolve()
+        else:
+            source = source.resolve()
+        if not source.is_file():
+            raise SiteMapError(f"site map does not exist or is not a file: {source}")
+    else:
+        candidate = site / MAP_FILENAME
+        source = candidate if candidate.is_file() else None
+
+    defaults = {
+        key: _resolve_contract_path(
+            key=key,
+            value=value,
+            site_dir=site,
+            product_root=product,
+        )
+        for key, value in DEFAULT_PATHS.items()
+    }
+    if source is None:
+        return SiteMap(site_dir=site, source=None, paths=defaults)
+
+    try:
+        raw = yaml.safe_load(source.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise SiteMapError(f"cannot parse site map {source}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise SiteMapError(f"site map root must be a mapping: {source}")
+    _unknown_keys(raw, ALLOWED_TOP_LEVEL_KEYS, "top-level")
+    version = raw.get("contract_version")
+    if type(version) is not int or version != 1:
+        raise SiteMapError(f"contract_version must be integer 1 (got {version!r}): {source}")
+
+    paths_raw = raw.get("paths", {})
+    if paths_raw is None:
+        paths_raw = {}
+    if not isinstance(paths_raw, dict):
+        raise SiteMapError("paths must be a mapping")
+    _unknown_keys(paths_raw, ALLOWED_PATH_KEYS, "paths")
+    paths = dict(defaults)
+    for key, value in paths_raw.items():
+        paths[key] = _resolve_contract_path(
+            key=key,
+            value=value,
+            site_dir=site,
+            product_root=product,
+        )
+    duplicates: dict[Path, list[str]] = {}
+    for key, value in paths.items():
+        duplicates.setdefault(value, []).append(key)
+    collisions = [keys for keys in duplicates.values() if len(keys) > 1]
+    if collisions:
+        names = "; ".join(", ".join(keys) for keys in collisions)
+        raise SiteMapError(f"contract paths must resolve to distinct files; collision: {names}")
+
+    serverapps = _parse_serverapps(
+        raw.get("serverapps"),
+        site_dir=site,
+        product_root=product,
+    )
+    return SiteMap(site_dir=site, source=source, paths=paths, serverapps=serverapps)

--- a/control/site_contract/site_sync.py
+++ b/control/site_contract/site_sync.py
@@ -23,6 +23,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal, Sequence
 
+from control.site_contract.site_map import SiteMap, SiteMapError, load_site_map
+
 try:
     from jinja2 import Environment, StrictUndefined
 except ModuleNotFoundError as exc:  # pragma: no cover - exercised when deps missing
@@ -360,6 +362,7 @@ def _site_render_context(
     product_version: str,
     product_commit: str,
     source_template: str,
+    site_map: SiteMap,
 ) -> dict[str, str]:
     """Build template context from product identity + optional site registry facts."""
     context: dict[str, str] = {
@@ -370,9 +373,20 @@ def _site_render_context(
         "product_version": product_version,
         "product_commit": product_commit,
         "source_template": source_template,
+        "inventory_path": site_map.relative_path("inventory"),
+        "registry_ports_path": site_map.relative_path("registry_ports"),
+        "registry_paths_path": site_map.relative_path("registry_paths"),
     }
+    inventory_path = site_map.path("inventory")
+    if inventory_path.is_file():
+        try:
+            inventory = yaml.safe_load(inventory_path.read_text(encoding="utf-8")) or {}
+        except (OSError, yaml.YAMLError):
+            inventory = {}
+        if isinstance(inventory, dict):
+            context["inventory_loaded"] = "true"
     # Optional site facts from registry (never required for the minimal scaffold).
-    ports_path = site_dir / "registry" / "ports.yml"
+    ports_path = site_map.path("registry_ports")
     if ports_path.is_file():
         try:
             ports = yaml.safe_load(ports_path.read_text(encoding="utf-8")) or {}
@@ -380,7 +394,7 @@ def _site_render_context(
             ports = {}
         if isinstance(ports, dict) and isinstance(ports.get("product"), str):
             context["registry_product"] = ports["product"]
-    paths_path = site_dir / "registry" / "paths.yml"
+    paths_path = site_map.path("registry_paths")
     if paths_path.is_file():
         try:
             paths = yaml.safe_load(paths_path.read_text(encoding="utf-8")) or {}
@@ -437,6 +451,10 @@ def build_plan(
     """Compute the full sync plan without writing anything."""
     product = (product_root or REPO_ROOT).resolve()
     destination = resolve_site_dir(dir_path=dir_path, product_root=product, env=env)
+    try:
+        site_map = load_site_map(site_dir=destination, product_root=product)
+    except SiteMapError as exc:
+        raise SiteSyncError(str(exc)) from exc
     manifest = load_manifest(manifest_path)
     version = product_version if product_version is not None else load_product_version(product)
     commit = product_commit if product_commit is not None else load_product_commit(product)
@@ -468,6 +486,7 @@ def build_plan(
             product_version=version,
             product_commit=commit,
             source_template=source_template,
+            site_map=site_map,
         )
         content = _render_template(template_path, context)
         digest = _sha256_bytes(content)
@@ -702,6 +721,9 @@ def _docs_markdown() -> str:
             "product_version": _DOCS_PRODUCT_VERSION,
             "product_commit": _DOCS_PRODUCT_COMMIT,
             "source_template": f"control/site_contract/sync_templates/{entry.template}",
+            "inventory_path": "inventory/hosts.yml",
+            "registry_ports_path": "registry/ports.yml",
+            "registry_paths_path": "registry/paths.yml",
         }
         _render_template(template_path, context)
 
@@ -765,6 +787,8 @@ def _docs_markdown() -> str:
         "- `mode=docs`: emit this document; no writes.",
         "- `--force-generated` / `force-generated=1`: overwrite drifted generated files (still only under generated/).",
         "- Exit codes: `0` success/no-op; `1` bad input/precondition; `2` would overwrite drifted content.",
+        "- `<site-dir>/site-map.yml` is auto-discovered before defaults. Unknown keys",
+        "  fail closed; C4 maps inventory and registries but performs no serverapp writes.",
         "",
         "## Sync rules (spec §4)",
         "",
@@ -773,8 +797,9 @@ def _docs_markdown() -> str:
         "   (hand edit), stop with exit 2 and list drifted paths unless `force-generated`.",
         "3. Paths that leave the product manifest are deleted from the generated area",
         "   (listed in dry-run first).",
-        "4. Phase C3 never writes outside `generated/<product>/` (no serverapp inject mode).",
-        "5. User area outside `generated/<product>/` is never touched.",
+        "4. Site facts are read from mapped `inventory`, `registry_ports`, and `registry_paths` locations.",
+        "5. Phase C4 never writes outside `generated/<product>/` (no serverapp inject mode).",
+        "6. User area outside `generated/<product>/` is never touched.",
         "",
         "## Lockfile shape",
         "",

--- a/control/site_contract/sync_templates/README.md.j2
+++ b/control/site_contract/sync_templates/README.md.j2
@@ -11,6 +11,8 @@ source_template: {{ source_template }}
 This directory is owned by **`site-sync`**. Content is re-rendered from the
 product checkout on each sync and recorded in `.lockfile.yml`.
 
+Site inventory source: `{{ inventory_path }}`.
+
 ## Rules
 
 - Do **not** hand-edit files under `generated/{{ product }}/`.

--- a/control/site_contract/templates/README.md.j2
+++ b/control/site_contract/templates/README.md.j2
@@ -11,9 +11,9 @@ otherwise.
 
 ## Layout
 
-- `inventory/hosts.yml` starts from the product's generic example. Replace all
+- `{{ inventory_path }}` starts from the product's generic example. Replace all
   RFC 5737 addresses, example aliases, and placeholder serials before deploy.
-- `registry/ports.yml` and `registry/paths.yml` contain product defaults to
+- `{{ registry_ports_path }}` and `{{ registry_paths_path }}` contain product defaults to
   reconcile with this site's actual allocations.
 - `secretspec.toml` declares the stayturgid secret profile without storing any
   values.
@@ -28,5 +28,5 @@ The wrapper `justfile` locates the public product at
 `~/ops/stayturgid` in that order. The site and product must remain sibling
 checkouts; never nest this private repository inside the public product tree.
 
-Review `inventory/hosts.yml` and the two registries before running a deployment.
+Review `{{ inventory_path }}` and the two registries before running a deployment.
 Then use `just inventory-check`, `just deploy-check`, and `just deploy`.

--- a/control/site_contract/templates/ansible.cfg.j2
+++ b/control/site_contract/templates/ansible.cfg.j2
@@ -1,5 +1,5 @@
 [defaults]
-inventory = inventory/hosts.yml
+inventory = {{ inventory_path }}
 roles_path = {{ product_root }}/ansible/roles
 # Product collections are supplied by the stayturgid checkout rendered above.
 collections_path = {{ product_root }}/.ansible/collections:{{ product_root }}

--- a/tests/python/test_site_contract_templates.py
+++ b/tests/python/test_site_contract_templates.py
@@ -22,6 +22,9 @@ def _render(name: str) -> str:
     return environment.from_string((TEMPLATES / name).read_text(encoding="utf-8")).render(
         site_name="example",
         product_root="/srv/products/stayturgid",
+        inventory_path="inventory/hosts.yml",
+        registry_ports_path="registry/ports.yml",
+        registry_paths_path="registry/paths.yml",
     )
 
 

--- a/tests/python/test_site_init.py
+++ b/tests/python/test_site_init.py
@@ -204,6 +204,32 @@ def test_apply_via_just_wrapper(tmp_path: Path) -> None:
     assert (dest / "inventory/hosts.yml").is_file()
 
 
+def test_explicit_map_via_just_wrapper(tmp_path: Path) -> None:
+    dest = tmp_path / "mapped-from-just"
+    map_file = tmp_path / "site-map.yml"
+    map_file.write_text(
+        "contract_version: 1\npaths:\n  inventory: custom/inventory.yml\n",
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [
+            "just",
+            "site-init",
+            "sitename=example",
+            f"dir={dest}",
+            f"map={map_file}",
+            "mode=apply",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=ROOT,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert (dest / "custom/inventory.yml").is_file()
+    assert not (dest / "inventory").exists()
+
+
 def test_just_wrapper_dry_run_and_docs_exit_codes(tmp_path: Path) -> None:
     dest = tmp_path / "via-just"
     dry = subprocess.run(
@@ -284,16 +310,128 @@ def test_empty_sitename_via_just_exits_1() -> None:
     assert "usage:" in result.stderr.lower() or "sitename" in result.stderr.lower()
 
 
-def test_map_argument_rejected_until_c4(tmp_path: Path) -> None:
+def test_explicit_map_remaps_inventory_without_writing_default(tmp_path: Path) -> None:
+    dest = tmp_path / "site-example"
+    map_file = tmp_path / "custom-site-map.yml"
+    map_file.write_text(
+        "contract_version: 1\npaths:\n  inventory: ansible/inventories/home/hosts.yml\n",
+        encoding="utf-8",
+    )
+    code, _, stderr = _run_api(
+        sitename="example",
+        dir_path=str(dest),
+        map_path=str(map_file),
+        mode="apply",
+    )
+    assert code == si.EXIT_OK, stderr
+    mapped = dest / "ansible/inventories/home/hosts.yml"
+    assert mapped.is_file()
+    assert not (dest / "inventory/hosts.yml").exists()
+    assert not (dest / "inventory").exists()
+    config = configparser.ConfigParser(interpolation=None)
+    config.read_string((dest / "ansible.cfg").read_text(encoding="utf-8"))
+    assert config["defaults"]["inventory"] == "ansible/inventories/home/hosts.yml"
+
+
+@pytest.mark.parametrize(
+    ("map_text", "unknown_key"),
+    [
+        ("contract_version: 1\ntypo: true\n", "typo"),
+        ("contract_version: 1\npaths:\n  unknown_path: elsewhere/hosts.yml\n", "unknown_path"),
+        ("contract_version: 1\nserverapps:\n  unknown_app: {}\n", "unknown_app"),
+        ("contract_version: 1\nserverapps:\n  caddy:\n    unknown_field: caddy.d\n", "unknown_field"),
+    ],
+)
+def test_unknown_site_map_key_exits_1_naming_key(
+    tmp_path: Path,
+    map_text: str,
+    unknown_key: str,
+) -> None:
+    map_file = tmp_path / "site-map.yml"
+    map_file.write_text(map_text, encoding="utf-8")
     code, _, stderr = _run_api(
         sitename="example",
         dir_path=str(tmp_path / "site-example"),
-        map_path=str(tmp_path / "site-map.yml"),
+        map_path=str(map_file),
         mode="dry-run",
     )
     assert code == si.EXIT_PRECONDITION
-    assert "site-map" in stderr.lower() or "c4" in stderr.lower() or "phase" in stderr.lower()
+    assert unknown_key in stderr
     assert not (tmp_path / "site-example").exists()
+
+
+def test_site_map_relative_escape_exits_1_without_writes(tmp_path: Path) -> None:
+    dest = tmp_path / "site-example"
+    map_file = tmp_path / "site-map.yml"
+    map_file.write_text("contract_version: 1\npaths:\n  inventory: ../outside.yml\n", encoding="utf-8")
+    code, _, stderr = _run_api(
+        sitename="example",
+        dir_path=str(dest),
+        map_path=str(map_file),
+        mode="apply",
+    )
+    assert code == si.EXIT_PRECONDITION
+    assert "escapes" in stderr
+    assert not dest.exists()
+
+
+def test_site_map_rejects_contract_path_inside_generated_area(tmp_path: Path) -> None:
+    dest = tmp_path / "site-example"
+    map_file = tmp_path / "site-map.yml"
+    map_file.write_text(
+        "contract_version: 1\npaths:\n  inventory: generated/stayturgid/hosts.yml\n",
+        encoding="utf-8",
+    )
+    code, _, stderr = _run_api(
+        sitename="example",
+        dir_path=str(dest),
+        map_path=str(map_file),
+        mode="apply",
+    )
+    assert code == si.EXIT_PRECONDITION
+    assert "generated/stayturgid" in stderr
+    assert not dest.exists()
+
+
+def test_valid_serverapp_map_is_validation_only_in_c4(tmp_path: Path) -> None:
+    dest = tmp_path / "site-example"
+    map_file = tmp_path / "site-map.yml"
+    map_file.write_text(
+        "contract_version: 1\n"
+        "serverapps:\n"
+        "  caddy:\n"
+        "    config: /opt/homebrew/etc/Caddyfile\n"
+        "    fragment_dir: /opt/homebrew/etc/caddy.d\n"
+        "    mode: inject\n",
+        encoding="utf-8",
+    )
+    before = _snapshot(tmp_path)
+    code, stdout, stderr = _run_api(
+        sitename="example",
+        dir_path=str(dest),
+        map_path=str(map_file),
+        mode="dry-run",
+    )
+    assert code == si.EXIT_OK, stderr
+    assert "create" in stdout
+    assert _snapshot(tmp_path) == before
+    assert not dest.exists()
+
+
+def test_invalid_serverapp_mode_exits_1(tmp_path: Path) -> None:
+    map_file = tmp_path / "site-map.yml"
+    map_file.write_text(
+        "contract_version: 1\nserverapps:\n  caddy:\n    mode: typo\n",
+        encoding="utf-8",
+    )
+    code, _, stderr = _run_api(
+        sitename="example",
+        dir_path=str(tmp_path / "site-example"),
+        map_path=str(map_file),
+        mode="dry-run",
+    )
+    assert code == si.EXIT_PRECONDITION
+    assert "serverapps.caddy.mode" in stderr
 
 
 def test_invalid_mode_exits_1(tmp_path: Path) -> None:

--- a/tests/python/test_site_sync.py
+++ b/tests/python/test_site_sync.py
@@ -213,6 +213,50 @@ def test_apply_via_just_wrapper(tmp_path: Path) -> None:
     assert (dest / "generated/stayturgid/README.md").is_file()
 
 
+# --- Acceptance test 4: site-map remap ------------------------------------
+
+
+def test_site_map_remapped_inventory_used_and_default_never_written(tmp_path: Path) -> None:
+    dest = tmp_path / "site-mapped"
+    dest.mkdir()
+    (dest / "site-map.yml").write_text(
+        "contract_version: 1\npaths:\n  inventory: ansible/inventories/home/hosts.yml\n",
+        encoding="utf-8",
+    )
+    init_code = si.run_site_init(
+        sitename="mapped",
+        dir_path=str(dest),
+        mode="apply",
+        product_root=ROOT,
+        env={},
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+    )
+    assert init_code == si.EXIT_OK
+    mapped_inventory = dest / "ansible/inventories/home/hosts.yml"
+    assert mapped_inventory.is_file()
+    assert not (dest / "inventory").exists()
+
+    code, _, stderr = _run_api(dir_path=str(dest), mode="apply")
+    assert code == ss.EXIT_OK, stderr
+    generated = (dest / "generated/stayturgid/README.md").read_text(encoding="utf-8")
+    assert "ansible/inventories/home/hosts.yml" in generated
+    assert not (dest / "inventory").exists()
+
+
+def test_sync_invalid_auto_discovered_map_exits_1_naming_unknown_key(tmp_path: Path) -> None:
+    dest = _init_site(tmp_path)
+    (dest / "site-map.yml").write_text(
+        "contract_version: 1\npaths:\n  unknown_path: inventory/hosts.yml\n",
+        encoding="utf-8",
+    )
+    before = _snapshot(dest)
+    code, _, stderr = _run_api(dir_path=str(dest), mode="apply")
+    assert code == ss.EXIT_PRECONDITION
+    assert "unknown_path" in stderr
+    assert _snapshot(dest) == before
+
+
 # --- Acceptance test 3: hand-edit → exit 2; force-generated recovers -------
 
 


### PR DESCRIPTION
## Summary

- add fail-closed Site Contract v1 `site-map.yml` loading and validation
- remap C4 contract paths used by `site-init` and `site-sync`
- validate forward-compatible serverapp mappings without implementing adapters or inject writes
- preserve generated-area ownership, drift detection, exit codes, and no-map defaults

## Verification

- `61 passed` — C1-C4 focused pytest suite
- registry seed stale-output check passed
- `STAYTURGID_SITE_DIR=<active-overlay> just check` passed
- `STAYTURGID_SITE_DIR=<active-overlay> just test` passed
- strict overlay identity: zero drift, no secret-shaped strings
- strict upstream-example identity: zero drift, no secret-shaped strings
- relevant pre-commit hooks passed
- `git diff --check` passed
- public-diff safety scan found no operator paths, production ranges, or credential literals
- hosted CI passed all `check`, `test`, `lint`, and justfile-format stages

`just lint` completed all C4-relevant hooks but the aggregate recipe remained nonzero because this local checkout lacks the `ansible.posix` collection needed by the pre-existing consumer-full-fleet syntax check. Per task constraints, no collection was installed; hosted CI installs declared collections and is the authoritative full lint result.

## Human verification gate

- [ ] `site-map.yml` / `map=` accepted; unknown keys fail closed (exit 1)
- [ ] remapped inventory used; default inventory location not written
- [ ] no map preserves C1-C3 default behavior
- [ ] dry-run/docs make no writes; docs remain generic-only
- [ ] C3 drift / force-generated / lockfile semantics remain green
- [ ] no production identity or secrets in the public diff
- [ ] focused tests, `just check`, strict identities, pre-commit, and hosted CI pass
- [ ] approve merge after reviewing this checklist

Merge is intentionally held for human confirmation per the relay protocol.
