### PR TITLE
fix: sticky a11y candidate is degraded, not FAILED

### DIFF
--- a/device/autojs6/lib/comonitor.js
+++ b/device/autojs6/lib/comonitor.js
@@ -44,17 +44,23 @@ function probeA11y(split) {
   var list = (r.result || "").trim();
   var listed = !!(list && list !== "null" && list.indexOf(A11Y_SVC) >= 0);
 
-  // Sticky: Settings ON, service not bound (Android a11y lifecycle bug).
+  // Sticky candidate: Settings ON but auto.service null. On some builds/devices
+  // auto.service flickers null even while the engine is mid-cycle and listed
+  // (s24 noise after debug APK). Treat as degraded, not hard FAILED, and notify
+  // at most once per engine process so STATUS stays operational for health scrapes.
   if (listed && typeof auto !== "undefined") {
     try {
       if (!auto.service) {
-        log.append("[comonitor] A11Y STICKY — Settings lists AutoJs6 but service not bound; toggle OFF then ON");
-        notify.show(
-          "AutoJs6 accessibility stuck (ON but not bound)",
-          "Open Settings > Accessibility > AutoJs6: turn OFF then ON again, then re-run main.js.",
-          "a11y-stale",
-        );
-        return "FAILED";
+        if (!probeA11y._stickyLogged) {
+          probeA11y._stickyLogged = true;
+          log.append("[comonitor] A11Y STICKY candidate — listed ON but auto.service null (notify once; not FAILED)");
+          notify.show(
+            "AutoJs6 accessibility may be sticky",
+            "If Task is empty or UI automations fail: Settings → Accessibility → AutoJs6 OFF then ON, then re-run main.js.",
+            "a11y-stale",
+          );
+        }
+        return "degraded";
       }
     } catch (e2) {
       /* fall through */
@@ -261,8 +267,12 @@ function run(profile, opts) {
       "Co-monitor could not re-enable accessibility — enable AutoJs6 a11y.",
       "a11y-blocked",
     );
-  } else if (a11y === "up" || a11y === "repaired") {
+  } else if (a11y === "up" || a11y === "repaired" || a11y === "degraded") {
+    // degraded = sticky candidate already notified once under a11y-stale
     notify.clear("a11y-blocked");
+    if (a11y === "up" || a11y === "repaired") {
+      notify.clear("a11y-stale");
+    }
   }
 
   if (shellProbe.port === "open" || shellProbe.port === "skip") {

--- a/tests/js/comonitor.test.js
+++ b/tests/js/comonitor.test.js
@@ -82,12 +82,11 @@ ok(typeof comonitor.probeA11y === "function", "probeA11y exported");
 
 var profile = { id: "oneui-device", sdRoot: "/sdcard/stayturgid", notifyTag: "" };
 
-// Sticky: auto present, service null, settings lists AutoJs6 → FAILED (not false "up")
+// Sticky candidate: auto present, service null, settings lists AutoJs6 → degraded (not hard FAILED)
 global.auto = { service: null };
 var sticky = comonitor.run(profile, { force: true, reason: "sticky" });
-ok(sticky !== null && sticky.a11y === "FAILED",
-    "comonitor reports a11y FAILED when settings list ON but auto.service null (sticky)");
-
+ok(sticky !== null && sticky.a11y === "degraded",
+    "comonitor reports a11y degraded when settings list ON but auto.service null (sticky candidate)");
 // Bound: auto.service truthy → up
 global.auto = { service: {} };
 var result = comonitor.run(profile, { force: true, reason: "test" });


### PR DESCRIPTION
## Summary

s24 co-monitor logged `a11y=FAILED` every cycle when `auto.service` was null even though Settings listed AutoJs6 and main.js was running. Treat that sticky *candidate* as `degraded`, notify once per process, do not hard-fail STATUS.

## Test plan
- [x] node tests/js/comonitor.test.js
- [ ] CI; merge; scp comonitor.js to fleet