### PR TITLE
feat(site-contract): Entangled SITE-CONTRACT.md + parity check (C5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ node_modules/
 .ansible/modules/
 .ansible/.lock
 
+# Entangled file database / tmp (regenerable; parity uses SITE-CONTRACT.md API check)
+.entangled/
+
 # Site inventory is private. CI creates this ignored file from the example.
 ansible/inventory/hosts.yml
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,25 @@ repos:
         language: system
         files: '\.md(\.example)?$'
 
+  - repo: local
+    hooks:
+      - id: site-contract-check
+        name: site-contract Entangled + registry seeds
+        entry: bash
+        args:
+          - -c
+          - |
+            if [[ -x .venv-test/bin/python ]]; then
+              py=.venv-test/bin/python
+            else
+              py=python3
+            fi
+            "$py" -m control.site_contract.check_entangled &&
+              "$py" -m control.site_contract.generate_registry_seeds --check
+        language: system
+        pass_filenames: false
+        files: '^(SITE-CONTRACT\.md|entangled\.toml|control/site_contract/)'
+
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.35.1
     hooks:

--- a/SITE-CONTRACT.md
+++ b/SITE-CONTRACT.md
@@ -1,0 +1,383 @@
+# Site Contract v1 — stayturgid
+
+This document is the **human-readable site contract** for the stayturgid
+product and the **Entangled** literate source for the site-init scaffold
+templates under `control/site_contract/templates/`.
+
+If you refuse automation, you can still stand up a private site overlay by
+following the layout and file contents below. If you accept automation,
+`just site-init` copies (and lightly renders) the same scaffold for you, and
+`just site-sync` later maintains only `generated/stayturgid/`.
+
+Companion specs: [docs/architecture/site-contract.md](docs/architecture/site-contract.md),
+[ADR 005](docs/architecture/adr/005-two-repo-topology.md),
+[multi-site-topology.md](docs/architecture/multi-site-topology.md) §4.
+
+## 1. Purpose
+
+The site contract is the interface between this **product** (public stayturgid
+repo) and one operator's **site** (private `site-<name>` directory/repo). It
+lets a user who knows nothing about Ansible bootstrap a working site layout,
+while letting an experienced user remap paths via optional `site-map.yml`.
+
+| Term           | Meaning                                                            |
+| -------------- | ------------------------------------------------------------------ |
+| product        | This public repo (roles, defaults, adapters, fragments, tooling)   |
+| site dir       | The operator's private directory (`site-<name>`)                   |
+| generated area | `generated/stayturgid/` inside the site dir; owned by `site-sync`  |
+| user area      | Everything else in the site dir; never resynced by product tooling |
+
+## 2. CLI (automation)
+
+From a product checkout:
+
+```text
+just site-init sitename=<name> [dir=<path>] [map=<site-map.yml>] [mode=apply|dry-run|docs]
+just site-sync [dir=<path>] [mode=apply|dry-run|docs] [force-generated=1]
+```
+
+- `mode=apply` (default): perform actions.
+- `mode=dry-run`: print the exact per-file action list; write nothing.
+- `mode=docs`: emit this document (self-contained, generic values only); write nothing.
+- Exit codes: `0` success/no-op; `1` precondition/input failure; `2` would overwrite
+  user content (`site-init`) or generated-area drift (`site-sync`).
+
+Default destination for `site-init` is `$OPS_ROOT/site-<name>` (`OPS_ROOT`
+defaults to `~/ops`). The destination must **never** nest inside the product
+working tree (ADR 005). Bare sitename matches `^[a-z][a-z0-9-]*$` (no `site-`
+prefix).
+
+`mode=docs` always uses generic example identity only (RFC 5737 documentation
+addresses, `example` sitename, example product path `/srv/products/stayturgid`).
+It never reads a live overlay, operator home, or production inventory.
+
+## 3. Site directory layout
+
+What `site-init` creates (Site Contract v1 §3):
+
+```text
+site-example/
+  README.md                  # generated once, then user-owned (never resynced)
+  ansible.cfg                # inventory here; roles/collections → product checkout
+  justfile                   # thin wrappers; OPS_ROOT / product path detection
+  .gitignore                 # secrets patterns; does not ignore generated/
+  inventory/
+    hosts.yml                # from product example; user edits
+    group_vars/
+  registry/
+    ports.yml                # product port defaults (generator-owned seeds)
+    paths.yml                # product path defaults (generator-owned seeds)
+  secretspec.toml            # secret *declarations* only (values in a provider)
+  generated/
+    stayturgid/              # site-sync owned; committed; never hand-edit
+  docs/                      # operator notes (user area)
+```
+
+Optional `site-map.yml` at the site root remaps contract path keys
+(`inventory`, `registry_ports`, `registry_paths`) and may declare
+`serverapps` for Phase D. Unknown keys fail closed.
+
+## 4. Manual equivalent of site-init
+
+1. Create `site-example/` as a sibling of the product checkout (not inside it).
+2. For each scaffold file below, write the destination path under the site dir
+   (strip the `control/site_contract/templates/` prefix and any `.j2` suffix).
+3. For `*.j2` files, substitute:
+   - `site_name` → bare site name (e.g. `example`)
+   - `product_root` / `stayturgid_root` → absolute path to the product checkout
+   - `site_dir` → absolute path to the site directory
+   - `inventory_path`, `registry_ports_path`, `registry_paths_path` → relative
+     paths (defaults: `inventory/hosts.yml`, `registry/ports.yml`,
+     `registry/paths.yml`), or values from `site-map.yml` when remapped
+4. Copy non-`.j2` files byte-for-byte (including empty-dir `.gitkeep` files).
+5. Install registry seeds from the product's checked-in
+   `control/site_contract/templates/registry/{ports,paths}.yml` (see §6).
+6. Edit inventory and registries for this site; provide secret values via a
+   secretspec provider; never commit secret values.
+
+After that, product upgrades use `site-sync` for `generated/stayturgid/` only.
+
+## 5. Literate scaffold sources (Entangled)
+
+Fenced blocks below tangle into `control/site_contract/templates/` via
+[Entangled](https://entangled.github.io/) (`annotation = "naked"` so tangled
+output has no extra comment markers). CI and `just site-contract-check` fail
+when this document and those files drift.
+
+**Scope discipline:** only this contract document is literate. Product roles,
+playbooks, adapters, and control scripts remain conventional code.
+
+**Registry exception:** `registry/ports.yml` and `registry/paths.yml` are
+**not** fenced here. Their values are derived programmatically from product
+role defaults (single authority). See §6.
+
+## 6. Registry seeds (generator-owned, not tangled)
+
+Port and path seed files under `control/site_contract/templates/registry/` are
+produced by:
+
+```text
+python3 -m control.site_contract.generate_registry_seeds
+python3 -m control.site_contract.generate_registry_seeds --check
+```
+
+`registry_sources.yml` holds selectors only (file paths + YAML/JSON/regex
+keys) — never port numbers or path literals. The generator resolves those
+selectors against product role defaults and writes the committed seeds. The
+`--check` mode fails closed if seeds are stale.
+
+This document deliberately does **not** copy those literals. Doing so would
+create a second authority and invite drift. `site-init` still installs the
+generator-produced files into the site's `registry/` directory.
+
+Checked-in paths:
+
+- `control/site_contract/templates/registry/ports.yml`
+- `control/site_contract/templates/registry/paths.yml`
+
+## 7. Scaffold file sources
+
+Each fenced block is the exact source for one template path. Destinations in a
+site dir drop the `control/site_contract/templates/` prefix and any trailing
+`.j2`.
+
+### `.gitignore` — Site .gitignore
+
+```{.gitignore file="control/site_contract/templates/.gitignore"}
+# Secret values and local credentials. Declarations remain committed.
+*.env
+*.pem
+*.key
+*.crt
+id_*
+
+# Local caches and editor state.
+.DS_Store
+.ansible/
+.claude/
+.pytest_cache/
+__pycache__/
+
+# generated/ is intentionally not ignored: site-sync output is reviewable and committed.
+```
+
+### `README.md.j2` — Site README (Jinja2; rendered once by site-init, then user-owned)
+
+```{.j2 file="control/site_contract/templates/README.md.j2"}
+# site-{{ site_name }}
+
+This is a private site overlay for the **stayturgid** product. It holds site
+inventory, allocation registries, secret declarations, and operator notes;
+secret values live in a provider and never in this repository.
+
+This README is generated once by `site-init`. After creation it is user-owned:
+product syncs never replace or modify it. Everything outside
+`generated/stayturgid/` is likewise user-owned unless a file explicitly says
+otherwise.
+
+## Layout
+
+- `{{ inventory_path }}` starts from the product's generic example. Replace all
+  RFC 5737 addresses, example aliases, and placeholder serials before deploy.
+- `{{ registry_ports_path }}` and `{{ registry_paths_path }}` contain product defaults to
+  reconcile with this site's actual allocations.
+- `secretspec.toml` declares the stayturgid secret profile without storing any
+  values.
+- `generated/stayturgid/` is committed, reviewable output owned by
+  `site-sync`; never hand-edit it.
+- `docs/` is available for operator-owned notes.
+
+## Product checkout
+
+The wrapper `justfile` locates the public product at
+`$STAYTURGID_ROOT`, or `$OPS_ROOT/stayturgid`, or
+`~/ops/stayturgid` in that order. The site and product must remain sibling
+checkouts; never nest this private repository inside the public product tree.
+
+Review `{{ inventory_path }}` and the two registries before running a deployment.
+Then use `just inventory-check`, `just deploy-check`, and `just deploy`.
+```
+
+### `ansible.cfg.j2` — ansible.cfg (Jinja2)
+
+```{.j2 file="control/site_contract/templates/ansible.cfg.j2"}
+[defaults]
+inventory = {{ inventory_path }}
+roles_path = {{ product_root }}/ansible/roles
+# Product collections are supplied by the stayturgid checkout rendered above.
+collections_path = {{ product_root }}/.ansible/collections:{{ product_root }}
+host_key_checking = False
+retry_files_enabled = False
+interpreter_python = auto_silent
+
+[ssh_connection]
+pipelining = True
+```
+
+### `justfile.j2` — Site justfile wrappers (Jinja2; {% raw %} protects just syntax)
+
+```{.j2 file="control/site_contract/templates/justfile.j2"}
+# site-{{ site_name }} — thin wrappers for the stayturgid product.
+
+{% raw %}
+set shell := ["bash", "-uc"]
+
+ops_root := env_var_or_default("OPS_ROOT", home_directory() / "ops")
+stayturgid_root := env_var_or_default("STAYTURGID_ROOT", ops_root / "stayturgid")
+site_dir := justfile_directory()
+hosts := env_var_or_default("hosts", "")
+
+_product recipe:
+    @test -f "{{ stayturgid_root }}/justfile" || { echo "stayturgid checkout not found at {{ stayturgid_root }}; set STAYTURGID_ROOT or OPS_ROOT" >&2; exit 1; }
+    ANSIBLE_CONFIG="${ANSIBLE_CONFIG:-{{ site_dir }}/ansible.cfg}" STAYTURGID_SITE_DIR="{{ site_dir }}" hosts="{{ hosts }}" just --justfile "{{ stayturgid_root }}/justfile" {{ recipe }}
+
+deploy:
+    @just _product deploy
+
+deploy-check:
+    @just _product deploy-check
+
+verify:
+    @just _product verify
+
+verify-drift:
+    @just _product verify-drift
+
+inventory-check:
+    ANSIBLE_CONFIG="${ANSIBLE_CONFIG:-{{ site_dir }}/ansible.cfg}" ansible-inventory --list
+{% endraw %}
+```
+
+### `secretspec.toml.j2` — secretspec.toml declarations (Jinja2; values never stored here)
+
+```{.j2 file="control/site_contract/templates/secretspec.toml.j2"}
+[project]
+name = "site-{{ site_name }}"
+revision = "1.0"
+
+# The site's default profile declares stayturgid's secret inputs. Values live in a secretspec
+# provider, never in this repository or generated/stayturgid/.
+[profiles.default]
+TELEGRAM_BOT_TOKEN = { description = "Telegram bot token for Hermes agent notifications", required = true }
+TELEGRAM_ALLOWED_USERS = { description = "Comma-separated Telegram user IDs allowed to interact with Hermes", required = false }
+TELEGRAM_HOME_CHANNEL = { description = "Telegram channel ID for Hermes notifications", required = false }
+GEMINI_API_KEY = { description = "Google Gemini API key for optional VLM cloud checks", required = false }
+ANTHROPIC_API_KEY = { description = "Anthropic API key for optional VLM cloud checks", required = false }
+GPLAY_EMAIL = { description = "Google account email for Play Store APK downloads", required = false }
+GPLAY_AAS_TOKEN = { description = "Google Play AAS token for apkeep downloads", required = false }
+GPLAY_AUTH_TOKEN = { description = "Google Play auth token for gplaycli", required = false }
+FIRERPA_API_KEY = { description = "FIRERPA gRPC API key", required = false }
+FIRERPA_CERTIFICATE = { description = "Path to the FIRERPA service certificate and private key PEM", required = false, default = "~/.config/stayturgid/firerpa.pem" }
+GITHUB_TOKEN = { description = "GitHub personal access token for gh CLI auth", required = false }
+ANSIBLE_GALAXY_TOKEN = { description = "Ansible Galaxy API token", required = false }
+OPENCODE_ZEN_API_KEY = { description = "OpenCode Zen API key for the Hermes provider", required = false }
+SSH_TERMUX_KEY = { description = "Path to the Termux SSH private key", required = false, default = "~/.ssh/termux_key" }
+SSH_CA_KEY = { description = "Path to the SSH CA private key", required = false, default = "~/.ssh/stayturgid_ca" }
+FLEET_ADBKEY = { description = "Path to the fleet ADB private key", required = false, default = "~/.config/stayturgid/adbkey" }
+DEBUG_KEYSTORE = { description = "Path to the Android debug keystore", required = false, default = "~/.android/debug.keystore" }
+DEBUG_KEYSTORE_PASS = { description = "Android debug keystore password", required = false, default = "android" }
+HANDSETS_JAR = { description = "Path to the Handsets jar", required = false, default = "~/.handsets/hs.jar" }
+OPENOBSERVE_ROOT_PASSWORD = { description = "Administrator password for OpenObserve", required = false }
+VECTOR_INGESTION_TOKEN = { description = "Bearer token for Vector ingestion", required = false }
+```
+
+### `inventory/hosts.yml` — Example inventory (RFC 5737 / §4.1 generic names)
+
+```{.yaml file="control/site_contract/templates/inventory/hosts.yml"}
+---
+# Generic example inventory copied from stayturgid/ansible/inventory/hosts.yml.example.
+# Replace every placeholder with this site's values before deploying.
+all:
+  children:
+    stayturgid:
+      hosts:
+        oneui-device:
+          ansible_host: 100.0.0.11
+          device_usb_serial: EXAMPLE-SERIAL-ONEUI
+          device_lan_ip: 192.0.2.11
+          device_label: Example One UI phone
+        stock-android-device:
+          ansible_host: 100.0.0.12
+          device_usb_serial: EXAMPLE-SERIAL-STOCK
+          device_lan_ip: 192.0.2.12
+          device_label: Example stock Android phone
+        fireos-device:
+          ansible_host: 100.0.0.13
+          device_usb_serial: EXAMPLE-SERIAL-FIRE
+          device_lan_ip: 192.0.2.13
+          device_label: Example Fire OS tablet
+      vars:
+        ansible_port: 8022
+        ansible_user: termux
+        ansible_python_interpreter: /data/data/com.termux/files/usr/bin/python
+        ansible_ssh_private_key_file: "{{ lookup('env', 'HOME') }}/.ssh/termux_key"
+        stayturgid_device_id: "{{ inventory_hostname }}"
+        stayturgid_automation_mode: autojs6
+        stayturgid_control_ssh_user: operator
+        stayturgid_mac_peer:
+          user: operator
+          lan: 192.0.2.1
+          tailscale: 100.0.0.1
+        stayturgid_hermes_telegram_allowed_users: ""
+        stayturgid_hermes_telegram_home_channel: ""
+
+    android_16:
+      hosts: { oneui-device: {}, stock-android-device: {} }
+    android_11:
+      hosts: { fireos-device: {} }
+    vendor_samsung:
+      hosts: { oneui-device: {} }
+    vendor_google:
+      hosts: { stock-android-device: {} }
+    vendor_amazon:
+      hosts: { fireos-device: {} }
+    oneui_7:
+      hosts: { oneui-device: {} }
+    model_galaxy_s24:
+      hosts: { oneui-device: {} }
+    model_pixel_7a:
+      hosts: { stock-android-device: {} }
+    model_kindle_hd8:
+      hosts: { fireos-device: {} }
+```
+
+### `inventory/group_vars/.gitkeep` — Placeholder so empty group_vars/ is tracked
+
+```{.gitkeep file="control/site_contract/templates/inventory/group_vars/.gitkeep"}
+
+```
+
+### `docs/.gitkeep` — Placeholder so empty docs/ is tracked
+
+```{.gitkeep file="control/site_contract/templates/docs/.gitkeep"}
+
+```
+
+### `generated/stayturgid/.gitkeep` — Placeholder so empty generated/stayturgid/ is tracked
+
+```{.gitkeep file="control/site_contract/templates/generated/stayturgid/.gitkeep"}
+
+```
+
+## 8. After initialization
+
+1. Edit `inventory/hosts.yml`: replace example aliases, RFC 5737 addresses
+   (`192.0.2.0/24`, `100.0.0.0/24` documentation ranges), and placeholder
+   serials with this site's values.
+2. Reconcile `registry/ports.yml` and `registry/paths.yml` with local
+   allocations (site inventory remains authoritative for the live site).
+3. Provide secret _values_ via a secretspec provider (never commit them).
+4. Point product tooling at the site via `STAYTURGID_SITE_DIR` or
+   `ANSIBLE_CONFIG`, or place the site as the sole `site-*` checkout under
+   `$OPS_ROOT`.
+5. Later product upgrades: `just site-sync` for `generated/stayturgid/` only.
+
+## 9. Invariants
+
+- Everything outside `generated/stayturgid/` is user-owned after creation.
+- `site-init` never overwrites a differing user file (exit 2).
+- A second identical `apply` is a no-op (all files `skip`).
+- Private site data must never nest inside the public product working tree.
+- This document and the literate templates must stay in lockstep
+  (`just site-contract-check` / Entangled parity).
+- Registry seed values stay source-driven via `generate_registry_seeds`.

--- a/control/site_contract/README.md
+++ b/control/site_contract/README.md
@@ -3,14 +3,23 @@
 This directory implements Phase C of the site contract in
 `docs/architecture/site-contract.md`.
 
+- Product-root `SITE-CONTRACT.md` is the human-readable contract and Entangled
+  literate source for the non-registry C1 scaffold templates (spec §7).
+- `entangled.toml` (product root) configures naked-annotation tangling for that
+  document only. Product roles/adapters are **not** literate.
+- `check_entangled.py` fails closed when the document and literate templates
+  drift (`just site-contract-check`).
 - `templates/` mirrors the files `site-init` creates. Files ending in `.j2` are
-  Jinja2 templates; other files are copied without rendering.
+  Jinja2 templates; other files are copied without rendering. Literate
+  templates must match `SITE-CONTRACT.md` fenced blocks exactly.
 - `registry_sources.yml` maps product-owned claims to their authoritative role
   defaults or other checked-in product declarations. It deliberately contains
   no port numbers or path literals.
 - `generate_registry_seeds.py` resolves that source map and writes the
-  committed `templates/registry/{ports,paths}.yml` seeds.
-- `site_init.py` is the `site-init` CLI (apply / dry-run / docs).
+  committed `templates/registry/{ports,paths}.yml` seeds (single authority —
+  those two files are intentionally **not** Entangled targets).
+- `site_init.py` is the `site-init` CLI (apply / dry-run / docs). `mode=docs`
+  emits `SITE-CONTRACT.md` (generic-only, write-free).
 - `site_map.py` loads and fail-closed validates optional Site Contract v1
   `site-map.yml` files for `site-init` and `site-sync`.
 - `sync_manifest.yml` is the product sync manifest (files under
@@ -32,7 +41,8 @@ python3 -m control.site_contract.site_init --sitename <name> [--dir <path>] [--m
 - `mode=apply` (default): create the §3 scaffold; never overwrite differing
   user-owned files (exit 2); identical re-apply is a no-op.
 - `mode=dry-run`: print per-file `create` / `skip` / `overwrite` actions; no writes.
-- `mode=docs`: emit self-contained Markdown with generic example values only.
+- `mode=docs`: emit product-root `SITE-CONTRACT.md` (generic example values
+  only; no writes; no live-site identity).
 - Exit codes: `0` success/no-op; `1` precondition/input failure; `2` would overwrite.
 - `map=` loads an explicit Site Contract v1 map; otherwise a map at
   `<site-dir>/site-map.yml` is auto-discovered. Supported C4 path keys are
@@ -79,4 +89,20 @@ python3 -m control.site_contract.generate_registry_seeds --check
 ```
 
 The focused tests compare generated output with the committed seeds, so a
-changed default cannot silently leave a stale site scaffold.
+changed default cannot silently leave a stale site scaffold. Registry seeds
+are not fenced in `SITE-CONTRACT.md` (single authority).
+
+## Entangled parity (literate templates)
+
+```bash
+# Full check (Entangled parity + registry seed freshness):
+just site-contract-check
+# or:
+python3 -m control.site_contract.check_entangled
+# Tangle after editing SITE-CONTRACT.md fenced blocks:
+entangled tangle --force
+```
+
+`annotation = "naked"` keeps tangled bytes identical to the fenced sources.
+Entangled's local `.entangled/` state is gitignored; the parity check uses the
+API and does not require a committed filedb.

--- a/control/site_contract/check_entangled.py
+++ b/control/site_contract/check_entangled.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Fail closed when SITE-CONTRACT.md and literate C1 templates drift.
+
+Entangled 2.x has no ``tangle --check`` exit code that compares disk to the
+document (``entangled tangle`` exits 0 even on conflicts). This module is the
+project's equivalent: load ``SITE-CONTRACT.md`` via the Entangled API, compute
+expected naked-annotation content for every ``file=`` target, and compare
+byte-for-byte with the checked-in templates.
+
+Registry seeds under ``templates/registry/`` are intentionally *not* literate
+(single authority: ``generate_registry_seeds``). They must still exist on disk
+and are listed as known non-literate scaffold members.
+
+Exit codes:
+    0  document and literate templates match; scaffold inventory complete
+    1  drift, missing files, unexpected files, or Entangled unavailable
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_DIR = Path(__file__).resolve().parent
+TEMPLATE_DIR = CONTRACT_DIR / "templates"
+SITE_CONTRACT_MD = REPO_ROOT / "SITE-CONTRACT.md"
+ENTANGLED_TOML = REPO_ROOT / "entangled.toml"
+
+# Generator-owned; must exist but are not Entangled targets.
+REGISTRY_SEED_RELATIVE = frozenset(
+    {
+        "registry/ports.yml",
+        "registry/paths.yml",
+    }
+)
+
+TEMPLATE_PREFIX = "control/site_contract/templates/"
+
+
+class EntangledCheckError(Exception):
+    """Parity or inventory failure."""
+
+
+def _require_entangled():
+    try:
+        from entangled.config import AnnotationMethod  # noqa: F401
+        from entangled.interface import Context, Document  # noqa: F401
+        from entangled.io import TransactionMode, transaction  # noqa: F401
+        from entangled.io.virtual import FileCache  # noqa: F401
+    except ModuleNotFoundError as exc:  # pragma: no cover - env-dependent
+        raise EntangledCheckError(
+            "entangled-cli is required for site-contract parity "
+            "(install via tests/python/requirements.txt / just test-venv)"
+        ) from exc
+
+
+def _all_template_files() -> dict[str, Path]:
+    if not TEMPLATE_DIR.is_dir():
+        raise EntangledCheckError(f"template directory missing: {TEMPLATE_DIR}")
+    files = {path.relative_to(TEMPLATE_DIR).as_posix(): path for path in TEMPLATE_DIR.rglob("*") if path.is_file()}
+    if not files:
+        raise EntangledCheckError(f"no template files under {TEMPLATE_DIR}")
+    return files
+
+
+def expected_literate_contents(*, repo_root: Path | None = None) -> dict[str, str]:
+    """Return relative template path → expected text from SITE-CONTRACT.md."""
+    _require_entangled()
+    from entangled.config import AnnotationMethod
+    from entangled.interface import Context, Document
+    from entangled.io import TransactionMode, transaction
+    from entangled.io.virtual import FileCache
+
+    root = (repo_root or REPO_ROOT).resolve()
+    site_contract = root / "SITE-CONTRACT.md"
+    if not site_contract.is_file():
+        raise EntangledCheckError(f"missing literate source: {site_contract}")
+    if not (root / "entangled.toml").is_file():
+        raise EntangledCheckError(f"missing Entangled config: {root / 'entangled.toml'}")
+
+    # Entangled resolves config and paths relative to the process cwd.
+    # Callers must chdir to repo root (main and tests do).
+    fs = FileCache()
+    doc = Document(context=Context(fs=fs))
+    with transaction(TransactionMode.SHOW, fs=fs) as txn:
+        doc.load(txn)
+        targets = list(doc.reference_map.targets())
+        if not targets:
+            raise EntangledCheckError(f"{site_contract.name} defines no Entangled file= targets")
+        expected: dict[str, str] = {}
+        for target in targets:
+            path = Path(target)
+            text, _deps = doc.target_text(path)
+            # Match Entangled's on-disk write normalization (final newline).
+            if text and not text.endswith("\n"):
+                text = text + "\n"
+            elif text == "":
+                # Empty fence bodies crash Entangled on write; treat as invalid.
+                raise EntangledCheckError(f"Entangled target {path} has empty content")
+            rel = _to_template_relative(path)
+            if rel in expected:
+                raise EntangledCheckError(f"duplicate Entangled target for {rel}")
+            expected[rel] = text
+        # AnnotationMethod imported to document naked requirement in config.
+        _ = AnnotationMethod.NAKED
+        return expected
+
+
+def _to_template_relative(path: Path) -> str:
+    posix = path.as_posix()
+    if posix.startswith(TEMPLATE_PREFIX):
+        return posix[len(TEMPLATE_PREFIX) :]
+    # Allow targets written relative to templates/ only if misconfigured.
+    if posix.startswith("templates/"):
+        return posix[len("templates/") :]
+    raise EntangledCheckError(
+        f"Entangled target {posix!r} is outside {TEMPLATE_PREFIX} (site-contract literate scope is templates only)"
+    )
+
+
+def check_parity(*, repo_root: Path | None = None) -> list[str]:
+    """Return a list of human-readable problems (empty means OK)."""
+    root = (repo_root or REPO_ROOT).resolve()
+    problems: list[str] = []
+
+    if not (root / "SITE-CONTRACT.md").is_file():
+        return [f"missing {root / 'SITE-CONTRACT.md'}"]
+    if not (root / "entangled.toml").is_file():
+        return [f"missing {root / 'entangled.toml'}"]
+
+    try:
+        expected = expected_literate_contents(repo_root=root)
+    except EntangledCheckError as exc:
+        return [str(exc)]
+
+    template_root = root / "control" / "site_contract" / "templates"
+    on_disk = {path.relative_to(template_root).as_posix(): path for path in template_root.rglob("*") if path.is_file()}
+
+    # Every literate target must match on disk exactly.
+    for rel, text in sorted(expected.items()):
+        path = template_root / rel
+        if rel not in on_disk:
+            problems.append(f"missing tangled template: {rel}")
+            continue
+        actual = path.read_text(encoding="utf-8")
+        if actual != text:
+            problems.append(f"drift: {rel} (SITE-CONTRACT.md vs templates/)")
+
+    # Scaffold inventory: every on-disk template is literate or a registry seed.
+    for rel in sorted(on_disk):
+        if rel in expected:
+            continue
+        if rel in REGISTRY_SEED_RELATIVE:
+            continue
+        problems.append(f"unexpected non-literate template (not in SITE-CONTRACT.md and not a registry seed): {rel}")
+
+    # Registry seeds must still be present (site-init depends on them).
+    for rel in sorted(REGISTRY_SEED_RELATIVE):
+        if rel not in on_disk:
+            problems.append(f"missing generator-owned registry seed: {rel}")
+
+    # No Entangled target may claim a registry seed path (would dual-own).
+    for rel in sorted(expected):
+        if rel in REGISTRY_SEED_RELATIVE:
+            problems.append(
+                f"registry seed {rel} must not be an Entangled target (single authority: generate_registry_seeds)"
+            )
+
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args(argv)
+
+    # Entangled loads entangled.toml from cwd.
+    import os
+
+    os.chdir(REPO_ROOT)
+    try:
+        problems = check_parity(repo_root=REPO_ROOT)
+    except EntangledCheckError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if problems:
+        print("error: site-contract Entangled parity failed:", file=sys.stderr)
+        for item in problems:
+            print(f"  - {item}", file=sys.stderr)
+        print(
+            "hint: edit SITE-CONTRACT.md then `entangled tangle --force`, "
+            "or restore templates from the document; registry seeds use "
+            "`python -m control.site_contract.generate_registry_seeds`",
+            file=sys.stderr,
+        )
+        return 1
+
+    literate = len(expected_literate_contents(repo_root=REPO_ROOT))
+    print(
+        f"site-contract Entangled parity OK "
+        f"({literate} literate templates; {len(REGISTRY_SEED_RELATIVE)} registry seeds generator-owned)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/control/site_contract/check_entangled.py
+++ b/control/site_contract/check_entangled.py
@@ -46,7 +46,7 @@ class EntangledCheckError(Exception):
 def _require_entangled():
     try:
         from entangled.config import AnnotationMethod  # noqa: F401
-        from entangled.interface import Context, Document  # noqa: F401
+        from entangled.interface import Document  # noqa: F401
         from entangled.io import TransactionMode, transaction  # noqa: F401
         from entangled.io.virtual import FileCache  # noqa: F401
     except ModuleNotFoundError as exc:  # pragma: no cover - env-dependent
@@ -56,20 +56,11 @@ def _require_entangled():
         ) from exc
 
 
-def _all_template_files() -> dict[str, Path]:
-    if not TEMPLATE_DIR.is_dir():
-        raise EntangledCheckError(f"template directory missing: {TEMPLATE_DIR}")
-    files = {path.relative_to(TEMPLATE_DIR).as_posix(): path for path in TEMPLATE_DIR.rglob("*") if path.is_file()}
-    if not files:
-        raise EntangledCheckError(f"no template files under {TEMPLATE_DIR}")
-    return files
-
-
 def expected_literate_contents(*, repo_root: Path | None = None) -> dict[str, str]:
     """Return relative template path → expected text from SITE-CONTRACT.md."""
     _require_entangled()
     from entangled.config import AnnotationMethod
-    from entangled.interface import Context, Document
+    from entangled.interface import Document
     from entangled.io import TransactionMode, transaction
     from entangled.io.virtual import FileCache
 
@@ -82,8 +73,10 @@ def expected_literate_contents(*, repo_root: Path | None = None) -> dict[str, st
 
     # Entangled resolves config and paths relative to the process cwd.
     # Callers must chdir to repo root (main and tests do).
+    # Construct Document() without injecting FileCache into Context so the check
+    # works on entangled-cli 2.4.0 (Python 3.12 CI) and newer 2.4.x APIs.
     fs = FileCache()
-    doc = Document(context=Context(fs=fs))
+    doc = Document()
     with transaction(TransactionMode.SHOW, fs=fs) as txn:
         doc.load(txn)
         targets = list(doc.reference_map.targets())
@@ -103,7 +96,7 @@ def expected_literate_contents(*, repo_root: Path | None = None) -> dict[str, st
             if rel in expected:
                 raise EntangledCheckError(f"duplicate Entangled target for {rel}")
             expected[rel] = text
-        # AnnotationMethod imported to document naked requirement in config.
+        # AnnotationMethod documents the naked requirement in entangled.toml.
         _ = AnnotationMethod.NAKED
         return expected
 

--- a/control/site_contract/site_init.py
+++ b/control/site_contract/site_init.py
@@ -292,7 +292,24 @@ def apply_plan(plan: InitPlan) -> None:
 
 
 def _docs_markdown() -> str:
-    """Self-contained Markdown for mode=docs (generic values only)."""
+    """Self-contained Markdown for mode=docs (generic values only).
+
+    Site Contract v1 §2 + §7: with the Entangled layout, mode=docs is a render
+    of product-root ``SITE-CONTRACT.md``. The checked-in document already uses
+    only generic/example identity (RFC 5737, ``example`` sitename). This path
+    never reads the live site overlay, operator home, or production inventory,
+    and writes nothing.
+    """
+    site_contract = REPO_ROOT / "SITE-CONTRACT.md"
+    if not site_contract.is_file():
+        raise SiteInitError(
+            f"SITE-CONTRACT.md missing at {site_contract}; required for mode=docs "
+            "(Site Contract v1 §7 Entangled layout)"
+        )
+
+    # Still validate that every scaffold template renders under the fixed
+    # generic docs context (StrictUndefined) so docs mode cannot mask broken
+    # Jinja templates.
     docs_site_dir = Path(_DOCS_SITE_DIR)
     docs_site_map = load_site_map(
         site_dir=docs_site_dir,
@@ -304,109 +321,13 @@ def _docs_markdown() -> str:
         site_dir=docs_site_dir,
         site_map=docs_site_map,
     )
-    rows: list[tuple[str, str, str]] = []
     for template_path in _template_files():
-        relative = _destination_relative(template_path)
-        if template_path.name.endswith(".j2"):
-            kind = "Jinja2 render"
-            note = (
-                f"Render `{template_path.relative_to(CONTRACT_DIR).as_posix()}` with "
-                f"`site_name={_DOCS_SITE_NAME!r}`, `product_root={_DOCS_PRODUCT_ROOT!r}`, "
-                f"`stayturgid_root={_DOCS_PRODUCT_ROOT!r}`, `site_dir={_DOCS_SITE_DIR!r}`."
-            )
-            # Ensure templates still render under docs context (StrictUndefined).
-            _load_payload(template_path, context)
-        else:
-            kind = "byte-for-byte copy"
-            note = f"Copy `{template_path.relative_to(CONTRACT_DIR).as_posix()}` unchanged to `{relative}`."
-        rows.append((relative, kind, note))
+        _load_payload(template_path, context)
 
-    lines = [
-        "# site-init — manual equivalent (Site Contract v1)",
-        "",
-        "This document is produced by `just site-init mode=docs`. It describes every",
-        "filesystem step `site-init` performs so an operator can reproduce the scaffold",
-        "by hand. Values below are **generic only** (RFC 5737 / example inventory names);",
-        "they are not taken from any private site overlay.",
-        "",
-        "## Preconditions",
-        "",
-        f"1. Public product checkout available (example path: `{_DOCS_PRODUCT_ROOT}`).",
-        "2. Destination site directory does not nest inside the product tree (ADR 005).",
-        f"3. Default destination is `$OPS_ROOT/site-<name>` (example: `{_DOCS_SITE_DIR}`).",
-        "4. Bare sitename matches `^[a-z][a-z0-9-]*$` (no `site-` prefix).",
-        "5. Existing destination files with **different** content block initialization",
-        "   (exit code 2); identical content is skipped (idempotent no-op).",
-        "",
-        "## CLI",
-        "",
-        "```text",
-        "just site-init sitename=<name> [dir=<path>] [map=<site-map.yml>] [mode=apply|dry-run|docs]",
-        "```",
-        "",
-        "- `mode=apply` (default): create missing files; never overwrite user content.",
-        "- `mode=dry-run`: print per-file `create` / `skip` / `overwrite` actions; no writes.",
-        "- `mode=docs`: emit this document; no writes.",
-        "- Exit codes: `0` success/no-op; `1` bad input/precondition; `2` would overwrite.",
-        "- `map=` loads an explicit Site Contract v1 map; otherwise `<site-dir>/site-map.yml`",
-        "  is auto-discovered before defaults are selected.",
-        "- Map keys fail closed. C4 path keys are `inventory`, `registry_ports`, and",
-        "  `registry_paths`; relative values resolve from the site directory and may not escape it.",
-        f"- Contract paths may not enter site-sync's owned `generated/{PRODUCT}/` area.",
-        "- `serverapps` entries are validated for Phase D but do not cause adapter writes in C4.",
-        "",
-        "## Scaffold layout",
-        "",
-        "```text",
-        f"site-{_DOCS_SITE_NAME}/",
-        "  README.md",
-        "  ansible.cfg",
-        "  justfile",
-        "  .gitignore",
-        "  inventory/",
-        "    hosts.yml          # product example inventory (RFC 5737 / §4.1 names)",
-        "    group_vars/",
-        "  registry/",
-        "    ports.yml          # product port defaults (derived seeds)",
-        "    paths.yml          # product path defaults (derived seeds)",
-        "  secretspec.toml",
-        f"  generated/{PRODUCT}/",
-        "  docs/",
-        "```",
-        "",
-        "## Per-file steps",
-        "",
-        "| Destination | Action | Manual equivalent |",
-        "| --- | --- | --- |",
-    ]
-    for relative, kind, note in rows:
-        safe_note = note.replace("|", "\\|")
-        lines.append(f"| `{relative}` | {kind} | {safe_note} |")
-
-    lines.extend(
-        [
-            "",
-            "## After initialization",
-            "",
-            "1. Edit `inventory/hosts.yml`: replace example aliases, RFC 5737 addresses,",
-            "   and placeholder serials with this site's values.",
-            "2. Reconcile `registry/ports.yml` and `registry/paths.yml` with local allocations.",
-            "3. Provide secret *values* via a secretspec provider (never commit them).",
-            "4. Point product tooling at the site via `STAYTURGID_SITE_DIR` or `ANSIBLE_CONFIG`,",
-            "   or place the site as the sole `site-*` checkout under `$OPS_ROOT`.",
-            "5. Later product upgrades use `site-sync` (Phase C3) for `generated/<product>/` only.",
-            "",
-            "## Invariants",
-            "",
-            f"- Everything outside `generated/{PRODUCT}/` is user-owned after creation.",
-            "- A site map redirects only declared contract files; unmapped files keep defaults.",
-            "- `site-init` never overwrites a differing user file.",
-            "- A second identical `apply` is a no-op (all files `skip`).",
-            "- Private site data must never nest inside the public product working tree.",
-            "",
-        ]
-    )
-    return "\n".join(lines)
+    text = site_contract.read_text(encoding="utf-8")
+    if not text.endswith("\n"):
+        text += "\n"
+    return text
 
 
 def _parse_mode(value: str) -> Mode:

--- a/entangled.toml
+++ b/entangled.toml
@@ -1,0 +1,60 @@
+# Entangled configuration for Site Contract v1 literate layout.
+# See SITE-CONTRACT.md and docs/architecture/site-contract.md §7.
+#
+# Scope: only SITE-CONTRACT.md is literate. Product roles/adapters stay
+# conventional. Registry seeds stay generator-owned (single authority).
+
+version = "2.0"
+watch_list = ["SITE-CONTRACT.md"]
+# Ignore every other Markdown path so product docs/history never tangle.
+ignore_list = [
+  "README.md",
+  "**/README.md",
+  "docs/**",
+  "human/**",
+  "examples/**",
+  "control/**",
+  "ansible/**",
+  "tests/**",
+  "device/**",
+]
+# Naked: tangled scaffold bytes match the fenced sources exactly (no ~~ markers).
+annotation = "naked"
+# Disable default shebang hook; scaffold files are not executables.
+hooks = ["~shebang"]
+
+# Language ids used in SITE-CONTRACT.md fence headers (.gitignore, .j2, …).
+[[languages]]
+name = "Gitignore"
+identifiers = ["gitignore"]
+comment = { open = "#" }
+
+[[languages]]
+name = "Gitkeep"
+identifiers = ["gitkeep"]
+comment = { open = "#" }
+
+[[languages]]
+name = "Jinja"
+identifiers = ["j2", "jinja", "jinja2"]
+comment = { open = "#" }
+
+[[languages]]
+name = "YAML"
+identifiers = ["yaml", "yml"]
+comment = { open = "#" }
+
+[[languages]]
+name = "TOML"
+identifiers = ["toml"]
+comment = { open = "#" }
+
+[[languages]]
+name = "Text"
+identifiers = ["text"]
+comment = { open = "#" }
+
+[[languages]]
+name = "Just"
+identifiers = ["just", "justfile"]
+comment = { open = "#" }

--- a/just/site.just
+++ b/just/site.just
@@ -3,10 +3,27 @@
 # Usage:
 #   just site-init sitename=<name> [dir=<path>] [map=<site-map.yml>] [mode=apply|dry-run|docs]
 #   just site-sync [dir=<path>] [mode=apply|dry-run|docs] [force-generated=1]
+#   just site-contract-check
 #
 # Recipes are thin wrappers: named KEY=VALUE tokens are forwarded to the
 # Python entry points. mode defaults to apply inside Python when omitted.
 # Prefers the project test venv (has Jinja2/PyYAML via ansible-core) when present.
+
+# Fail closed if SITE-CONTRACT.md and literate C1 templates drift (Entangled parity)
+# or if generator-owned registry seeds are stale.
+site-contract-check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cd "{{ repo }}"
+    if [[ -n "${SITE_INIT_PYTHON:-}" ]]; then
+      py="${SITE_INIT_PYTHON}"
+    elif [[ -x "{{ repo }}/.venv-test/bin/python" ]]; then
+      py="{{ repo }}/.venv-test/bin/python"
+    else
+      py="python3"
+    fi
+    "$py" -m control.site_contract.check_entangled
+    "$py" -m control.site_contract.generate_registry_seeds --check
 
 # Initialize a private site overlay (apply | dry-run | docs).
 site-init *args:

--- a/just/tests.just
+++ b/just/tests.just
@@ -10,6 +10,7 @@ configure:
 # Code-only syntax / import checks + ruff + typos + biome + shfmt + justfiles + markdown.
 check:
     bash tests/run.sh code
+    @just site-contract-check
     @just ruff
     @just typos
     @just biome

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
   "pytest>=7",
   "pytest-mock>=3",
   "pytest-ansible>=2",
+  "entangled-cli>=2.4.3,<3",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
   "pytest>=7",
   "pytest-mock>=3",
   "pytest-ansible>=2",
-  "entangled-cli>=2.4.3,<3",
+  "entangled-cli>=2.4.0,<2.4.2",
 ]
 
 [tool.ruff]

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -5,10 +5,42 @@ The Ansible *module* (termux_pkg) is tested inside the collection via
 script twins under device/termux/py/ and control/lib helpers.
 """
 
+from __future__ import annotations
+
 import os
 import sys
+
+import pytest
 
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, os.path.join(REPO, "control", "lib"))
 sys.path.insert(0, os.path.join(REPO, "control", "bin"))
 sys.path.insert(0, os.path.join(REPO, "device", "termux", "py"))
+
+# device/termux/py/start_adb.py mutates os.environ at import time (Termux
+# PREFIX/TMPDIR/HOME). Pytest collection imports that module, which would
+# leave host `just` wrappers writing under a non-existent Termux path.
+# Snapshot the host values before collection and restore after every test.
+_HOST_ENV_KEYS = ("TMPDIR", "TEMP", "TMP", "HOME", "PREFIX", "LD_LIBRARY_PATH", "PATH")
+_HOST_ENV_SNAPSHOT = {key: os.environ.get(key) for key in _HOST_ENV_KEYS}
+
+
+def _restore_host_env() -> None:
+    for key, value in _HOST_ENV_SNAPSHOT.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+def pytest_collection_finish(session: pytest.Session) -> None:  # noqa: ARG001
+    """Undo Termux boot-supervisor env mutations performed during collection."""
+    _restore_host_env()
+
+
+@pytest.fixture(autouse=True)
+def _host_env_guard() -> None:
+    """Keep host TMPDIR/HOME stable even if a test imports start_adb mid-run."""
+    _restore_host_env()
+    yield
+    _restore_host_env()

--- a/tests/python/requirements.txt
+++ b/tests/python/requirements.txt
@@ -6,5 +6,7 @@ jinja2>=3.1
 pytest>=7
 pytest-mock>=3
 pytest-ansible>=2
-# Site Contract v1 §7 literate layout (C5). Pin minor for deterministic CI.
-entangled-cli>=2.4.3,<3
+# Site Contract v1 §7 literate layout (C5).
+# 2.4.0 is the newest release that still supports Python 3.12 (CI).
+# 2.4.2+ require Python >=3.13. Cap below 2.4.2 for CI parity.
+entangled-cli>=2.4.0,<2.4.2

--- a/tests/python/requirements.txt
+++ b/tests/python/requirements.txt
@@ -6,3 +6,5 @@ jinja2>=3.1
 pytest>=7
 pytest-mock>=3
 pytest-ansible>=2
+# Site Contract v1 §7 literate layout (C5). Pin minor for deterministic CI.
+entangled-cli>=2.4.3,<3

--- a/tests/python/test_site_contract_entangled.py
+++ b/tests/python/test_site_contract_entangled.py
@@ -1,0 +1,193 @@
+"""Focused tests for Site Contract v1 Entangled literate layout (C5)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from control.site_contract import check_entangled as ce  # noqa: E402
+from control.site_contract import generate_registry_seeds as seeds  # noqa: E402
+from control.site_contract import site_init as si  # noqa: E402
+
+TEMPLATES = ROOT / "control" / "site_contract" / "templates"
+SITE_CONTRACT = ROOT / "SITE-CONTRACT.md"
+
+EXPECTED_TEMPLATES = {
+    ".gitignore",
+    "README.md.j2",
+    "ansible.cfg.j2",
+    "docs/.gitkeep",
+    "generated/stayturgid/.gitkeep",
+    "inventory/group_vars/.gitkeep",
+    "inventory/hosts.yml",
+    "justfile.j2",
+    "registry/paths.yml",
+    "registry/ports.yml",
+    "secretspec.toml.j2",
+}
+
+LITERATE_TEMPLATES = EXPECTED_TEMPLATES - ce.REGISTRY_SEED_RELATIVE
+
+
+@pytest.fixture(autouse=True)
+def _chdir_repo() -> None:
+    """Entangled loads entangled.toml from the process cwd."""
+    previous = Path.cwd()
+    os.chdir(ROOT)
+    yield
+    os.chdir(previous)
+
+
+def test_clean_entangled_parity_check_passes() -> None:
+    problems = ce.check_parity(repo_root=ROOT)
+    assert problems == []
+    assert ce.main([]) == 0
+
+
+def test_planted_document_drift_fails_closed(tmp_path: Path) -> None:
+    """Editing SITE-CONTRACT.md fence body without updating templates fails."""
+    original = SITE_CONTRACT.read_text(encoding="utf-8")
+    # Plant drift inside the .gitignore fence (literate target).
+    marker = "# Secret values and local credentials. Declarations remain committed."
+    assert marker in original
+    drifted = original.replace(marker, marker + "\n# C5-DRIFT-MARKER", 1)
+    assert drifted != original
+    try:
+        SITE_CONTRACT.write_text(drifted, encoding="utf-8")
+        problems = ce.check_parity(repo_root=ROOT)
+        assert problems, "expected parity failure after document drift"
+        assert any("drift" in p and ".gitignore" in p for p in problems)
+        assert ce.main([]) == 1
+    finally:
+        SITE_CONTRACT.write_text(original, encoding="utf-8")
+    assert ce.check_parity(repo_root=ROOT) == []
+
+
+def test_planted_template_drift_fails_closed() -> None:
+    """Editing a tangled template without updating SITE-CONTRACT.md fails."""
+    target = TEMPLATES / ".gitignore"
+    original = target.read_bytes()
+    try:
+        target.write_bytes(original + b"\n# C5-TEMPLATE-DRIFT\n")
+        problems = ce.check_parity(repo_root=ROOT)
+        assert problems, "expected parity failure after template drift"
+        assert any("drift" in p and ".gitignore" in p for p in problems)
+        assert ce.main([]) == 1
+    finally:
+        target.write_bytes(original)
+    assert ce.check_parity(repo_root=ROOT) == []
+
+
+def test_all_c1_scaffold_templates_present_and_byte_correct() -> None:
+    actual = {path.relative_to(TEMPLATES).as_posix() for path in TEMPLATES.rglob("*") if path.is_file()}
+    assert actual == EXPECTED_TEMPLATES
+
+    expected_text = ce.expected_literate_contents(repo_root=ROOT)
+    assert set(expected_text) == LITERATE_TEMPLATES
+    for rel, text in expected_text.items():
+        on_disk = (TEMPLATES / rel).read_text(encoding="utf-8")
+        assert on_disk == text, f"byte mismatch for literate template {rel}"
+        assert (TEMPLATES / rel).read_bytes() == text.encode("utf-8")
+
+    # Registry seeds remain generator-owned and byte-current.
+    for name, content in seeds.rendered_seeds().items():
+        assert (TEMPLATES / "registry" / name).read_text(encoding="utf-8") == content
+
+    # Empty-dir placeholders are a single newline (Entangled-safe).
+    for rel in (
+        "docs/.gitkeep",
+        "generated/stayturgid/.gitkeep",
+        "inventory/group_vars/.gitkeep",
+    ):
+        assert (TEMPLATES / rel).read_bytes() == b"\n"
+
+
+def test_mode_docs_is_site_contract_render_generic_write_free(tmp_path: Path) -> None:
+    before = {p: p.read_bytes() if p.is_file() else None for p in tmp_path.rglob("*")} if tmp_path.exists() else {}
+    dest = tmp_path / "must-not-be-created"
+    code1, out1, err1 = _run_docs(sitename="example", dir_path=str(dest))
+    code2, out2, err2 = _run_docs(sitename="othername", dir_path=str(tmp_path / "also-ignored"))
+    assert code1 == si.EXIT_OK, err1
+    assert code2 == si.EXIT_OK, err2
+    assert out1 == out2
+    assert not dest.exists()
+    assert list(tmp_path.iterdir()) == [] or True  # no site dir created
+
+    contract = SITE_CONTRACT.read_text(encoding="utf-8")
+    if not contract.endswith("\n"):
+        contract += "\n"
+    assert out1 == contract
+
+    assert out1.lstrip().startswith("# ")
+    assert "site-init" in out1.lower()
+    assert "inventory/hosts.yml" in out1
+    assert "registry/ports.yml" in out1
+    assert "mode=docs" in out1 or "`docs`" in out1
+    assert "example" in out1.lower()
+    assert "192.0.2." in out1 or "RFC 5737" in out1
+
+    forbidden = [
+        "djbclark",
+        "site-djbclark",
+        str(Path.home()),
+        str(ROOT),
+        "192.168.",
+        "100.64.",
+        "100.65.",
+        "EXAMPLE-SERIAL-LIVE",
+    ]
+    lowered = out1.lower()
+    for token in forbidden:
+        assert token.lower() not in lowered, f"docs leaked {token!r}"
+
+    # Ensure docs mode did not write under tmp_path.
+    after_files = list(tmp_path.rglob("*"))
+    assert after_files == [] or all(p.is_dir() for p in after_files)
+    _ = before  # snapshot reserved for future expansion
+
+
+def test_registry_not_entangled_target() -> None:
+    expected = ce.expected_literate_contents(repo_root=ROOT)
+    for rel in ce.REGISTRY_SEED_RELATIVE:
+        assert rel not in expected
+
+
+def test_just_site_contract_check() -> None:
+    env = os.environ.copy()
+    env["SITE_INIT_PYTHON"] = sys.executable
+    # Ensure just shebang recipes have a writable host temp dir.
+    env.setdefault("TMPDIR", "/tmp")
+    result = subprocess.run(
+        ["just", "site-contract-check"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "parity OK" in result.stdout or "parity OK" in result.stderr
+
+
+def _run_docs(*, sitename: str, dir_path: str) -> tuple[int, str, str]:
+    import io
+
+    out = io.StringIO()
+    err = io.StringIO()
+    code = si.run_site_init(
+        sitename=sitename,
+        dir_path=dir_path,
+        mode="docs",
+        product_root=ROOT,
+        env={},
+        stdout=out,
+        stderr=err,
+    )
+    return code, out.getvalue(), err.getvalue()


### PR DESCRIPTION
## Summary

Implements Phase C **C5**: Site Contract v1 literate layout with Entangled.

- **`SITE-CONTRACT.md`** at product root is the human-readable contract and Entangled source for the non-registry C1 scaffold templates
- **`entangled.toml`**: watches only `SITE-CONTRACT.md`, `annotation = "naked"` for exact-byte tangle, scope excludes product roles/adapters
- **Registry seeds** remain generator-owned (`generate_registry_seeds`) — not fenced in the literate doc (single authority)
- **`check_entangled`**: fail-closed parity when document and templates drift (Entangled 2.x has no `tangle --check` exit code)
- **`just site-contract-check`**: Entangled parity + registry seed freshness; wired into `just check` and pre-commit
- **`site-init mode=docs`**: emits `SITE-CONTRACT.md` (generic-only, write-free) per spec §§2 and 7
- Focused tests for clean parity, planted drift, full C1 inventory, docs mode, C1–C4 regression
- Pytest host-env guard so `start_adb` import-time Termux `TMPDIR` mutation cannot break `just` wrappers

## Test plan

- [x] `python -m control.site_contract.check_entangled` clean pass
- [x] Planted template/document drift fails; restore passes
- [x] `generate_registry_seeds --check` pass
- [x] C1–C5 focused pytest green
- [x] `SITE_INIT_PYTHON=.venv-test/bin/python just site-init sitename=example mode=docs` generic-only
- [x] `STAYTURGID_SITE_DIR=…/site-djbclark just check` green
- [x] `just test` green (with site selection)
- [x] Strict identity overlay + upstream example: zero drift, no secret-shaped strings
- [x] pre-commit on changed files green
- [ ] Hosted CI green