### PR TITLE
fix: ASCII-only AutoJs6 paths; retire 脚本/Scripts mirrors

### DIFF
--- a/ansible_collections/stayturgid/android_common/plugins/module_utils/autojs6_deploy_util.py
+++ b/ansible_collections/stayturgid/android_common/plugins/module_utils/autojs6_deploy_util.py
@@ -12,6 +12,17 @@ from ansible_collections.stayturgid.android_common.plugins.module_utils import a
 DEFAULT_TARGET = "/sdcard/stayturgid/autojs6"
 DEFAULT_DEVICE_JSON_DEST = "/sdcard/stayturgid/state/device.json"
 
+# Stale project copies outside the ASCII canonical target confuse operators and
+# AutoJs6 (Chinese-locale default sample dir is 脚本/Scripts). Never deploy there;
+# remove leftover trees on each deploy so main.js is only under DEFAULT_TARGET.
+STALE_PROJECT_MIRRORS = (
+    "/sdcard/Scripts/stayturgid",
+    "/storage/emulated/0/Scripts/stayturgid",
+    # AutoJs6 Chinese UI "Scripts" folder name (U+811A U+672C)
+    "/sdcard/\u811a\u672c/stayturgid",
+    "/storage/emulated/0/\u811a\u672c/stayturgid",
+)
+
 VERIFY_SHELL = (
     "test -f '{target}/lib/shizuku_shell.js' "
     "&& test -f '{target}/lib/comonitor.js' "
@@ -77,6 +88,13 @@ def deploy_project(run_command, device, repo_root, target=DEFAULT_TARGET, check_
     ok, msg = verify_deploy(run_command, device, target)
     if not ok:
         return False, msg, True
+
+    # Retire non-canonical / non-ASCII project mirrors (see STALE_PROJECT_MIRRORS).
+    for mirror in STALE_PROJECT_MIRRORS:
+        if os.path.normpath(mirror) == os.path.normpath(target):
+            continue
+        adb_shell.adb_shell(run_command, device, "rm -rf '%s'" % mirror)
+
     return True, "", True
 
 

--- a/docs/architecture/components/autojs6.md
+++ b/docs/architecture/components/autojs6.md
@@ -34,6 +34,21 @@ Mac soft-health (`fleet_health_monitor.py`) restarts `main.js` if
 `watchdog_stale`/`watchdog_missing` persists (~10 min), so a dead AutoJs6
 engine self-heals without a manual `start_watchdog.py`.
 
+## Project path (ASCII only)
+
+Canonical install path (all hosts):
+
+```text
+/sdcard/stayturgid/autojs6/main.js
+```
+
+Do **not** run or leave a stayturgid project under AutoJs6’s locale sample
+directories (`Scripts/` or Chinese **脚本/**). A stale tree at
+`/sdcard/脚本/stayturgid` on p7a produced `SyntaxError: Invalid quantifier` when
+opening that copy (2026-07-19). Deploy retires those mirrors
+(`STALE_PROJECT_MIRRORS` in `autojs6_deploy_util.py`). Policy:
+[coding-rules.md — Path and character set](../../coding-rules.md).
+
 ## Prerequisites
 
 1. AutoJs6 (`org.autojs.autojs6`) — `setup_autojs6.py` or Obtainium; fleet harden grants storage, `RUN_COMMAND`, notifications, battery unrestricted, unused-app off

--- a/docs/coding-rules.md
+++ b/docs/coding-rules.md
@@ -100,6 +100,26 @@ Do not hide a warning, force a zero exit code, weaken a test, or broadly catch a
 exception merely to make output green. Default summaries may group historical errors,
 but raw diagnostic detail must remain available.
 
+## Path and character set (ASCII-only for on-device paths)
+
+- **On-device filesystem paths must be ASCII-only** (English letters, digits, `/`,
+  `_`, `-`, `.`). No CJK or other non-ASCII code points in path segments we create
+  or deploy to.
+- Canonical AutoJs6 project path: **`/sdcard/stayturgid/autojs6`** (also reachable
+  as `/storage/emulated/0/stayturgid/autojs6`). Do **not** install or leave a
+  project under AutoJs6’s locale sample folders:
+  - English: `/sdcard/Scripts/stayturgid`
+  - Chinese UI: `/sdcard/脚本/stayturgid` (U+811A U+672C “Scripts”)
+- AutoJs6 Chinese builds open **脚本** as the default sample directory. A stale
+  copy there was the p7a `SyntaxError: Invalid quantifier` failure when running
+  an old `main.js` under a non-ASCII path (2026-07-19). Always open/run
+  `file:///sdcard/stayturgid/autojs6/main.js`.
+- Repo-relative paths and identifiers used as paths in code (`device/autojs6/…`,
+  inventory targets, deploy destinations) must also stay ASCII. Prose docs may
+  use Unicode punctuation (em dash, etc.); path **literals** must not.
+- After AutoJs6 project deploy, remove known stale mirrors (see
+  `STALE_PROJECT_MIRRORS` in `autojs6_deploy_util.py`).
+
 ## Device safety
 
 - Use `oneui-device` for the first live test unless the task explicitly depends on

--- a/docs/options.md
+++ b/docs/options.md
@@ -77,14 +77,14 @@ priority or symptom-triggered.
 
 ## Pick a track
 
-| Track                  | Focus                                              | Open IDs            | Typical risk                  |
-| ---------------------- | -------------------------------------------------- | ------------------- | ----------------------------- |
-| **A — Operational**    | Live deploy, human unblockers, current reliability | H1, H3, H5, 38, H14 | Low–High                      |
-| **B — Ansible-native** | Bootstrap APK automation follow-ups                | B63, B64            | Low–Medium                    |
-| **D — Reliability**    | Symptom-driven hardening                           | 43–45, A11          | Latent until triggered        |
-| **E — On-device LLM**  | shell-gpt escalation; incubator note               | 54                  | Medium (mis-scope risk)       |
-| **F — FIRERPA**        | gRPC backup channel enhancements                   | F1–F4               | Medium (future, core is done) |
-| **T — Tooling**        | Planned command-runner migration                   | T1                  | Low–Medium                    |
+| Track                  | Focus                                              | Open IDs       | Typical risk                  |
+| ---------------------- | -------------------------------------------------- | -------------- | ----------------------------- |
+| **A — Operational**    | Live deploy, human unblockers, current reliability | H1, H3, H5, 38 | Low–High                      |
+| **B — Ansible-native** | Bootstrap APK automation follow-ups                | B63, B64       | Low–Medium                    |
+| **D — Reliability**    | Symptom-driven hardening                           | 43–45          | Latent until triggered        |
+| **E — On-device LLM**  | shell-gpt escalation; incubator note               | 54             | Medium (mis-scope risk)       |
+| **F — FIRERPA**        | gRPC backup channel enhancements                   | F1–F4          | Medium (future, core is done) |
+| **T — Tooling**        | Planned command-runner migration                   | T1             | Low–Medium                    |
 
 Parked (not a track): Inferno/Styx → [docs/research/experiments/inferno-styx/](research/experiments/inferno-styx).
 
@@ -144,27 +144,12 @@ fleet does not depend on it day-to-day. Unlocks agent item **38**.
 Publish `stayturgid.*` collections to Ansible Galaxy. Public/irreversible for
 that version; only after H5 and a deliberate version bump review.
 
-#### H14 — Build & deploy AutoJs6 sticky-a11y rebind APK (agent + human) · Risk: **Medium** · Cross-ref: **A11**, AutoJs6 PR
+#### ~~H14 — Build & deploy AutoJs6 sticky-a11y rebind APK~~ · **Done 2026-07-19** · Cross-ref: **A11**
 
-**Problem (2026-07-19, s24):** Settings showed AutoJs6 Accessibility **ON**, but
-Task was empty and `main.js` bounced to the Accessibility screen. Operator fixed
-by **toggle OFF → ON**, then re-ran `main.js`. Root cause is primarily **Android**
-(enabled in settings ≠ service bound; AutoJs6 has a 2017 FIXME blaming Android).
-Secondary: AutoJs6 recovery UX; tertiary: stayturgid false-positive `a11y=up` from
-settings-list alone.
-
-**AutoJs6 fork PR:** https://github.com/djbclark/AutoJs6/pull/1
-(`fix/a11y-sticky-malfunction-rebind`) — when `isMalfunctioning()` (listed but
-not bound), `ensureService()` tries privileged `restartService()` then opens
-Accessibility with an OFF→ON toast. Cross-links stayturgid **A11** /
-https://github.com/djbclark/stayturgid/pull/29.
-
-**This item:** after AutoJs6#1 is reviewed/merged (or from the branch),
-**build the fleet-profile APK**, ship via Obtainium/fleet, and smoke on s24:
-force sticky if possible (or after a Termux freeze) and confirm rebind or clear
-OFF→ON prompt. Operator can do GUI smoke steps.
-
-**Stayturgid half is A11** / stayturgid#29 (detect + notify without `settings put`).
+AutoJs6#1 merged; fleet **debug17** arm64 installed on s24/p7a/hd8 (LeakCanary
+disabled). GitHub release asset upload may still be flaky (503). **Code-review
+carry-forward:** include AutoJs6 sticky-rebind + LeakCanary-off defaults +
+stayturgid#29 + ASCII-only path policy in the next project-level review.
 
 ---
 
@@ -175,20 +160,12 @@ Mac **soft health**: launchd `com.stayturgid.fleet-health` →
 Restarts stale AutoJs6 `main.js` when `watchdog_stale`/`watchdog_missing`.
 Reachability in `access-monitor`. Prefer health trail before 43–45.
 
-#### A11 — Sticky AutoJs6 a11y detect + notify (agent) · Risk: **Low** · Cross-ref: **H14**, AutoJs6 PR
+#### ~~A11 — Sticky AutoJs6 a11y detect + notify~~ · **Merged 2026-07-19** · stayturgid#29
 
-Land / finish fleet-side sticky-a11y observability (companion to AutoJs6 **H14**):
-
-- `guard.js` / `comonitor.js`: do not treat settings-list alone as bound when
-  `auto.service` is null; notify OFF→ON (`a11y-stale`).
-- `fleet_health`: issue `autojs6_a11y_stale` when `autojs6_a11y=ok` but watchdog
-  missing/stale; dashboard `HUMAN_ACTIONS` text for OFF→ON + run `main.js`.
-- `stayturgid_repair.py`: ACTION_REQUIRED when a11y listed but watchdog quiet ≥30m.
-- **Policy G3 unchanged:** never auto-`settings put` `enabled_accessibility_services`.
-
-**PR:** https://github.com/djbclark/stayturgid/pull/29
-(`fix/a11y-sticky-detect-notify`). Merge when green; deploy AutoJs6 project to
-phones. Pair with **H14** / AutoJs6#1 APK for full rebind.
+Shipped on master (`199ea20`). Companion AutoJs6#1 + fleet debug APK builds 16–17
+(LeakCanary off on 17). **Code-review carry-forward (next project review):**
+sticky a11y detect/notify, catastrophic-alert 2h window, Fire OS skip-catastrophic,
+ASCII-only AutoJs6 paths / `STALE_PROJECT_MIRRORS` (p7a `脚本/` SyntaxError).
 
 #### 43 — AutoJs6 WorkManager (agent) · Risk: **Latent / Low until upstream**
 

--- a/tests/python/test_ascii_paths.py
+++ b/tests/python/test_ascii_paths.py
@@ -1,0 +1,63 @@
+"""ASCII-only path policy for on-device deploy targets and AutoJs6 project code."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(
+    0,
+    str(REPO / "ansible_collections" / "stayturgid" / "android_common" / "plugins" / "module_utils"),
+)
+import autojs6_deploy_util as util  # noqa: E402
+
+AUTOJS6 = REPO / "device" / "autojs6"
+NON_ASCII = re.compile(r"[^\x00-\x7F]")
+# Path-like string literals (absolute or repo-ish) — must be ASCII if present.
+PATH_LITERAL = re.compile(
+    r"""(?x)
+    (?:['"])
+    (
+      /sdcard/[^'"]+
+      | /storage/emulated/[^'"]+
+      | /data/data/[^'"]+
+      | \./device/[^'"]+
+      | stayturgid/[a-zA-Z0-9_./-]+
+    )
+    (?:['"])
+    """
+)
+
+
+def test_default_autojs6_target_is_ascii():
+    assert util.DEFAULT_TARGET == "/sdcard/stayturgid/autojs6"
+    assert not NON_ASCII.search(util.DEFAULT_TARGET)
+    for mirror in util.STALE_PROJECT_MIRRORS:
+        # Mirrors may document the Chinese locale folder for removal only;
+        # the deploy *target* must stay ASCII.
+        assert mirror != util.DEFAULT_TARGET
+
+
+def test_autojs6_project_source_filenames_ascii():
+    for path in AUTOJS6.rglob("*"):
+        if path.is_file() and ".git" not in path.parts:
+            assert not NON_ASCII.search(path.name), "non-ASCII filename: %s" % path
+
+
+def test_autojs6_js_path_literals_ascii():
+    """Hard-coded on-device paths in JS must not introduce non-ASCII segments."""
+    bad: list[str] = []
+    for path in AUTOJS6.rglob("*.js"):
+        text = path.read_text(encoding="utf-8")
+        for m in PATH_LITERAL.finditer(text):
+            lit = m.group(1)
+            if NON_ASCII.search(lit):
+                bad.append("%s: %s" % (path.relative_to(REPO), lit))
+    assert bad == [], "non-ASCII path literals:\n  " + "\n  ".join(bad)
+
+
+def test_engine_guard_main_is_canonical():
+    text = (AUTOJS6 / "lib" / "engine_guard.js").read_text(encoding="utf-8")
+    assert 'MAIN = "/sdcard/stayturgid/autojs6/main.js"' in text


### PR DESCRIPTION
## Summary

**p7a 2026-07-19:** `SyntaxError: Invalid quantifier` when running `main.js` from AutoJs6 file browser under the Chinese-locale sample folder:

`/storage/emulated/0/脚本/stayturgid/` (脚本 = Scripts)

That tree was a **stale Jul 5 copy** (old main.js/lib), not the canonical project. Rhino/AutoJs6 choke on that path/copy combo.

### Live fix already applied on devices

- Removed `/sdcard/脚本/stayturgid` (p7a) and `/sdcard/Scripts/stayturgid` mirrors (s24/hd8)
- Launched `file:///sdcard/stayturgid/autojs6/main.js` — p7a watchdog cycle green (`a11y=up`)

### Code changes

- `autojs6_deploy_util.STALE_PROJECT_MIRRORS` + `rm -rf` after every project deploy
- `docs/coding-rules.md` — ASCII-only on-device path policy
- `docs/architecture/components/autojs6.md` — canonical path section
- `tests/python/test_ascii_paths.py` — filenames + path literals in `device/autojs6`
- options: mark H14/A11 done; **code-review carry-forward** listed for next project review

### Survey

Repo path **filenames** under product trees are ASCII. Docs use Unicode punctuation (em dash) in prose only — allowed. On-device path **literals** in AutoJs6 JS are ASCII (`/sdcard/stayturgid/...`).

## Test plan

- [x] p7a main.js from ASCII path after removing 脚本/
- [x] `pytest tests/python/test_ascii_paths.py` + autojs6 deploy units
- [ ] CI green; merge; next project code review includes this + stayturgid#29 + AutoJs6#1