### PR TITLE
REVIEW-1: fix identity drift comment + example lint resolution

### DIFF
--- a/control/bin/fleet_health_monitor.py
+++ b/control/bin/fleet_health_monitor.py
@@ -349,8 +349,8 @@ def maybe_verify_hd8_google_closeout(name: str) -> None:
 
 # Only count catastrophic/headless failures inside this window. Counting the
 # entire log (or last-50 grep with no time filter) re-fired Mac notifications
-# forever after a resolved CLOSED_NO_SHELL incident (p7a 2026-07-19: 55 historical
-# lines → alert every 5 min while fleet was healthy).
+# forever after a resolved CLOSED_NO_SHELL incident (2026-07-19: one fleet phone
+# had 55 historical lines → alert every 5 min while fleet was healthy).
 CATASTROPHIC_ALERT_WINDOW_SEC = 2 * 60 * 60
 CATASTROPHIC_ALERT_MIN = 3
 CATASTROPHIC_NOTIFY_COOLDOWN_SEC = 6 * 60 * 60

--- a/examples/consumer-fdroid-only/ansible.cfg
+++ b/examples/consumer-fdroid-only/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 inventory = inventory/hosts.yml
-collections_path = ./collections:../../ansible_collections
+roles_path = ../../ansible/roles
+collections_path = ./collections:../../.ansible/collections:../../ansible_collections
 host_key_checking = False
 
 [ssh_connection]

--- a/examples/consumer-full-fleet/ansible.cfg
+++ b/examples/consumer-full-fleet/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 inventory = inventory/hosts.yml
-collections_path = ./collections:../../ansible_collections
+roles_path = ../../ansible/roles
+collections_path = ./collections:../../.ansible/collections:../../ansible_collections
 host_key_checking = False
 interpreter_python = auto_silent
 

--- a/examples/consumer-termux-only/ansible.cfg
+++ b/examples/consumer-termux-only/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 inventory = inventory/hosts.yml
-collections_path = ./collections:../../ansible_collections
+roles_path = ../../ansible/roles
+collections_path = ./collections:../../.ansible/collections:../../ansible_collections
 host_key_checking = False
 interpreter_python = auto_silent
 


### PR DESCRIPTION
Found by REVIEW-1 whole-repo review.

1. `just check` was failing on master: validate-identity flags device alias in a comment added by #29 (control/bin/fleet_health_monitor.py). Reworded generically.
2. `just lint` failed locally: examples/consumer-full-fleet ansible-lint follows the import into ansible/playbooks/site.yml but the example ansible.cfg had no roles_path and a collections_path that excluded the repo's .ansible/collections (where the lint recipe installs ansible.posix). Added both, all three examples, consistently.

Full local suite green: just syntax && just check && just test && just lint → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)