### PR TITLE
fix(serverapp_caddy): persistently disable legacy caddy label after bootout (R1 must-fix)

### DIFF
--- a/ansible/roles/serverapp_caddy/tasks/main.yml
+++ b/ansible/roles/serverapp_caddy/tasks/main.yml
@@ -135,6 +135,41 @@
     - _caddy_launch_state.stdout | trim == 'unloaded'
   register: _caddy_legacy_bootout
 
+# R1 must-fix (2026-07-19): bootout is session-scoped — the retained legacy
+# plist (RunAtLoad + KeepAlive) would re-bootstrap at next login and fight the
+# site label for 80/443. Persistently disable the label instead of deleting
+# the plist (rollback/D7 still need the file). Rollback becomes:
+#   launchctl bootout gui/<uid>/com.<site_ns>.caddy \
+#     && launchctl enable gui/<uid>/com.stayturgid.caddy \
+#     && launchctl bootstrap gui/<uid> ~/Library/LaunchAgents/com.stayturgid.caddy.plist
+- name: Check whether legacy caddy plist remains on disk
+  ansible.builtin.stat:
+    path: "{{ serverapp_caddy_home }}/Library/LaunchAgents/com.stayturgid.caddy.plist"
+  register: _caddy_legacy_plist
+
+- name: Probe whether legacy caddy label is persistently disabled
+  ansible.builtin.shell: |
+    set -eu
+    if launchctl print-disabled "gui/{{ serverapp_caddy_uid }}" 2>/dev/null \
+      | grep -Eq '"com\.stayturgid\.caddy" => (true|disabled)'; then
+      echo disabled
+    else
+      echo enabled
+    fi
+  args:
+    executable: /bin/bash
+  register: _caddy_legacy_disabled
+  changed_when: false
+  when: _caddy_legacy_plist.stat.exists
+
+- name: Persistently disable legacy caddy label (survives login; plist retained)
+  ansible.builtin.command:
+    cmd: launchctl disable gui/{{ serverapp_caddy_uid }}/com.stayturgid.caddy
+  when:
+    - _caddy_legacy_plist.stat.exists
+    - (_caddy_legacy_disabled.stdout | default('disabled') | trim) == 'enabled'
+  register: _caddy_legacy_disable
+
 - name: Bootstrap site-namespace caddy when unloaded
   ansible.builtin.command:
     cmd: >-


### PR DESCRIPTION
R1 first-adapter review found that `launchctl bootout` is session-scoped: the retained `com.stayturgid.caddy.plist` (RunAtLoad + KeepAlive, not in launchd's disabled DB) would re-bootstrap at next login and contend with `com.<site_ns>.caddy` for ports 80/443 — nondeterministic front-door state after reboot.

Fix: after the legacy bootout, persistently disable the legacy label (`launchctl disable`) whenever the legacy plist remains on disk. The plist itself is retained for rollback and D7 retirement, per design notes §1.9's no-cutover rule. Rollback command gains an `enable` step (documented in the task comment and site review doc).

Verified live on m1-air: apply exit 0, `print-disabled` shows the label disabled, `com.djbclark.caddy` running, /health 200, HTTPS front door 200, second apply exit 0 (disable task skips). `just check` green; ansible-lint production profile passed.

Review doc: site `docs/relay/reviews/r1-d1-adapter-review.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)