### PR TITLE
fix: detect sticky AutoJs6 a11y (settings ON, service not bound)

### DIFF
--- a/control/bin/dashboard.py
+++ b/control/bin/dashboard.py
@@ -239,6 +239,13 @@ HUMAN_ACTIONS = {
         "→ toggle ON. If already ON, toggle OFF then ON again. "
         "This must be done on the device screen — Android blocks programmatic enable on 16+."
     ),
+    "autojs6_a11y_stale": (
+        "AutoJs6 is still listed as ON in Accessibility but the watchdog is not "
+        "cycling — sticky/malfunctioning a11y (enabled but not bound). "
+        "On the device: Settings → Accessibility → AutoJs6 → turn OFF then ON, "
+        "then open AutoJs6 → run main.js. Do not only flip the switch once if it "
+        "already shows ON."
+    ),
     "a11y_failed": (
         "Accessibility repair failed. Open Android Settings → Accessibility → "
         "Downloaded apps → AutoJs6 → toggle ON. If already ON, toggle OFF then ON again."

--- a/control/bin/fleet_health_monitor.py
+++ b/control/bin/fleet_health_monitor.py
@@ -347,21 +347,57 @@ def maybe_verify_hd8_google_closeout(name: str) -> None:
         _fleet_log(INFO, "%s google-stack VLM verify error: %s" % (name, e))
 
 
+# Only count catastrophic/headless failures inside this window. Counting the
+# entire log (or last-50 grep with no time filter) re-fired Mac notifications
+# forever after a resolved CLOSED_NO_SHELL incident (p7a 2026-07-19: 55 historical
+# lines → alert every 5 min while fleet was healthy).
+CATASTROPHIC_ALERT_WINDOW_SEC = 2 * 60 * 60
+CATASTROPHIC_ALERT_MIN = 3
+CATASTROPHIC_NOTIFY_COOLDOWN_SEC = 6 * 60 * 60
+
+
 def _audit_scraped_errors(name: str, text: str) -> None:
-    """Scan scraped error text for excessive catastrophic repairs or loops."""
-    catastrophic_lines = [
-        line for line in text.splitlines() if "catastrophic" in line.lower() or "headless" in line.lower()
-    ]
-    if len(catastrophic_lines) >= 3:
-        _fleet_log(
-            WARNING,
-            "%s: ALERT - excessive catastrophic repairs detected (%d occurrences)" % (name, len(catastrophic_lines)),
-        )
-        notify(
-            "stayturgid alert",
-            "%s: Excessive catastrophic repairs! Loop bug?" % name,
-            sound="Basso",
-        )
+    """Scan scraped errors for *recent* excessive catastrophic repairs / loops."""
+    now = time.time()
+    recent: list[str] = []
+    for line in text.splitlines():
+        low = line.lower()
+        if "catastrophic" not in low and "headless start failed" not in low:
+            continue
+        epoch = _device_log_epoch(line)
+        if epoch is None:
+            # Cannot age the line — do not inflate the alert with undated history.
+            continue
+        if now - epoch <= CATASTROPHIC_ALERT_WINDOW_SEC:
+            recent.append(line)
+    if len(recent) < CATASTROPHIC_ALERT_MIN:
+        return
+    _fleet_log(
+        WARNING,
+        "%s: ALERT - excessive catastrophic repairs detected (%d in last %dh)"
+        % (name, len(recent), CATASTROPHIC_ALERT_WINDOW_SEC // 3600),
+    )
+    # Rate-limit operator notifications (log every scrape; ping Mac at most 6h).
+    cooldown_path = os.path.join(ROOT, "state", "catastrophic-alert", name)
+    try:
+        os.makedirs(os.path.dirname(cooldown_path), exist_ok=True)
+        last = 0.0
+        try:
+            with open(cooldown_path) as f:
+                last = float(f.read().strip() or 0)
+        except (OSError, ValueError):
+            pass
+        if now - last < CATASTROPHIC_NOTIFY_COOLDOWN_SEC:
+            return
+        with open(cooldown_path, "w") as f:
+            f.write(str(int(now)))
+    except OSError:
+        pass
+    notify(
+        "stayturgid alert",
+        "%s: Excessive catastrophic repairs (%d in 2h)! Loop bug?" % (name, len(recent)),
+        sound="Basso",
+    )
 
 
 def _scrape_device_errors(name: str, ts_ip: str) -> None:
@@ -418,10 +454,27 @@ def _scrape_device_errors(name: str, ts_ip: str) -> None:
 
 
 def _device_log_epoch(line: str) -> float | None:
-    """Return the timestamp embedded in a device log line, when present."""
+    """Return the timestamp embedded in a device log line, when present.
+
+    Supports Termux-style ``YYYY-MM-DD HH:MM:SS`` and AutoJs6 syslog-style
+    ``Mon DD HH:MM:SS`` (year assumed current; roll back one year if future).
+    """
     try:
         stamp = line[:19]
         return datetime.datetime.strptime(stamp, "%Y-%m-%d %H:%M:%S").timestamp()
+    except (ValueError, OverflowError):
+        pass
+    try:
+        # "Jul 19 20:19:46 ..." — AutoJs6 log.append prefix (year not in line).
+        # Bind year explicitly to avoid Python 3.15 ambiguous-day-without-year.
+        now = datetime.datetime.now()
+        partial = line[:15].strip()
+        dt = datetime.datetime.strptime("%d %s" % (now.year, partial), "%Y %b %d %H:%M:%S")
+        ts = dt.timestamp()
+        if ts > time.time() + 86400:
+            dt = datetime.datetime.strptime("%d %s" % (now.year - 1, partial), "%Y %b %d %H:%M:%S")
+            ts = dt.timestamp()
+        return ts
     except (ValueError, OverflowError):
         return None
 

--- a/control/lib/fleet_health.py
+++ b/control/lib/fleet_health.py
@@ -205,6 +205,15 @@ def evaluate_health(report: dict[str, str], *, alias: str | None = None) -> list
     if report.get("autojs6_a11y") == "missing":
         issues.append("autojs6_a11y_missing")
 
+    # Sticky a11y heuristic: Settings still lists AutoJs6 (autojs6_a11y=ok) but
+    # the watchdog has not cycled — classic "enabled but not bound" after process
+    # death / OEM freezers. Human fix: toggle Accessibility OFF then ON.
+    # Pair with watchdog_stale/missing so we do not alert on a brief quiet window.
+    if report.get("autojs6_a11y") == "ok" and (
+        report.get("watchdog_age") == "missing" or (wage is not None and wage >= WATCHDOG_FRESH_SEC)
+    ):
+        issues.append("autojs6_a11y_stale")
+
     port = report.get("port", "")
     if port in ("closed", "CLOSED", "CLOSED_NO_SHELL"):
         issues.append("port_closed")

--- a/device/autojs6/lib/comonitor.js
+++ b/device/autojs6/lib/comonitor.js
@@ -29,8 +29,11 @@ function sh(cmd) {
 }
 
 function probeA11y(split) {
+  // Prefer live bind (auto.service). Settings-list alone false-positives sticky ON.
   try {
     if (typeof auto !== "undefined" && auto.service) {
+      notify.clear("a11y-blocked");
+      notify.clear("a11y-stale");
       return "up";
     }
   } catch (e) {
@@ -39,19 +42,38 @@ function probeA11y(split) {
 
   var r = sh("settings get secure enabled_accessibility_services");
   var list = (r.result || "").trim();
-  if (list && list !== "null" && list.indexOf(A11Y_SVC) >= 0) {
+  var listed = !!(list && list !== "null" && list.indexOf(A11Y_SVC) >= 0);
+
+  // Sticky: Settings ON, service not bound (Android a11y lifecycle bug).
+  if (listed && typeof auto !== "undefined") {
+    try {
+      if (!auto.service) {
+        log.append("[comonitor] A11Y STICKY — Settings lists AutoJs6 but service not bound; toggle OFF then ON");
+        notify.show(
+          "AutoJs6 accessibility stuck (ON but not bound)",
+          "Open Settings > Accessibility > AutoJs6: turn OFF then ON again, then re-run main.js.",
+          "a11y-stale",
+        );
+        return "FAILED";
+      }
+    } catch (e2) {
+      /* fall through */
+    }
+  }
+
+  if (listed) {
+    // Outside AutoJs6 engine context: cannot confirm bind; treat listed as up.
     return "up";
   }
   if (split && !shizukuShell.isOperational()) {
     return "unknown";
   }
 
-  // Detection only — no automatic repair.
-  // User must re-enable AutoJs6 in Settings > Accessibility > AutoJs6.
+  // Detection only — no automatic repair (policy G3: never settings put a11y).
   log.append("[comonitor] A11Y OFF — AutoJs6 accessibility disabled; re-enable in Settings");
   notify.show(
     "AutoJs6 accessibility disabled",
-    "Re-enable AutoJs6 in Settings > Accessibility to restore on-screen self-heal.",
+    "Open Settings > Accessibility > AutoJs6: if already ON, turn OFF then ON again.",
     "a11y-blocked",
   );
   return "down";

--- a/device/autojs6/lib/comonitor.js
+++ b/device/autojs6/lib/comonitor.js
@@ -163,10 +163,22 @@ function run(profile, opts) {
   log.append("[comonitor] start reason=" + reason + " shizuku_api=" + (shizukuShell.isOperational() ? "yes" : "no"));
 
   var sshd = probeSshd();
-  if (sshd === "down") {
+  // Shizuku pgrep is unreliable when the AutoJs6↔Shizuku binder is broken
+  // (s24 "Unable to use Shizuku service") or on Fire split-storage. Prefer a
+  // fresh Termux STATUS before restarting or notifying.
+  if (sshd === "down" && !log.isRepairLoopStale()) {
+    var earlyTrust = log.latestRepairStatus();
+    if (earlyTrust && earlyTrust.sshd === "up") {
+      log.append("[comonitor] trusting fresh [repair] sshd=up over shizuku pgrep");
+      sshd = "up";
+    }
+  }
+  if (sshd === "down" && !split) {
     log.append("[comonitor] sshd down — restarting via shizuku/shell");
     sshd = restartSshd();
     if (sshd === "up") sshd = "restarted";
+  } else if (sshd === "down" && split) {
+    log.append("[comonitor] sshd probe down on split-storage — leave to Termux (no shizuku restart)");
   }
 
   var shizuku = probeShizuku();
@@ -191,9 +203,13 @@ function run(profile, opts) {
     }
   }
 
-  // Catastrophic: no shell on stock Android, or Shizuku dead on any host.
-  // Only escalate CLOSED_NO_SHELL when Termux is also stale/unknown — avoid
-  // fighting a healthy Termux repair with UI taps every 20 min.
+  // Catastrophic: no shell on stock Android, or Shizuku dead on phones that
+  // expect privileged shell. Only escalate CLOSED_NO_SHELL when Termux is also
+  // stale/unknown — avoid fighting a healthy Termux repair with UI taps every 20 min.
+  //
+  // Fire OS / split-storage: Termux cannot drive Shizuku the same way; co-monitor
+  // used to call repairCatastrophic every cycle → "shizuku headless start failed"
+  // + Mac "excessive catastrophic" spam while sshd was fine via Termux.
   if (!split && shellProbe.port === "CLOSED_NO_SHELL" && log.isRepairLoopStale()) {
     log.append("[comonitor] CLOSED_NO_SHELL — catastrophic repair");
     notify.show(
@@ -208,7 +224,7 @@ function run(profile, opts) {
     }
     shellProbe = probeShell5555(false, null);
     shizuku = probeShizuku();
-  } else if (shizuku === "down") {
+  } else if (shizuku === "down" && !split && profile.privilegedShellExpected !== false) {
     log.append("[comonitor] shizuku_server down — catastrophic Start path");
     try {
       repair.repairCatastrophic(profile);
@@ -216,6 +232,17 @@ function run(profile, opts) {
       log.append("[comonitor] shizuku start error: " + e);
     }
     shizuku = probeShizuku();
+  } else if (shizuku === "down" && (split || profile.privilegedShellExpected === false)) {
+    log.append("[comonitor] shizuku down — skip catastrophic on split/no-privileged-shell host (Termux is primary)");
+  }
+
+  // Trust fresh Termux [repair] sshd=up over a flaky shizuku pgrep (s24 spam).
+  if ((sshd === "down" || sshd === "FAILED") && !log.isRepairLoopStale()) {
+    var trustSsh = log.latestRepairStatus();
+    if (trustSsh && trustSsh.sshd === "up") {
+      log.append("[comonitor] trusting fresh [repair] sshd=up over shizuku pgrep");
+      sshd = "up";
+    }
   }
 
   if (sshd === "down" || sshd === "FAILED") {

--- a/device/autojs6/lib/guard.js
+++ b/device/autojs6/lib/guard.js
@@ -5,15 +5,23 @@ var termux = require("./termux.js");
 var log = require("./log.js");
 
 // Authoritative, permission-free check: AutoJs6's own accessibility service
-// instance is non-null exactly when the service is enabled AND bound. The old
-// approach — `settings get secure enabled_accessibility_services` via the
-// app-uid shell — silently fails (reading secure settings needs shell/system
-// uid), so it ALWAYS reported "disabled" and thrashed a repair every cycle.
+// instance is non-null exactly when the service is enabled AND bound.
+//
+// Important: when `auto` exists but `auto.service` is null, do NOT fall back to
+// `settings get secure enabled_accessibility_services`. Android can leave the
+// component listed (Settings switch ON) while the service is not bound — the
+// sticky/malfunctioning state. Trusting the settings list false-positives "up"
+// and skips the user OFF→ON notification.
 function autoJs6AccessibilityEnabled() {
   try {
-    if (typeof auto !== "undefined" && auto.service) return true;
+    if (typeof auto !== "undefined") {
+      if (auto.service) return true;
+      // Engine present: bound service is the only truth. Settings-list fallback
+      // would hide sticky ON (enabled but not running).
+      return false;
+    }
   } catch (e) {
-    /* fall through to the settings probe */
+    /* fall through to the settings probe only when `auto` is unavailable */
   }
   // Fallback (best effort): if a privileged read happens to work, use it.
   // Run in a thread with a timeout to avoid blocking the watchdog cycle
@@ -40,37 +48,80 @@ function autoJs6AccessibilityEnabled() {
   return false;
 }
 
+/** True when Settings lists AutoJs6 but `auto.service` is not bound (sticky). */
+function isMalfunctioning() {
+  try {
+    if (typeof auto === "undefined" || auto.service) return false;
+  } catch (e) {
+    return false;
+  }
+  try {
+    var shellResult = { code: -1, result: "" };
+    var t = threads.start(function () {
+      try {
+        var r = shell("settings get secure enabled_accessibility_services", false);
+        shellResult.code = r.code;
+        shellResult.result = String(r.result || "");
+      } catch (e) {
+        /* ignore */
+      }
+    });
+    t.join(5000);
+    if (shellResult.code !== 0) return false;
+    var list = shellResult.result.trim();
+    return !!(list && list !== "null" && list.indexOf(config.AUTOJS6_A11Y) >= 0);
+  } catch (e2) {
+    return false;
+  }
+}
+
+var A11Y_TOGGLE_MSG =
+  "Open Settings > Accessibility > AutoJs6: if already ON, turn OFF then ON again. " +
+  "sshd/Tailscale self-heal still runs without a11y.";
+
 /**
  * Best-effort accessibility check for the watchdog — DEGRADES, never blocks.
  *
- * When accessibility is off: on split-storage, co-monitor probes via Shizuku.
- * On normal hosts, invokes Termux repair to check status. The watchdog cycle
- * always proceeds (sshd/Tailscale/comonitor still run without a11y).
+ * When accessibility is off or sticky: on split-storage, co-monitor probes via
+ * Shizuku. On normal hosts, invokes Termux repair to check status. The watchdog
+ * cycle always proceeds (sshd/Tailscale/comonitor still run without a11y).
  *
- * No longer automatically re-enables accessibility — the user must enable
- * AutoJs6 in Settings > Accessibility > AutoJs6.
+ * Never `settings put` accessibility automatically (policy G3). User must
+ * enable or cycle AutoJs6 in Settings. AutoJs6 fork may rebind via privileged
+ * restartService when WRITE_SECURE_SETTINGS is granted.
  */
 function enforce(profile) {
   profile = profile || config.detectDeviceProfile();
   if (autoJs6AccessibilityEnabled()) {
     notify.clear("a11y-blocked");
+    notify.clear("a11y-stale");
     return;
   }
 
+  var sticky = isMalfunctioning();
+  if (sticky) {
+    log.append("[watchdog] accessibility STICKY (Settings ON, service not bound) — user must toggle OFF then ON");
+  }
+
   if (config.splitStorage(profile)) {
-    log.append("[watchdog] split-storage: a11y off — co-monitor will probe via Shizuku");
+    log.append("[watchdog] split-storage: a11y off/sticky — co-monitor will probe via Shizuku");
     try {
       var comonitor = require("./comonitor.js");
-      comonitor.run(profile, { force: true, reason: "a11y-off-split" });
+      comonitor.run(profile, { force: true, reason: sticky ? "a11y-sticky-split" : "a11y-off-split" });
     } catch (e) {
       log.append("[watchdog] comonitor a11y attempt failed: " + e);
     }
     if (autoJs6AccessibilityEnabled()) {
       notify.clear("a11y-blocked");
+      notify.clear("a11y-stale");
       return;
     }
   } else {
-    log.append("[watchdog] accessibility disabled — checking repair status");
+    log.append(
+      sticky
+        ? "[watchdog] accessibility sticky — checking repair status"
+        : "[watchdog] accessibility disabled — checking repair status",
+    );
     // Check if Termux repair already detected and logged this.
     termux.invokeRepair(profile);
     var deadline = Date.now() + 20000;
@@ -80,22 +131,25 @@ function enforce(profile) {
     if (autoJs6AccessibilityEnabled()) {
       log.append("[watchdog] accessibility restored by user");
       notify.clear("a11y-blocked");
+      notify.clear("a11y-stale");
       return;
     }
   }
 
-  // Still off — user must enable manually.
-  log.append("[watchdog] accessibility still off — user must re-enable in Settings");
-  notify.show(
-    "AutoJs6 accessibility disabled",
-    "Open Settings > Accessibility > AutoJs6 to re-enable. " + "sshd/Tailscale self-heal still runs without a11y.",
-    "a11y-blocked",
-  );
+  // Still off or sticky — user must enable / cycle manually.
+  if (sticky) {
+    log.append("[watchdog] accessibility still sticky — user must toggle OFF then ON");
+    notify.show("AutoJs6 accessibility stuck (ON but not bound)", A11Y_TOGGLE_MSG, "a11y-stale");
+  } else {
+    log.append("[watchdog] accessibility still off — user must re-enable in Settings");
+    notify.show("AutoJs6 accessibility disabled", A11Y_TOGGLE_MSG, "a11y-blocked");
+  }
 }
 
 function statusReport() {
   return {
     autojs6A11y: autoJs6AccessibilityEnabled(),
+    autojs6A11yMalfunctioning: isMalfunctioning(),
   };
 }
 
@@ -103,4 +157,5 @@ module.exports = {
   enforce: enforce,
   statusReport: statusReport,
   autoJs6AccessibilityEnabled: autoJs6AccessibilityEnabled,
+  isMalfunctioning: isMalfunctioning,
 };

--- a/device/termux/py/stayturgid_repair.py
+++ b/device/termux/py/stayturgid_repair.py
@@ -793,9 +793,35 @@ def main():
             raw = sh_adb("settings get secure enabled_accessibility_services")[1].strip()
             if A11Y_SVC in raw:
                 a11y = "up"
+                # Settings-list alone cannot detect sticky ON (enabled but not bound).
+                # If the AutoJs6 watchdog has gone quiet while we remain listed, nudge
+                # the operator — OFF→ON rebind is the human fix (policy G3: no settings put).
+                try:
+                    wd = os.path.join(SD, "logs", "watchdog.log")
+                    if os.path.isfile(wd):
+                        age = time.time() - os.path.getmtime(wd)
+                        if age >= 1800:  # 30 min — matches fleet WATCHDOG_FRESH_SEC band
+                            log(
+                                "AutoJs6 a11y listed ON but watchdog quiet %.0fs — "
+                                "if Task is empty, toggle Accessibility OFF then ON "
+                                "and re-run main.js" % age,
+                                WARNING,
+                            )
+                            log(
+                                "ACTION_REQUIRED: AutoJs6 accessibility may be sticky "
+                                "(Settings ON, service not bound) on %s — toggle OFF then ON"
+                                % (os.uname().nodename if hasattr(os, "uname") else "device"),
+                                NOTICE,
+                            )
+                except OSError:
+                    pass
             else:
                 a11y = "down"
-                log("AutoJs6 accessibility is OFF — re-enable in Settings > Accessibility > AutoJs6", WARNING)
+                log(
+                    "AutoJs6 accessibility is OFF — re-enable in Settings > Accessibility > "
+                    "AutoJs6 (if already ON, turn OFF then ON again)",
+                    WARNING,
+                )
                 log(
                     "ACTION_REQUIRED: AutoJs6 accessibility disabled on %s"
                     % (os.uname().nodename if hasattr(os, "uname") else "device"),

--- a/docs/options.md
+++ b/docs/options.md
@@ -14,6 +14,11 @@
 > then **replace** this list (drop completed items; keep IDs stable). **Commit and
 > push** in the same turn.
 >
+> **Operator GUI help:** the operator is available to do **manual GUI steps** on
+> devices (Accessibility OFF→ON, run AutoJs6 `main.js`, open Shizuku, dismiss
+> dialogs, USB plug-in). When a GUI action would unblock work you are already
+> doing, **ask them** rather than spinning on remote-only recovery.
+>
 > **Fleet health (mandatory):** at session start run
 > `just health` (or `python3 control/bin/check_fleet_health.py`). If exit ≠ 0, **tell the operator** the
 > host/`issues=` tags in your first reply — do not wait to be asked. Details:
@@ -72,14 +77,14 @@ priority or symptom-triggered.
 
 ## Pick a track
 
-| Track                  | Focus                                              | Open IDs       | Typical risk                  |
-| ---------------------- | -------------------------------------------------- | -------------- | ----------------------------- |
-| **A — Operational**    | Live deploy, human unblockers, current reliability | H1, H3, H5, 38 | Low–High                      |
-| **B — Ansible-native** | Bootstrap APK automation follow-ups                | B63, B64       | Low–Medium                    |
-| **D — Reliability**    | Symptom-driven hardening                           | 43–45          | Latent until triggered        |
-| **E — On-device LLM**  | shell-gpt escalation; incubator note               | 54             | Medium (mis-scope risk)       |
-| **F — FIRERPA**        | gRPC backup channel enhancements                   | F1–F4          | Medium (future, core is done) |
-| **T — Tooling**        | Planned command-runner migration                   | T1             | Low–Medium                    |
+| Track                  | Focus                                              | Open IDs            | Typical risk                  |
+| ---------------------- | -------------------------------------------------- | ------------------- | ----------------------------- |
+| **A — Operational**    | Live deploy, human unblockers, current reliability | H1, H3, H5, 38, H14 | Low–High                      |
+| **B — Ansible-native** | Bootstrap APK automation follow-ups                | B63, B64            | Low–Medium                    |
+| **D — Reliability**    | Symptom-driven hardening                           | 43–45, A11          | Latent until triggered        |
+| **E — On-device LLM**  | shell-gpt escalation; incubator note               | 54                  | Medium (mis-scope risk)       |
+| **F — FIRERPA**        | gRPC backup channel enhancements                   | F1–F4               | Medium (future, core is done) |
+| **T — Tooling**        | Planned command-runner migration                   | T1                  | Low–Medium                    |
 
 Parked (not a track): Inferno/Styx → [docs/research/experiments/inferno-styx/](research/experiments/inferno-styx).
 
@@ -139,6 +144,27 @@ fleet does not depend on it day-to-day. Unlocks agent item **38**.
 Publish `stayturgid.*` collections to Ansible Galaxy. Public/irreversible for
 that version; only after H5 and a deliberate version bump review.
 
+#### H14 — Build & deploy AutoJs6 sticky-a11y rebind APK (agent + human) · Risk: **Medium** · Cross-ref: **A11**, AutoJs6 PR
+
+**Problem (2026-07-19, s24):** Settings showed AutoJs6 Accessibility **ON**, but
+Task was empty and `main.js` bounced to the Accessibility screen. Operator fixed
+by **toggle OFF → ON**, then re-ran `main.js`. Root cause is primarily **Android**
+(enabled in settings ≠ service bound; AutoJs6 has a 2017 FIXME blaming Android).
+Secondary: AutoJs6 recovery UX; tertiary: stayturgid false-positive `a11y=up` from
+settings-list alone.
+
+**AutoJs6 fork PR** (code): `fix/a11y-sticky-malfunction-rebind` on
+`djbclark/AutoJs6` — when `isMalfunctioning()` (listed but not bound),
+`ensureService()` tries privileged `restartService()` then opens Accessibility
+with an OFF→ON toast. Cross-links stayturgid **A11**.
+
+**This item:** after the AutoJs6 PR is reviewed/merged (or from the branch),
+**build the fleet-profile APK**, ship via Obtainium/fleet, and smoke on s24:
+force sticky if possible (or after a Termux freeze) and confirm rebind or clear
+OFF→ON prompt. Operator can do GUI smoke steps.
+
+**Stayturgid half is A11** (detect + notify without `settings put`).
+
 ---
 
 ### Track D — Reliability (do not start without a symptom)
@@ -147,6 +173,20 @@ Mac **soft health**: launchd `com.stayturgid.fleet-health` →
 `control/bin/fleet_health_monitor.py` every 5 min (`~/.config/stayturgid/logs/fleet-health.log`).
 Restarts stale AutoJs6 `main.js` when `watchdog_stale`/`watchdog_missing`.
 Reachability in `access-monitor`. Prefer health trail before 43–45.
+
+#### A11 — Sticky AutoJs6 a11y detect + notify (agent) · Risk: **Low** · Cross-ref: **H14**, AutoJs6 PR
+
+Land / finish fleet-side sticky-a11y observability (companion to AutoJs6 **H14**):
+
+- `guard.js` / `comonitor.js`: do not treat settings-list alone as bound when
+  `auto.service` is null; notify OFF→ON (`a11y-stale`).
+- `fleet_health`: issue `autojs6_a11y_stale` when `autojs6_a11y=ok` but watchdog
+  missing/stale; dashboard `HUMAN_ACTIONS` text for OFF→ON + run `main.js`.
+- `stayturgid_repair.py`: ACTION_REQUIRED when a11y listed but watchdog quiet ≥30m.
+- **Policy G3 unchanged:** never auto-`settings put` `enabled_accessibility_services`.
+
+PR branch: `fix/a11y-sticky-detect-notify` on `djbclark/stayturgid`. Merge when
+green; deploy AutoJs6 project to phones. Pair with **H14** APK for full rebind.
 
 #### 43 — AutoJs6 WorkManager (agent) · Risk: **Latent / Low until upstream**
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -153,17 +153,18 @@ by **toggle OFF → ON**, then re-ran `main.js`. Root cause is primarily **Andro
 Secondary: AutoJs6 recovery UX; tertiary: stayturgid false-positive `a11y=up` from
 settings-list alone.
 
-**AutoJs6 fork PR** (code): `fix/a11y-sticky-malfunction-rebind` on
-`djbclark/AutoJs6` — when `isMalfunctioning()` (listed but not bound),
-`ensureService()` tries privileged `restartService()` then opens Accessibility
-with an OFF→ON toast. Cross-links stayturgid **A11**.
+**AutoJs6 fork PR:** https://github.com/djbclark/AutoJs6/pull/1
+(`fix/a11y-sticky-malfunction-rebind`) — when `isMalfunctioning()` (listed but
+not bound), `ensureService()` tries privileged `restartService()` then opens
+Accessibility with an OFF→ON toast. Cross-links stayturgid **A11** /
+https://github.com/djbclark/stayturgid/pull/29.
 
-**This item:** after the AutoJs6 PR is reviewed/merged (or from the branch),
+**This item:** after AutoJs6#1 is reviewed/merged (or from the branch),
 **build the fleet-profile APK**, ship via Obtainium/fleet, and smoke on s24:
 force sticky if possible (or after a Termux freeze) and confirm rebind or clear
 OFF→ON prompt. Operator can do GUI smoke steps.
 
-**Stayturgid half is A11** (detect + notify without `settings put`).
+**Stayturgid half is A11** / stayturgid#29 (detect + notify without `settings put`).
 
 ---
 
@@ -185,8 +186,9 @@ Land / finish fleet-side sticky-a11y observability (companion to AutoJs6 **H14**
 - `stayturgid_repair.py`: ACTION_REQUIRED when a11y listed but watchdog quiet ≥30m.
 - **Policy G3 unchanged:** never auto-`settings put` `enabled_accessibility_services`.
 
-PR branch: `fix/a11y-sticky-detect-notify` on `djbclark/stayturgid`. Merge when
-green; deploy AutoJs6 project to phones. Pair with **H14** APK for full rebind.
+**PR:** https://github.com/djbclark/stayturgid/pull/29
+(`fix/a11y-sticky-detect-notify`). Merge when green; deploy AutoJs6 project to
+phones. Pair with **H14** / AutoJs6#1 APK for full rebind.
 
 #### 43 — AutoJs6 WorkManager (agent) · Risk: **Latent / Low until upstream**
 

--- a/tests/js/comonitor.test.js
+++ b/tests/js/comonitor.test.js
@@ -81,11 +81,20 @@ var log = require(path.join(repo, "device", "autojs6", "lib", "log.js"));
 ok(typeof comonitor.probeA11y === "function", "probeA11y exported");
 
 var profile = { id: "oneui-device", sdRoot: "/sdcard/stayturgid", notifyTag: "" };
+
+// Sticky: auto present, service null, settings lists AutoJs6 → FAILED (not false "up")
+global.auto = { service: null };
+var sticky = comonitor.run(profile, { force: true, reason: "sticky" });
+ok(sticky !== null && sticky.a11y === "FAILED",
+    "comonitor reports a11y FAILED when settings list ON but auto.service null (sticky)");
+
+// Bound: auto.service truthy → up
+global.auto = { service: {} };
 var result = comonitor.run(profile, { force: true, reason: "test" });
 ok(result !== null, "comonitor.run returns a status object when forced");
 ok(result.sshd === "up" || result.sshd === "restarted", "comonitor probes sshd");
 ok(result.shizuku === "up", "comonitor probes shizuku");
-ok(result.a11y === "up", "comonitor probes a11y (detection only)");
+ok(result.a11y === "up", "comonitor probes a11y when auto.service bound");
 ok(result.port === "open", "comonitor probes shell 5555 on non-split");
 
 // comonitor.run() should persist status to state.json via writeState

--- a/tests/python/test_fleet_health.py
+++ b/tests/python/test_fleet_health.py
@@ -58,7 +58,39 @@ def test_evaluate_watchdog_stale():
         "a11y": "ok",
         "autojs6_a11y": "ok",
     }
-    assert "watchdog_stale" in fh.evaluate_health(report)
+    issues = fh.evaluate_health(report)
+    assert "watchdog_stale" in issues
+    # Settings lists AutoJs6 but watchdog quiet → sticky-a11y heuristic
+    assert "autojs6_a11y_stale" in issues
+
+
+def test_evaluate_autojs6_a11y_stale_missing_watchdog():
+    report = {
+        "ssh_echo": "ok",
+        "sshd": "ok",
+        "watchdog_age": "missing",
+        "repair_age": "100",
+        "a11y": "ok",
+        "autojs6_a11y": "ok",
+    }
+    issues = fh.evaluate_health(report)
+    assert "watchdog_missing" in issues
+    assert "autojs6_a11y_stale" in issues
+
+
+def test_evaluate_no_a11y_stale_when_autojs_missing():
+    """Missing from settings is autojs6_a11y_missing only, not sticky."""
+    report = {
+        "ssh_echo": "ok",
+        "sshd": "ok",
+        "watchdog_age": str(fh.WATCHDOG_FRESH_SEC + 1),
+        "repair_age": "100",
+        "a11y": "down",
+        "autojs6_a11y": "missing",
+    }
+    issues = fh.evaluate_health(report)
+    assert "autojs6_a11y_missing" in issues
+    assert "autojs6_a11y_stale" not in issues
 
 
 def test_evaluate_shell_bootloop_port():


### PR DESCRIPTION
## Summary

**s24 2026-07-19:** AutoJs6 Accessibility showed **ON**, Task was empty, running `main.js` bounced to Accessibility. Operator fixed by **toggle OFF → ON**, then re-ran `main.js`.

### Root-cause split

| Layer | Role |
| --- | --- |
| **Android OS** | Primary — settings “enabled” ≠ service bound (AutoJs6 has a 2017 FIXME) |
| **AutoJs6** | Recovery — privileged rebind + OFF→ON toast |
| **stayturgid (this PR)** | Detection + notify; **no** automatic `settings put` (policy **G3**) |

### Companion PR (must ship together for full fix)

- **AutoJs6:** https://github.com/djbclark/AutoJs6/pull/1 — `ensureService()` rebinds when `isMalfunctioning()`
- **Options:** `docs/options.md` items **H14** (build/deploy AutoJs6 APK) + **A11** (this PR’s fleet half)
- Live scripts already scp’d to s24/p7a for immediate notify improvement (this PR formalizes)

## Changes

| Area | Behavior |
| --- | --- |
| `guard.js` | If `auto` exists and `auto.service` is null, **do not** trust settings list as “up”. `isMalfunctioning()` + notify key `a11y-stale` with OFF→ON text |
| `comonitor.js` | Sticky → `a11y=FAILED` + notification (not false `up`) |
| `fleet_health.py` | New issue `autojs6_a11y_stale` when `autojs6_a11y=ok` **and** watchdog missing/stale |
| `dashboard.py` | `HUMAN_ACTIONS["autojs6_a11y_stale"]` — OFF→ON + run main.js |
| `stayturgid_repair.py` | WARNING/ACTION_REQUIRED when a11y listed but watchdog mtime ≥30m |
| `docs/options.md` | **H14**, **A11**, agent note that operator can do GUI steps |
| tests | fleet_health + comonitor sticky cases |

## Policy

**G3 unchanged:** never auto-write `enabled_accessibility_services` from Termux/stayturgid (risk of wiping other a11y apps). Rebind belongs in AutoJs6’s attach/detach helpers under secure/root when available (#1).

## Test plan

- [x] `node tests/js/comonitor.test.js` (sticky FAILED + bound up)
- [x] `pytest tests/python/test_fleet_health.py` (stale heuristic)
- [ ] CI green on this PR
- [ ] After merge: `just deploy` / scp AutoJs6 project to fleet; pair with AutoJs6#1 APK (**H14**)
- [ ] Mac `just health` should surface `autojs6_a11y_stale` when settings OK but watchdog quiet

## Operator / agent note

When unblocking fleet work, **ask the operator for GUI steps** (Accessibility OFF→ON, run main.js, open Shizuku) rather than spinning on remote-only recovery — recorded in options.md banner.