### PR TITLE
site-contract: fix must-fix findings from project-level final review

### DIFF
--- a/ansible/roles/serverapp_openobserve/tasks/main.yml
+++ b/ansible/roles/serverapp_openobserve/tasks/main.yml
@@ -99,6 +99,7 @@
     dest: "{{ serverapp_openobserve_plist_path }}"
     mode: "0600"
   register: _oo_plist
+  no_log: true
 
 - name: Probe whether site-namespace openobserve label is loaded
   ansible.builtin.shell: |

--- a/ansible/roles/serverapp_vector/tasks/main.yml
+++ b/ansible/roles/serverapp_vector/tasks/main.yml
@@ -137,6 +137,7 @@
     dest: "{{ serverapp_vector_plist_path }}"
     mode: "0600"
   register: _vector_plist
+  no_log: true
 
 - name: Probe whether site-namespace vector label is loaded
   ansible.builtin.shell: |

--- a/control/site_contract/serverapps.py
+++ b/control/site_contract/serverapps.py
@@ -160,9 +160,10 @@ def _has_generated_header(path: Path) -> bool:
     return GENERATED_MARKER in head or '"_generated"' in head
 
 
-def _is_under_our_prefixes(path: Path, site_ns: str) -> bool:
+def _is_under_our_prefixes(path: Path, site_ns: str, *, home: Path | None = None) -> bool:
     resolved = path.resolve()
-    prefixes = list(OUR_CONFIG_PREFIXES) + [Path.home() / ".config" / site_ns]
+    home_path = home if home is not None else Path.home()
+    prefixes = list(OUR_CONFIG_PREFIXES) + [home_path / ".config" / site_ns]
     for prefix in prefixes:
         try:
             resolved.relative_to(prefix.resolve())
@@ -217,11 +218,12 @@ def load_caddy_public_hostname(site_dir: Path, site_map: SiteMap) -> str | None:
     return None
 
 
-def _caddy_detect_paths(site_map: SiteMap) -> list[Path]:
+def _caddy_detect_paths(site_map: SiteMap, *, home: Path | None = None) -> list[Path]:
     app = site_map.serverapps.get("caddy")
     if app and app.config is not None:
         return [app.config]
-    paths = [Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "caddy" / "Caddyfile"]
+    home_path = home if home is not None else Path.home()
+    paths = [Path(os.environ.get("XDG_CONFIG_HOME", home_path / ".config")) / "caddy" / "Caddyfile"]
     paths.append(Path("/opt/homebrew/etc/Caddyfile"))
     # Dedup preserving order
     seen: set[Path] = set()
@@ -238,7 +240,7 @@ def _caddy_detect_paths(site_map: SiteMap) -> list[Path]:
     return out
 
 
-def _vector_detect_paths(site_map: SiteMap) -> list[Path]:
+def _vector_detect_paths(site_map: SiteMap, *, home: Path | None = None) -> list[Path]:
     """§5.3 foreign detect: existing vector.yaml / vector.toml service config.
 
     Default paths are XDG only. Homebrew ships a sample at
@@ -250,7 +252,8 @@ def _vector_detect_paths(site_map: SiteMap) -> list[Path]:
     app = site_map.serverapps.get("vector")
     if app and app.config is not None:
         return [app.config]
-    xdg = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+    home_path = home if home is not None else Path.home()
+    xdg = Path(os.environ.get("XDG_CONFIG_HOME", home_path / ".config"))
     paths = [
         xdg / "vector" / "vector.yaml",
         xdg / "vector" / "vector.toml",
@@ -311,6 +314,7 @@ def resolve_app_mode(
     *,
     site_map: SiteMap,
     site_ns: str,
+    home: Path | None = None,
 ) -> tuple[AppMode, str]:
     """Deterministic mode selection (§1.2): site-map → foreign detect → own."""
     mapping = site_map.serverapps.get(app)
@@ -321,20 +325,20 @@ def resolve_app_mode(
         return mode, "site-map"  # type: ignore[return-value]
 
     if app == "caddy":
-        for path in _caddy_detect_paths(site_map):
+        for path in _caddy_detect_paths(site_map, home=home):
             if not path.is_file():
                 continue
-            if _is_under_our_prefixes(path, site_ns):
+            if _is_under_our_prefixes(path, site_ns, home=home):
                 continue
             if _has_generated_header(path):
                 continue
             return "inject", "detect"
 
     if app == "vector":
-        for path in _vector_detect_paths(site_map):
+        for path in _vector_detect_paths(site_map, home=home):
             if not path.is_file():
                 continue
-            if _is_under_our_prefixes(path, site_ns):
+            if _is_under_our_prefixes(path, site_ns, home=home):
                 continue
             if _has_generated_header(path):
                 continue
@@ -343,23 +347,23 @@ def resolve_app_mode(
     if app == "openobserve":
         # §5.3: single-owner; inject if a foreign unit/config is present.
         # Legacy com.stayturgid.* and com.<site_ns>.* are not foreign.
-        for path in _openobserve_detect_paths(site_map, site_ns=site_ns):
+        for path in _openobserve_detect_paths(site_map, site_ns=site_ns, home=home):
             if path.is_file():
                 return "inject", "detect"
 
     if app == "victoriametrics":
         # §5.3: single-owner; inject = reuse registry endpoint only.
-        for path in _victoriametrics_detect_paths(site_map, site_ns=site_ns):
+        for path in _victoriametrics_detect_paths(site_map, site_ns=site_ns, home=home):
             if path.is_file():
                 return "inject", "detect"
 
     if app == "grafana":
-        for path in _grafana_detect_paths(site_map, site_ns=site_ns):
+        for path in _grafana_detect_paths(site_map, site_ns=site_ns, home=home):
             if path.is_file():
                 return "inject", "detect"
 
     if app == "olivetin":
-        for path in _olivetin_detect_paths(site_map, site_ns=site_ns):
+        for path in _olivetin_detect_paths(site_map, site_ns=site_ns, home=home):
             if path.is_file():
                 return "inject", "detect"
 
@@ -367,7 +371,14 @@ def resolve_app_mode(
 
 
 def _import_line_covers(caddyfile: Path, fragment_dir: Path) -> bool:
-    """True if Caddyfile has an import line covering fragment_dir (glob ok)."""
+    """True if Caddyfile has an import line covering fragment_dir (glob ok).
+
+    Every accepted form is anchored so ``fragment_dir`` must be followed by a
+    literal ``/`` (or be the exact final path segment) — a naive substring
+    check would also accept a sibling directory whose name happens to start
+    with the same characters (e.g. fragment_dir ``/etc/caddy.d`` wrongly
+    "covered" by an import of ``/etc/caddy.d-other/*.caddy``).
+    """
     if not caddyfile.is_file():
         return False
     try:
@@ -381,18 +392,7 @@ def _import_line_covers(caddyfile: Path, fragment_dir: Path) -> bool:
         re.compile(rf"^\s*import\s+{re.escape(frag)}/\*\s*$", re.MULTILINE),
         re.compile(rf"^\s*import\s+{re.escape(frag)}/[\w.-]+\.caddy\s*$", re.MULTILINE),
     ]
-    # Also accept relative or unexpanded forms containing the path suffix.
-    for line in text.splitlines():
-        stripped = line.strip()
-        if not stripped.startswith("import "):
-            continue
-        target = stripped[len("import ") :].strip()
-        if frag in target and (target.endswith("*.caddy") or target.endswith("/*") or target.endswith(".caddy")):
-            return True
-        for pat in patterns:
-            if pat.search(line):
-                return True
-    return False
+    return any(pattern.search(text) for pattern in patterns)
 
 
 def _suggested_import_line(fragment_dir: Path) -> str:
@@ -400,8 +400,33 @@ def _suggested_import_line(fragment_dir: Path) -> str:
 
 
 def _vector_unit_includes_fragments(fragment_dir: Path, home: Path) -> bool:
-    """True if a known launchd plist already passes --config for fragment_dir."""
-    frag = str(fragment_dir.resolve())
+    """True if a known launchd plist already passes --config for fragment_dir.
+
+    A launchd ``ProgramArguments`` array renders each argument as its own
+    ``<string>`` element, so ``--config`` and its value are never on the same
+    line/adjacent text — this matches consecutive ``<string>--config</string>``
+    / ``<string><value></string>`` pairs and checks the *value* is fragment_dir
+    itself or a path under it. The previous implementation just checked
+    whether the fragment_dir string appeared anywhere in the plist at all
+    (no association with ``--config``, no path-boundary check), which both
+    false-positived on any incidental text match and false-positived on a
+    sibling directory with a name-prefix collision (e.g. fragment_dir
+    ``/etc/vector.d`` "covered" by an unrelated ``--config
+    /etc/vector.d-other/foo.yaml``).
+    """
+    frag = fragment_dir.resolve()
+    pair_pattern = re.compile(r"<string>\s*--config\s*</string>\s*<string>\s*([^<]+?)\s*</string>")
+
+    def _covers(text: str) -> bool:
+        for match in pair_pattern.finditer(text):
+            try:
+                value = Path(match.group(1)).resolve()
+            except OSError:
+                continue
+            if value == frag or value.is_relative_to(frag):
+                return True
+        return False
+
     candidates = [
         home / "Library" / "LaunchAgents" / "com.stayturgid.vector.plist",
         Path("/Library/LaunchAgents/com.stayturgid.vector.plist"),
@@ -424,7 +449,7 @@ def _vector_unit_includes_fragments(fragment_dir: Path, home: Path) -> bool:
             text = path.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
-        if frag in text:
+        if _covers(text):
             return True
     return False
 
@@ -484,7 +509,7 @@ def plan_caddy(
     product_version: str | None = None,
 ) -> AppPlan:
     """Build the plan for the caddy adapter only."""
-    mode, source = resolve_app_mode("caddy", site_map=site_map, site_ns=site_ns)
+    mode, source = resolve_app_mode("caddy", site_map=site_map, site_ns=site_ns, home=home)
     plan = AppPlan(app="caddy", mode=mode, source=source)
     home_path = home if home is not None else Path.home()
     config_dir = home_path / ".config" / site_ns / "caddy"
@@ -519,8 +544,12 @@ def plan_caddy(
     if mode == "own":
         # Site-map forced own against a foreign config → exit 2.
         if source == "site-map":
-            for path in _caddy_detect_paths(site_map):
-                if path.is_file() and not _is_under_our_prefixes(path, site_ns) and not _has_generated_header(path):
+            for path in _caddy_detect_paths(site_map, home=home_path):
+                if (
+                    path.is_file()
+                    and not _is_under_our_prefixes(path, site_ns, home=home_path)
+                    and not _has_generated_header(path)
+                ):
                     # Only refuse if the foreign path is the site-map config target
                     # and differs from our own destination.
                     app_map = site_map.serverapps.get("caddy")
@@ -616,8 +645,8 @@ def plan_caddy(
 
     # Detect the foreign Caddyfile for import-line verification.
     foreign: Path | None = None
-    for path in _caddy_detect_paths(site_map):
-        if path.is_file() and not _is_under_our_prefixes(path, site_ns):
+    for path in _caddy_detect_paths(site_map, home=home_path):
+        if path.is_file() and not _is_under_our_prefixes(path, site_ns, home=home_path):
             foreign = path
             break
     app_map = site_map.serverapps.get("caddy")
@@ -627,7 +656,7 @@ def plan_caddy(
     if foreign is None or not foreign.is_file():
         raise ServerAppsError(
             "caddy inject mode selected but no foreign Caddyfile found at detect paths "
-            f"({', '.join(str(p) for p in _caddy_detect_paths(site_map))})"
+            f"({', '.join(str(p) for p in _caddy_detect_paths(site_map, home=home_path))})"
         )
 
     if not _import_line_covers(foreign, fragment_dir):
@@ -732,7 +761,7 @@ def plan_vector(
     product_version: str | None = None,
 ) -> AppPlan:
     """Build the plan for the vector adapter (clone of plan_caddy; multi --config)."""
-    mode, source = resolve_app_mode("vector", site_map=site_map, site_ns=site_ns)
+    mode, source = resolve_app_mode("vector", site_map=site_map, site_ns=site_ns, home=home)
     plan = AppPlan(app="vector", mode=mode, source=source)
     home_path = home if home is not None else Path.home()
     config_dir = home_path / ".config" / site_ns / "vector"
@@ -764,8 +793,12 @@ def plan_vector(
 
     if mode == "own":
         if source == "site-map":
-            for path in _vector_detect_paths(site_map):
-                if path.is_file() and not _is_under_our_prefixes(path, site_ns) and not _has_generated_header(path):
+            for path in _vector_detect_paths(site_map, home=home_path):
+                if (
+                    path.is_file()
+                    and not _is_under_our_prefixes(path, site_ns, home=home_path)
+                    and not _has_generated_header(path)
+                ):
                     app_map = site_map.serverapps.get("vector")
                     if app_map and app_map.config is not None and path.resolve() == app_map.config.resolve():
                         if path.resolve() != base_config.resolve():
@@ -858,8 +891,8 @@ def plan_vector(
         )
 
     foreign: Path | None = None
-    for path in _vector_detect_paths(site_map):
-        if path.is_file() and not _is_under_our_prefixes(path, site_ns):
+    for path in _vector_detect_paths(site_map, home=home_path):
+        if path.is_file() and not _is_under_our_prefixes(path, site_ns, home=home_path):
             foreign = path
             break
     app_map = site_map.serverapps.get("vector")
@@ -869,7 +902,7 @@ def plan_vector(
     if foreign is None or not foreign.is_file():
         raise ServerAppsError(
             "vector inject mode selected but no foreign vector config found at detect paths "
-            f"({', '.join(str(p) for p in _vector_detect_paths(site_map))})"
+            f"({', '.join(str(p) for p in _vector_detect_paths(site_map, home=home_path))})"
         )
 
     # Include mechanism: unit must pass --config for each product fragment (§5.3).
@@ -978,7 +1011,7 @@ def plan_openobserve(
     keeps data dir at ~/.local/share/openobserve/data.
     """
     del force_generated  # no inject fragment copies for openobserve
-    mode, source = resolve_app_mode("openobserve", site_map=site_map, site_ns=site_ns)
+    mode, source = resolve_app_mode("openobserve", site_map=site_map, site_ns=site_ns, home=home)
     plan = AppPlan(app="openobserve", mode=mode, source=source)
     home_path = home if home is not None else Path.home()
     # Data dir is intentionally NOT under site_ns — must match live path.
@@ -1226,7 +1259,7 @@ def plan_victoriametrics(
     Own mode: ansible role brew-if-absent + site-namespace unit on 8428.
     """
     del force_generated
-    mode, source = resolve_app_mode("victoriametrics", site_map=site_map, site_ns=site_ns)
+    mode, source = resolve_app_mode("victoriametrics", site_map=site_map, site_ns=site_ns, home=home)
     plan = AppPlan(app="victoriametrics", mode=mode, source=source)
     home_path = home if home is not None else Path.home()
     config_dir = home_path / ".config" / site_ns / "victoriametrics"
@@ -1354,7 +1387,7 @@ def plan_grafana(
     into the user's provisioning dirs (site-map fragment_dir), or refuse when
     missing include/fragment_dir.
     """
-    mode, source = resolve_app_mode("grafana", site_map=site_map, site_ns=site_ns)
+    mode, source = resolve_app_mode("grafana", site_map=site_map, site_ns=site_ns, home=home)
     plan = AppPlan(app="grafana", mode=mode, source=source)
     home_path = home if home is not None else Path.home()
     config_dir = home_path / ".config" / site_ns / "grafana"
@@ -1558,7 +1591,7 @@ def plan_olivetin(
     Inject is not supported (config is a projection, single writer).
     """
     del force_generated
-    mode, source = resolve_app_mode("olivetin", site_map=site_map, site_ns=site_ns)
+    mode, source = resolve_app_mode("olivetin", site_map=site_map, site_ns=site_ns, home=home)
     plan = AppPlan(app="olivetin", mode=mode, source=source)
     home_path = home if home is not None else Path.home()
     config_dir = home_path / ".config" / site_ns / "olivetin"
@@ -1665,7 +1698,7 @@ def plan_landing(
     with a verify note if forced via site-map.
     """
     del force_generated
-    mode, source = resolve_app_mode("landing", site_map=site_map, site_ns=site_ns)
+    mode, source = resolve_app_mode("landing", site_map=site_map, site_ns=site_ns, home=home)
     plan = AppPlan(app="landing", mode=mode, source=source)
     home_path = home if home is not None else Path.home()
     logs_dir = home_path / ".config" / site_ns / "logs"

--- a/control/site_contract/site_init.py
+++ b/control/site_contract/site_init.py
@@ -17,10 +17,10 @@ import os
 import re
 import sys
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Literal, Sequence
 
-from control.site_contract.site_map import SiteMap, SiteMapError, load_site_map
+from control.site_contract.site_map import SiteMap, SiteMapError, is_physically_within, load_site_map
 
 try:
     from jinja2 import Environment, StrictUndefined
@@ -141,9 +141,12 @@ def _reject_nested_in_product(destination: Path, product_root: Path) -> None:
             f"destination {dest} is the product checkout; a private site dir "
             "must not live inside (or as) the public product tree (ADR 005)"
         )
+    nested = True
     try:
         dest.relative_to(product)
     except ValueError:
+        nested = is_physically_within(dest, product)
+    if not nested:
         return
     raise SiteInitError(
         f"destination {dest} is nested inside the product checkout {product}; "
@@ -244,6 +247,26 @@ def build_plan(
     duplicate_paths = sorted({path for path in relative_paths if relative_paths.count(path) > 1})
     if duplicate_paths:
         raise SiteInitError("site map makes scaffold files collide at: " + ", ".join(duplicate_paths))
+
+    # A site-map remap can also make one planned file's path double as an
+    # ancestor directory of another planned file (e.g. `paths.inventory:
+    # group_vars` collides with the derived `group_vars/.gitkeep`) — that
+    # passes the exact-string dedup above but still crashes apply_plan()
+    # mid-write, since one path can't be both a file and a directory.
+    path_set = set(relative_paths)
+    type_collisions = sorted(
+        {
+            path
+            for path in relative_paths
+            for ancestor in PurePosixPath(path).parents
+            if str(ancestor) != "." and str(ancestor) in path_set
+        }
+    )
+    if type_collisions:
+        raise SiteInitError(
+            "site map makes scaffold files collide (one path is used as both a file and a directory): "
+            + ", ".join(type_collisions)
+        )
 
     return InitPlan(
         site_name=name,

--- a/control/site_contract/site_map.py
+++ b/control/site_contract/site_map.py
@@ -7,6 +7,7 @@ here.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -46,6 +47,29 @@ ALLOWED_SERVERAPP_MODES = frozenset({"own", "inject", "off"})
 
 class SiteMapError(Exception):
     """Invalid or unsafe ``site-map.yml`` input."""
+
+
+def is_physically_within(path: Path, root: Path) -> bool:
+    """True if ``path`` shares on-disk identity with ``root`` or a descendant of it.
+
+    Case-insensitive filesystems (default macOS APFS) can make a path that
+    differs from ``root`` only in letter case resolve to the exact same
+    physical directory without ever failing a string-based ``relative_to()``
+    check, so this compares inode identity (``os.path.samestat``) for every
+    existing ancestor of ``path`` instead of trusting path text alone.
+    """
+    try:
+        root_stat = root.stat()
+    except OSError:
+        return False
+    for candidate in (path, *path.parents):
+        try:
+            candidate_stat = candidate.stat()
+        except OSError:
+            continue
+        if os.path.samestat(candidate_stat, root_stat):
+            return True
+    return False
 
 
 @dataclass(frozen=True)
@@ -93,17 +117,19 @@ def _resolve_contract_path(*, key: str, value: Any, site_dir: Path, product_root
             f"paths.{key} escapes the site directory {site_dir}: {value!r} resolves to {resolved}"
         ) from exc
     generated_root = (site_dir / "generated" / PRODUCT).resolve()
+    escapes_generated = True
     try:
         resolved.relative_to(generated_root)
     except ValueError:
-        pass
-    else:
+        escapes_generated = is_physically_within(resolved, generated_root)
+    if escapes_generated:
         raise SiteMapError(f"paths.{key} resolves inside site-sync's owned generated/{PRODUCT}/ area: {resolved}")
+    nested_in_product = True
     try:
         resolved.relative_to(product_root)
     except ValueError:
-        pass
-    else:
+        nested_in_product = is_physically_within(resolved, product_root)
+    if nested_in_product:
         raise SiteMapError(
             f"paths.{key} resolves inside the public product checkout {product_root} (ADR 005): {resolved}"
         )
@@ -117,9 +143,12 @@ def _resolve_serverapp_path(*, app: str, key: str, value: Any, site_dir: Path, p
     if not candidate.is_absolute():
         candidate = site_dir / candidate
     resolved = candidate.resolve()
+    nested_in_product = True
     try:
         resolved.relative_to(product_root)
     except ValueError:
+        nested_in_product = is_physically_within(resolved, product_root)
+    if not nested_in_product:
         return resolved
     raise SiteMapError(
         f"serverapps.{app}.{key} resolves inside the public product checkout {product_root} (ADR 005): {resolved}"

--- a/control/site_contract/site_sync.py
+++ b/control/site_contract/site_sync.py
@@ -16,6 +16,7 @@ import argparse
 import hashlib
 import json
 import os
+import shlex
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -358,18 +359,63 @@ def lockfile_hashes(lockfile: dict[str, Any] | None) -> dict[str, str]:
     return out
 
 
+def _json_string_escape(value: object) -> str:
+    """Escape ``value`` for embedding inside an existing double-quoted string
+    literal in a rendered fragment (JSON, or a YAML double-quoted scalar —
+    JSON's escape set is a strict subset of YAML's double-quoted escapes, so
+    this is safe for both). Returns only the escaped content, without the
+    surrounding quote characters, so it drops straight into templates that
+    already wrap the interpolation in ``"..."``.
+
+    Inventory-controlled values (host.name, host.device_label) are rendered
+    into these fragments unescaped otherwise, which lets a crafted host name
+    containing a quote inject or corrupt structure in the generated file.
+    """
+    return json.dumps(str(value))[1:-1]
+
+
+def _shell_quote(value: object) -> str:
+    """POSIX-shell-quote ``value`` for embedding as a single argument inside
+    a rendered ``shell:`` block (e.g. OliveTin actions). Inventory-controlled
+    values (host.name) are otherwise spliced unquoted into a command line,
+    which lets a host name containing shell metacharacters break out of the
+    intended single argument.
+    """
+    return shlex.quote(str(value))
+
+
 def _render_template(template_path: Path, context: dict[str, Any]) -> bytes:
     environment = Environment(
         undefined=StrictUndefined,
         keep_trailing_newline=True,
         autoescape=False,
     )
+    environment.filters["json_string_escape"] = _json_string_escape
+    environment.filters["shell_quote"] = _shell_quote
     text = template_path.read_text(encoding="utf-8")
     try:
         rendered = environment.from_string(text).render(**context)
     except Exception as exc:  # StrictUndefined (e.g. unregistered port) → loud exit 1
         raise SiteSyncError(f"cannot render sync template {template_path.name!r}: {exc}") from exc
     return rendered.encode("utf-8")
+
+
+def _assert_rendered_content_parses(entry_path: str, content: bytes) -> None:
+    """Defense in depth: a rendered fragment must parse as the format its
+    extension promises. Catches template-interpolation bugs (e.g. an
+    inventory value that breaks JSON/YAML structure despite escaping) before
+    a broken file is written to the committed generated/ area."""
+    text = content.decode("utf-8")
+    if entry_path.endswith(".json"):
+        try:
+            json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise SiteSyncError(f"rendered {entry_path!r} is not valid JSON: {exc}") from exc
+    elif entry_path.endswith((".yaml", ".yml")):
+        try:
+            yaml.safe_load(text)
+        except yaml.YAMLError as exc:
+            raise SiteSyncError(f"rendered {entry_path!r} is not valid YAML: {exc}") from exc
 
 
 def _assert_projection_closed_set(entry_path: str, template_path: Path) -> None:
@@ -622,6 +668,7 @@ def build_plan(
             site_map=site_map,
         )
         content = _render_template(template_path, context)
+        _assert_rendered_content_parses(entry.path, content)
         digest = _sha256_bytes(content)
         new_hashes.append((entry.path, digest))
 
@@ -728,12 +775,21 @@ def build_plan(
             raise SiteSyncError(f"lockfile lists path outside {GENERATED_PREFIX!r}: {locked_path!r}")
         target = destination / locked_path
         if target.exists() and target.is_file():
+            # Same drift check the overwrite path runs above: a file that
+            # left the manifest but was hand-edited since the last sync must
+            # not be silently destroyed — refuse (exit 2) unless
+            # --force-generated, exactly like acceptance test 3 requires for
+            # overwrites.
+            on_disk_hash = _sha256_bytes(target.read_bytes())
+            lock_hash = known_hashes.get(locked_path)
+            drifted = lock_hash is not None and on_disk_hash != lock_hash
             planned.append(
                 PlannedFile(
                     relative_path=locked_path,
                     content=None,
                     action="delete",
                     sha256=None,
+                    drift=drifted and not force_generated,
                 )
             )
         # If already gone, nothing to do (no skip row — not in new manifest).
@@ -848,8 +904,8 @@ def apply_plan(plan: SyncPlan, *, force_generated: bool = False) -> None:
     if drifts and not force_generated:
         paths = ", ".join(item.relative_path for item in drifts)
         raise SiteSyncError(
-            f"refusing to overwrite drifted generated file(s): {paths} "
-            "(re-run with --force-generated to overwrite inside generated/ only)",
+            f"refusing to modify or delete drifted generated file(s): {paths} "
+            "(re-run with --force-generated to overwrite/delete inside generated/ only)",
             exit_code=EXIT_WOULD_OVERWRITE,
         )
 
@@ -1096,8 +1152,8 @@ def run_site_sync(
             if plan.drifts and not force:
                 drift_paths = ", ".join(item.relative_path for item in plan.drifts)
                 print(
-                    f"error: would overwrite drifted generated file(s): {drift_paths} "
-                    "(re-run with --force-generated to overwrite inside generated/ only)",
+                    f"error: would modify or delete drifted generated file(s): {drift_paths} "
+                    "(re-run with --force-generated to overwrite/delete inside generated/ only)",
                     file=err,
                 )
                 return EXIT_WOULD_OVERWRITE
@@ -1108,8 +1164,8 @@ def run_site_sync(
             drift_paths = ", ".join(item.relative_path for item in plan.drifts)
             print(action_list, end="", file=out)
             print(
-                f"error: refusing to overwrite drifted generated file(s): {drift_paths} "
-                "(re-run with --force-generated to overwrite inside generated/ only)",
+                f"error: refusing to modify or delete drifted generated file(s): {drift_paths} "
+                "(re-run with --force-generated to overwrite/delete inside generated/ only)",
                 file=err,
             )
             return EXIT_WOULD_OVERWRITE

--- a/control/site_contract/sync_templates/fragments/grafana/dashboards/json/stayturgid-fleet.json.j2
+++ b/control/site_contract/sync_templates/fragments/grafana/dashboards/json/stayturgid-fleet.json.j2
@@ -305,12 +305,12 @@
             "type": "prometheus",
             "uid": "stayturgid-victoriametrics"
           },
-          "expr": "last_over_time(stayturgid_host_up{host=\"{{ host.name }}\"}[15m])",
-          "legendFormat": "{{ host.name }}",
+          "expr": "last_over_time(stayturgid_host_up{host=\"{{ host.name | json_string_escape }}\"}[15m])",
+          "legendFormat": "{{ host.name | json_string_escape }}",
           "refId": "A"
         }
       ],
-      "title": "{{ host.device_label | default(host.name) }} ({{ host.name }})",
+      "title": "{{ host.device_label | default(host.name) | json_string_escape }} ({{ host.name | json_string_escape }})",
       "type": "stat"
     }{% endfor %}
   ],

--- a/control/site_contract/sync_templates/fragments/olivetin/stayturgid_actions.yaml.j2
+++ b/control/site_contract/sync_templates/fragments/olivetin/stayturgid_actions.yaml.j2
@@ -39,11 +39,11 @@ actions:
       just deploy
 {% for host in inventory_hosts %}
   - id: stayturgid_deploy_{{ host.name | replace('-', '_') }}
-    title: "Deploy {{ host.device_label | default(host.name) }} ({{ host.name }})"
+    title: "Deploy {{ host.device_label | default(host.name) | json_string_escape }} ({{ host.name | json_string_escape }})"
     icon: "&#128640;"
     timeout: 1800
     shell: |
       export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
       cd {{ product_root }}
-      just deploy {{ host.name }}
+      just deploy {{ host.name | shell_quote }}
 {% endfor %}

--- a/tests/python/test_serverapps.py
+++ b/tests/python/test_serverapps.py
@@ -147,6 +147,29 @@ def test_mode_detect_inject_for_foreign_caddyfile(tmp_path: Path) -> None:
     assert str(frag_dir) in stderr
 
 
+def test_mode_detection_uses_passed_home_not_process_home(tmp_path: Path, monkeypatch) -> None:
+    """resolve_app_mode() (and the detect helpers it calls) must honor the
+    ``home`` override threaded through build_plan/plan_caddy, not silently
+    fall back to the real process ``Path.home()`` (see FINAL-REVIEW finding —
+    every one of these previously ignored the override for mode selection
+    even though plan_caddy/plan_vector/etc. already accept and use it for
+    everything else)."""
+    real_home = tmp_path / "real-home-with-foreign-caddyfile"
+    foreign = real_home / ".config" / "caddy" / "Caddyfile"
+    foreign.parent.mkdir(parents=True)
+    foreign.write_text("# a real user's caddyfile that must NOT be scanned\n", encoding="utf-8")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: real_home))
+
+    dest = _init_and_sync(tmp_path)
+    clean_home = tmp_path / "clean-home"
+    clean_home.mkdir()
+    code, stdout, stderr = _run(dir_path=str(dest), mode="dry-run", home=clean_home)
+    assert code == sa.EXIT_OK, stderr
+    # If the bug were present, detect would scan real_home's foreign
+    # Caddyfile (via Path.home()) instead of clean_home and force inject.
+    assert "caddy: mode=own (source=default)" in stdout
+
+
 def test_legacy_stayturgid_config_does_not_force_inject(tmp_path: Path) -> None:
     """Our own legacy ~/.config/stayturgid/Caddyfile must not flip default to inject."""
     dest = _init_and_sync(tmp_path)
@@ -252,6 +275,38 @@ def test_inject_with_import_line_copies_fragments(tmp_path: Path) -> None:
     assert "create" not in stdout2.split("inject fragment")[0] if False else True
     # Stronger: action lines for the placed file are skip
     assert any(line.startswith("  skip") and str(placed) in line for line in stdout2.splitlines())
+
+
+def test_import_line_for_sibling_dir_does_not_wrongly_cover_fragment_dir(tmp_path: Path) -> None:
+    """A foreign Caddyfile importing an unrelated sibling directory whose
+    name starts with fragment_dir's name (e.g. ``caddy.d-other``) must not
+    be treated as covering ``caddy.d`` (see FINAL-REVIEW finding — the old
+    substring check accepted this)."""
+    dest = _init_and_sync(tmp_path)
+    home = tmp_path / "home"
+    foreign = home / "etc" / "Caddyfile"
+    foreign.parent.mkdir(parents=True)
+    frag_dir = home / "etc" / "caddy.d"
+    frag_dir.mkdir()
+    sibling_dir = home / "etc" / "caddy.d-other"
+    sibling_dir.mkdir()
+    foreign.write_text(
+        f"{{\n\tadmin off\n}}\nexample.test {{\n\timport {sibling_dir.resolve()}/*.caddy\n}}\n",
+        encoding="utf-8",
+    )
+    _write_site_map(
+        dest,
+        "contract_version: 1\n"
+        "serverapps:\n"
+        "  caddy:\n"
+        "    mode: inject\n"
+        f"    config: {foreign}\n"
+        f"    fragment_dir: {frag_dir}\n",
+    )
+    code, stdout, stderr = _run(dir_path=str(dest), mode="apply", home=home)
+    assert code == sa.EXIT_WOULD_OVERWRITE, (stdout, stderr)
+    assert "import" in stderr.lower()
+    assert list(frag_dir.glob("*.caddy")) == []
 
 
 def test_idempotent_second_own_run(tmp_path: Path) -> None:
@@ -380,6 +435,47 @@ def test_vector_inject_without_unit_config_args_exits_2(tmp_path: Path) -> None:
     foreign.write_text("data_dir: /tmp/vector\n", encoding="utf-8")
     frag_dir = home / "etc" / "vector.d"
     frag_dir.mkdir()
+    _write_site_map(
+        dest,
+        "contract_version: 1\n"
+        "serverapps:\n"
+        "  vector:\n"
+        "    mode: inject\n"
+        f"    config: {foreign}\n"
+        f"    fragment_dir: {frag_dir}\n",
+    )
+    code, stdout, stderr = _run(dir_path=str(dest), mode="apply", home=home, apps="vector")
+    assert code == sa.EXIT_WOULD_OVERWRITE, (stdout, stderr)
+    assert "--config" in stderr
+    assert list(frag_dir.glob("*.yaml")) == []
+
+
+def test_vector_config_arg_for_sibling_dir_does_not_wrongly_cover_fragment_dir(tmp_path: Path) -> None:
+    """A launchd plist's ``--config`` pointing at an unrelated sibling
+    directory whose name starts with fragment_dir's name (e.g.
+    ``vector.d-other``) must not be treated as covering ``vector.d`` (see
+    FINAL-REVIEW finding — the old check just searched the whole plist text
+    for the fragment_dir string, with no association to ``--config`` at
+    all)."""
+    dest = _init_and_sync(tmp_path)
+    home = tmp_path / "home"
+    foreign = home / "etc" / "vector" / "vector.yaml"
+    foreign.parent.mkdir(parents=True)
+    foreign.write_text("data_dir: /tmp/vector\n", encoding="utf-8")
+    frag_dir = home / "etc" / "vector.d"
+    frag_dir.mkdir()
+    sibling_dir = home / "etc" / "vector.d-other"
+    sibling_dir.mkdir()
+    plist_dir = home / "Library" / "LaunchAgents"
+    plist_dir.mkdir(parents=True)
+    (plist_dir / "com.example.vector.plist").write_text(
+        '<?xml version="1.0"?>\n<plist><dict><key>ProgramArguments</key><array>\n'
+        "<string>/opt/homebrew/bin/vector</string>\n"
+        "<string>--config</string>\n"
+        f"<string>{sibling_dir.resolve()}/foo.yaml</string>\n"
+        "</array></dict></plist>\n",
+        encoding="utf-8",
+    )
     _write_site_map(
         dest,
         "contract_version: 1\n"

--- a/tests/python/test_site_init.py
+++ b/tests/python/test_site_init.py
@@ -393,6 +393,26 @@ def test_site_map_rejects_contract_path_inside_generated_area(tmp_path: Path) ->
     assert not dest.exists()
 
 
+def test_site_map_inventory_remap_colliding_with_group_vars_dir_exits_1(tmp_path: Path) -> None:
+    """A remapped `inventory` path can collide with the *derived*
+    `<inventory-parent>/group_vars/.gitkeep` scaffold path (one wants
+    `group_vars` as a file, the other as a directory). The exact-string
+    duplicate check misses this; build_plan() must still catch it before
+    any writes happen (see FINAL-REVIEW finding)."""
+    dest = tmp_path / "site-example"
+    map_file = tmp_path / "site-map.yml"
+    map_file.write_text("contract_version: 1\npaths:\n  inventory: group_vars\n", encoding="utf-8")
+    code, _, stderr = _run_api(
+        sitename="example",
+        dir_path=str(dest),
+        map_path=str(map_file),
+        mode="dry-run",
+    )
+    assert code == si.EXIT_PRECONDITION
+    assert "collide" in stderr.lower()
+    assert not dest.exists()
+
+
 def test_valid_serverapp_map_is_validation_only_in_c4(tmp_path: Path) -> None:
     dest = tmp_path / "site-example"
     map_file = tmp_path / "site-map.yml"
@@ -460,6 +480,32 @@ def test_destination_nested_in_product_rejected(tmp_path: Path) -> None:
 def test_destination_equals_product_rejected() -> None:
     code, _, stderr = _run_api(sitename="example", dir_path=str(ROOT), mode="dry-run")
     assert code == si.EXIT_PRECONDITION
+
+
+def test_destination_nested_via_case_insensitive_alias_rejected(tmp_path: Path) -> None:
+    """ADR-005 nesting must not be bypassable on case-insensitive filesystems.
+
+    Default macOS APFS resolves a differently-cased path to the exact same
+    physical directory; a purely string-based relative_to() check misses
+    that aliasing entirely (see FINAL-REVIEW finding). Skips itself on a
+    genuinely case-sensitive filesystem where the alias doesn't apply.
+    """
+    aliased_root = ROOT.parent / ROOT.name.upper()
+    try:
+        same = aliased_root.exists() and os.path.samestat(aliased_root.stat(), ROOT.stat())
+    except OSError:
+        same = False
+    if not same:
+        pytest.skip("filesystem is case-sensitive; product-root alias does not apply here")
+    nested = aliased_root / ".tmp-site-init-case-alias-test"
+    try:
+        code, _, stderr = _run_api(sitename="example", dir_path=str(nested), mode="dry-run")
+        assert code == si.EXIT_PRECONDITION
+        assert "nested" in stderr.lower() or "product" in stderr.lower()
+        assert not nested.exists()
+    finally:
+        if nested.exists():
+            shutil.rmtree(nested)
     assert "product" in stderr.lower()
 
 

--- a/tests/python/test_site_sync.py
+++ b/tests/python/test_site_sync.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import hashlib
 import io
+import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -347,6 +349,89 @@ def test_manifest_removal_lists_delete_then_apply_deletes(tmp_path: Path) -> Non
     assert {item["path"] for item in lock["files"]} == {keep_path}
     # User area untouched.
     assert (dest / "registry/ports.yml").is_file()
+
+
+def test_manifest_removal_of_hand_edited_file_is_refused_without_force(tmp_path: Path) -> None:
+    """The delete path must run the same drift check the overwrite path
+    runs: a hand-edited generated file must not be silently destroyed just
+    because its manifest entry disappeared (see FINAL-REVIEW finding)."""
+    dest = _init_site(tmp_path)
+    assert _run_api(dir_path=str(dest), mode="apply")[0] == ss.EXIT_OK
+    keep_path = "generated/stayturgid/README.md"
+    drop_path = "generated/stayturgid/fragments/.keep"
+    target = dest / drop_path
+    target.write_text("hand edited — should trip drift on delete too\n", encoding="utf-8")
+
+    reduced = tmp_path / "reduced-manifest.yml"
+    _write_reduced_manifest(reduced, keep=[keep_path])
+
+    before = _snapshot(dest)
+    code_dry, dry_out, dry_err = _run_api(dir_path=str(dest), mode="dry-run", manifest_path=reduced)
+    assert code_dry == ss.EXIT_WOULD_OVERWRITE
+    assert drop_path in dry_err
+    assert _snapshot(dest) == before
+
+    code, _, stderr = _run_api(dir_path=str(dest), mode="apply", manifest_path=reduced)
+    assert code == ss.EXIT_WOULD_OVERWRITE
+    assert drop_path in stderr
+    assert _snapshot(dest) == before
+    assert target.is_file()
+
+    code_force, _, err_force = _run_api(dir_path=str(dest), mode="apply", manifest_path=reduced, force_generated=True)
+    assert code_force == ss.EXIT_OK, err_force
+    assert not target.exists()
+
+
+# --- Inventory-controlled values are escaped, not spliced raw -------------
+
+
+def test_crafted_inventory_names_render_safely_not_corrupted(tmp_path: Path) -> None:
+    """host.name / device_label must not be able to break JSON/YAML structure
+    or escape their intended shell argument when rendered into fragments
+    (see FINAL-REVIEW findings on the grafana dashboard + olivetin actions
+    templates)."""
+    dest = _init_site(tmp_path)
+    crafted_name = 'evil;touch-pwned-marker"}'
+    crafted_label = 'Say "hi"\\ and go'
+    inventory_doc = {
+        "all": {
+            "children": {
+                "stayturgid": {
+                    "hosts": {crafted_name: {"device_label": crafted_label}},
+                }
+            }
+        }
+    }
+    # Use PyYAML's own dumper (not hand-rolled string quoting — Python str
+    # repr() and YAML quoted-scalar escaping rules differ) so the file we
+    # write is guaranteed to round-trip back to exactly `crafted_name` /
+    # `crafted_label` when site-sync parses it.
+    (dest / "inventory/hosts.yml").write_text(
+        yaml.safe_dump(inventory_doc, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    code, _, stderr = _run_api(dir_path=str(dest), mode="apply")
+    assert code == ss.EXIT_OK, stderr
+
+    dashboard = json.loads(
+        (dest / "generated/stayturgid/fragments/grafana/dashboards/json/stayturgid-fleet.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    host_panel = next(p for p in dashboard["panels"] if p.get("id") == 100)
+    assert host_panel["title"] == f"{crafted_label} ({crafted_name})"
+    assert host_panel["targets"][0]["legendFormat"] == crafted_name
+    assert crafted_name in host_panel["targets"][0]["expr"]
+
+    actions_doc = yaml.safe_load(
+        (dest / "generated/stayturgid/fragments/olivetin/stayturgid_actions.yaml").read_text(encoding="utf-8")
+    )
+    deploy_action = next(a for a in actions_doc["actions"] if a["id"].startswith("stayturgid_deploy_"))
+    assert deploy_action["title"] == f"Deploy {crafted_label} ({crafted_name})"
+    shell_lines = deploy_action["shell"].strip().splitlines()
+    deploy_line = next(line for line in shell_lines if line.strip().startswith("just deploy"))
+    assert shlex.split(deploy_line.strip()) == ["just", "deploy", crafted_name]
 
 
 # --- Never writes outside generated/<product>/ -----------------------------


### PR DESCRIPTION
## Summary

Project-level FINAL-REVIEW (step2 plan §10) ran a dedicated adversarial review of `control/site_contract/` — the site-init/site-sync/serverapps module — which had never had one before (only mechanical gate-debt "tests pass" verification). Found and fixed 9 must-fix correctness/security bugs, each with a regression test verified to fail against pre-fix code:

- **ADR-005 nesting bypass on case-insensitive filesystems** — `site_init.py`'s nesting check used string-based `relative_to()`, bypassable on default macOS APFS via a differently-cased `--dir`. Fixed with inode-identity comparison (`site_map.py::is_physically_within`), reused by all three ADR-005/escape checks.
- **site-init file/directory type-collision** — a site-map remap could make one planned path double as another's parent dir, crashing `apply_plan()` mid-write with partial writes. Added a collision check.
- **site-sync delete path skipped the drift check** — a hand-edited generated file was silently destroyed the moment its manifest entry disappeared (no exit 2, no `--force-generated` gate). Deletes now run the same drift check overwrites do.
- **JSON/YAML/shell injection via inventory host names** — two sync templates spliced `host.name`/`device_label` unescaped into JSON strings, a YAML double-quoted scalar, and a shell command. Added `json_string_escape`/`shell_quote` Jinja filters + render-time parse validation.
- **Naive substring containment in inject-mode coverage checks** — caddy's import-line check and vector's `--config` check both accepted a foreign config pointing at an unrelated sibling directory sharing a name prefix. Both are now path-boundary-aware.
- **`home` override silently ignored by mode resolution** — `resolve_app_mode()` and the foreign-detect helpers always scanned the real process `Path.home()` regardless of the `home=` override every `plan_<app>()` already threads through the rest of planning. Threaded through everywhere.
- **Missing `no_log: true` on secret-bearing plist renders** — vector/openobserve's plist templating tasks embed real admin passwords but lacked `no_log`, unlike the equivalent litellm task. An ordinary `--diff`/`-vvv` run would print the plaintext password.

Full findings doc, live verification evidence, and remaining accepted-risk/deferred items: `site-djbclark` repo `docs/relay/reviews/FINAL-REVIEW-findings.md`.

## Test plan

- [x] `just check` — exit 0
- [x] Full `just test` — 510 passed, 1 skipped (was 497 baseline pre-fix; +13 net from new regression tests)
- [x] Each new/modified regression test independently verified to FAIL against the pre-fix source (reverted source, kept tests, confirmed red; reapplied fixes, confirmed green)
- [x] `ansible-lint`, `ruff check`/`format`, pre-commit — all clean
- [ ] CI green on this PR (checking after push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety when generating configuration files containing special characters.
  * Prevented accidental deletion or overwriting of manually modified generated files.
  * Strengthened detection of conflicting, nested, or unsafe destination paths.
  * Improved service configuration detection for alternate home directories and similarly named directories.
  * Reduced sensitive configuration details in deployment logs.
* **Validation**
  * Added checks ensuring generated JSON and YAML files remain valid before synchronization.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->