### PR TITLE
chore: remove dead noqa suppressions

### DIFF
--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/module_utils/test_adb_resolve.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/module_utils/test_adb_resolve.py
@@ -6,7 +6,7 @@ import sys
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
 sys.path.insert(0, os.path.join(ROOT, "plugins", "module_utils"))
 
-import adb_resolve as ar  # noqa: E402
+import adb_resolve as ar
 
 
 def _listing(*lines):

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_a11y_services.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_a11y_services.py
@@ -9,7 +9,7 @@ import pytest
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
 sys.path.insert(0, os.path.join(ROOT, "plugins", "modules"))
 
-import android_a11y_services as mod  # noqa: E402
+import android_a11y_services as mod
 
 
 def run_module(mocker, args, cmd_results=None):

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_apk.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_apk.py
@@ -10,8 +10,8 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..",
 sys.path.insert(0, os.path.join(ROOT, "plugins", "modules"))
 sys.path.insert(0, os.path.join(ROOT, "plugins", "module_utils"))
 
-import android_apk as mod  # noqa: E402
-import apk_install  # noqa: E402
+import android_apk as mod
+import apk_install
 
 
 def test_parse_install_result_success():

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_appops.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_appops.py
@@ -10,8 +10,8 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..",
 sys.path.insert(0, os.path.join(ROOT, "plugins", "modules"))
 sys.path.insert(0, os.path.join(ROOT, "plugins", "module_utils"))
 
-import adb_shell  # noqa: E402
-import android_appops as mod  # noqa: E402
+import adb_shell
+import android_appops as mod
 
 
 def test_parse_appops_mode():

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_intent.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_intent.py
@@ -9,7 +9,7 @@ import pytest
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
 sys.path.insert(0, os.path.join(ROOT, "plugins", "modules"))
 
-import android_intent as mod  # noqa: E402
+import android_intent as mod
 
 
 def run_module(mocker, args, cmd_results=None):

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_settings.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_settings.py
@@ -9,7 +9,7 @@ import pytest
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
 sys.path.insert(0, os.path.join(ROOT, "plugins", "modules"))
 
-import android_settings as mod  # noqa: E402
+import android_settings as mod
 
 
 def run_module(mocker, args, cmd_results=None):

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_ui.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_ui.py
@@ -9,7 +9,7 @@ import pytest
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
 sys.path.insert(0, os.path.join(ROOT, "plugins", "modules"))
 
-import android_ui as mod  # noqa: E402
+import android_ui as mod
 
 
 def run_module(mocker, args):

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_autojs6_project_deploy.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_autojs6_project_deploy.py
@@ -10,8 +10,8 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..",
 sys.path.insert(0, os.path.join(ROOT, "plugins", "modules"))
 sys.path.insert(0, os.path.join(ROOT, "plugins", "module_utils"))
 
-import autojs6_deploy_util as deploy_util  # noqa: E402
-import autojs6_project_deploy as mod  # noqa: E402
+import autojs6_deploy_util as deploy_util
+import autojs6_project_deploy as mod
 
 
 def _fake_run(cmd_results=None):

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_shizuku_grant.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_shizuku_grant.py
@@ -10,8 +10,8 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..",
 sys.path.insert(0, os.path.join(ROOT, "plugins", "modules"))
 sys.path.insert(0, os.path.join(ROOT, "plugins", "module_utils"))
 
-import shizuku as shizuku_utils  # noqa: E402
-import shizuku_grant as mod  # noqa: E402
+import shizuku as shizuku_utils
+import shizuku_grant as mod
 
 
 def test_patch_shizuku_json_adds_entry():

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_shizuku_start.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_shizuku_start.py
@@ -10,7 +10,7 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..",
 sys.path.insert(0, os.path.join(ROOT, "plugins", "modules"))
 sys.path.insert(0, os.path.join(ROOT, "plugins", "module_utils"))
 
-import shizuku_start as mod  # noqa: E402
+import shizuku_start as mod
 
 # --- pure-function unit tests ---
 

--- a/ansible_collections/stayturgid/fdroid/tests/unit/plugins/modules/test_fdroid_apps.py
+++ b/ansible_collections/stayturgid/fdroid/tests/unit/plugins/modules/test_fdroid_apps.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.join(ROOT, "plugins", "module_utils"))
 sys.path.insert(0, REPO_ROOT)
 sys.path.insert(0, os.path.join(ROOT, "plugins", "module_utils"))
 
-import fdroid_apps as mod  # noqa: E402
+import fdroid_apps as mod
 
 
 def run_module(mocker, args, cmd_results=None):

--- a/ansible_collections/stayturgid/fdroid/tests/unit/plugins/modules/test_fdroid_install.py
+++ b/ansible_collections/stayturgid/fdroid/tests/unit/plugins/modules/test_fdroid_install.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.join(ROOT, "plugins", "module_utils"))
 sys.path.insert(0, REPO_ROOT)
 sys.path.insert(0, os.path.join(ROOT, "plugins", "module_utils"))
 
-import fdroid_install as mod  # noqa: E402
+import fdroid_install as mod
 
 
 def run_module(mocker, args, cmd_results=None):

--- a/ansible_collections/stayturgid/fdroid/tests/unit/plugins/modules/test_fdroid_repos.py
+++ b/ansible_collections/stayturgid/fdroid/tests/unit/plugins/modules/test_fdroid_repos.py
@@ -8,7 +8,7 @@ import pytest
 
 FLEET_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
 sys.path.insert(0, os.path.join(FLEET_ROOT, "plugins", "modules"))
-import fdroid_repos as mod  # noqa: E402
+import fdroid_repos as mod
 
 REAL_REPO_LIST = """\
 Name: f-droid

--- a/ansible_collections/stayturgid/play/tests/unit/plugins/modules/test_play_apps.py
+++ b/ansible_collections/stayturgid/play/tests/unit/plugins/modules/test_play_apps.py
@@ -8,7 +8,7 @@ import pytest
 
 FLEET_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
 sys.path.insert(0, os.path.join(FLEET_ROOT, "plugins", "modules"))
-import play_apps as mod  # noqa: E402
+import play_apps as mod
 
 
 def run_module(mocker, args, cmd_results=None, check=False):

--- a/ansible_collections/stayturgid/termux/tests/unit/plugins/modules/test_stayturgid_repair_check.py
+++ b/ansible_collections/stayturgid/termux/tests/unit/plugins/modules/test_stayturgid_repair_check.py
@@ -9,7 +9,7 @@ import pytest
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
 sys.path.insert(0, os.path.join(ROOT, "plugins", "modules"))
 
-import stayturgid_repair_check as mod  # noqa: E402
+import stayturgid_repair_check as mod
 
 
 def test_find_status_line_picks_last():

--- a/ansible_collections/stayturgid/termux/tests/unit/plugins/modules/test_termux_sshd.py
+++ b/ansible_collections/stayturgid/termux/tests/unit/plugins/modules/test_termux_sshd.py
@@ -9,7 +9,7 @@ import pytest
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
 sys.path.insert(0, os.path.join(ROOT, "plugins", "modules"))
 
-import termux_sshd as mod  # noqa: E402
+import termux_sshd as mod
 
 
 def test_apply_config_replaces_existing():

--- a/control/bin/access_monitor.py
+++ b/control/bin/access_monitor.py
@@ -27,7 +27,7 @@ _LIB = os.path.join(_REPO, "control", "lib")
 for _p in (_REPO, _LIB):
     if _p not in sys.path:
         sys.path.insert(0, _p)
-from control.lib.site_logging import (  # noqa: E402
+from control.lib.site_logging import (
     NOTICE,
     WARNING,
     log,
@@ -79,7 +79,7 @@ def read_devices(conf_path):
     """Yield (name, tailscale_ip, lan_ip) from devices.conf."""
     try:
         from stayturgid_device import iter_monitor_hosts
-    except Exception:  # noqa: BLE001
+    except Exception:
         iter_monitor_hosts = None
     if iter_monitor_hosts is not None:
         yield from iter_monitor_hosts(conf_path)

--- a/control/bin/adb_reconnect.py
+++ b/control/bin/adb_reconnect.py
@@ -98,7 +98,7 @@ def device_row(alias, conf_path):
         from stayturgid_device import device_row as _device_row
 
         return _device_row(alias, conf_path)
-    except Exception:  # noqa: BLE001
+    except Exception:
         pass
     try:
         with open(conf_path) as f:

--- a/control/bin/bootstrap_ssh.py
+++ b/control/bin/bootstrap_ssh.py
@@ -23,8 +23,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "control" / "lib"))
-import adb_cli as ac  # noqa: E402
-import termux_ssh_bootstrap as boot  # noqa: E402
+import adb_cli as ac
+import termux_ssh_bootstrap as boot
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/control/bin/check_et_mac.py
+++ b/control/bin/check_et_mac.py
@@ -16,7 +16,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "lib"))
 
-import et_mac as em  # noqa: E402
+import et_mac as em
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/control/bin/deploy_termux.py
+++ b/control/bin/deploy_termux.py
@@ -18,9 +18,9 @@ REQUIREMENTS = REPO_ROOT / "ansible" / "requirements.yml"
 SSH_OPTS = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=8", "-o", "LogLevel=ERROR"]
 
 sys.path.insert(0, str(REPO_ROOT / "control" / "lib"))
-import adb_cli as ac  # noqa: E402
-import termux_ssh_bootstrap as boot  # noqa: E402
-from ansible_context import (  # noqa: E402
+import adb_cli as ac
+import termux_ssh_bootstrap as boot
+from ansible_context import (
     AnsibleConfigError,
     require_limit_hosts,
     resolve_ansible_context,

--- a/control/bin/ensure_et_mac.py
+++ b/control/bin/ensure_et_mac.py
@@ -30,7 +30,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "lib"))
 
-import et_mac as em  # noqa: E402
+import et_mac as em
 
 
 def _detect_tailscale_ip() -> str:

--- a/control/bin/fire_help_monitor.py
+++ b/control/bin/fire_help_monitor.py
@@ -25,11 +25,11 @@ REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "lib"))
 
 
-import fire_peer_help as fph  # noqa: E402
+import fire_peer_help as fph
 
 try:
-    import stayturgid_device as dev  # noqa: E402
-except Exception:  # noqa: BLE001
+    import stayturgid_device as dev
+except Exception:
     dev = None
 
 ROOT = Path.home() / ".config" / "stayturgid"
@@ -64,7 +64,7 @@ def read_devices():
 
         yield from iter_monitor_hosts(str(CONF))
         return
-    except Exception:  # noqa: BLE001
+    except Exception:
         pass
     for line in CONF.read_text().splitlines():
         line = line.strip()
@@ -112,7 +112,7 @@ def adb_targets(name: str, ts_ip: str, lan_ip: str) -> list[str]:
     if dev is not None:
         try:
             add(dev.resolve_adb(name))
-        except Exception:  # noqa: BLE001
+        except Exception:
             pass
     if lan_ip and lan_ip != "-":
         add("%s:5555" % lan_ip)
@@ -218,7 +218,7 @@ def main() -> int:
             continue
         try:
             help_host(name, ts_ip, lan_ip)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             log("%s error: %s" % (name, e))
     return 0
 

--- a/control/bin/firerpa_heal.py
+++ b/control/bin/firerpa_heal.py
@@ -24,8 +24,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 for _p in (REPO_ROOT / "control" / "lib", REPO_ROOT):
     if str(_p) not in sys.path:
         sys.path.append(str(_p))
-from control.lib.firerpa_auth import certificate_path  # noqa: E402
-from control.lib.site_logging import (  # noqa: E402
+from control.lib.firerpa_auth import certificate_path
+from control.lib.site_logging import (
     ERR,
     INFO,
     NOTICE,

--- a/control/bin/firerpa_health_monitor.py
+++ b/control/bin/firerpa_health_monitor.py
@@ -22,8 +22,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 for _p in (REPO_ROOT, REPO_ROOT / "control" / "lib"):
     if str(_p) not in sys.path:
         sys.path.append(str(_p))
-from control.lib.firerpa_auth import certificate_path  # noqa: E402
-from control.lib.site_logging import INFO, WARNING, log, trim_log  # noqa: E402
+from control.lib.firerpa_auth import certificate_path
+from control.lib.site_logging import INFO, WARNING, log, trim_log
 
 LOG_NAME = "firerpa-health.log"
 ROOT = os.path.join(os.path.expanduser("~"), ".config", "stayturgid")

--- a/control/bin/fix_hd8_google_stack.py
+++ b/control/bin/fix_hd8_google_stack.py
@@ -30,9 +30,9 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "lib"))
-import hd8_google_stack as hgs  # noqa: E402
-import stayturgid_device as dev  # noqa: E402
-import vlm_helpers as vh  # noqa: E402
+import hd8_google_stack as hgs
+import stayturgid_device as dev
+import vlm_helpers as vh
 
 
 def run_command(cmd, *args, **kwargs):

--- a/control/bin/fleet_health_monitor.py
+++ b/control/bin/fleet_health_monitor.py
@@ -28,13 +28,13 @@ _LIB = os.path.join(_REPO, "control", "lib")
 for _p in (_LIB, _REPO):
     if _p not in sys.path:
         sys.path.append(_p)
-import fleet_health as fh  # noqa: E402
-import hd8_google_stack as hgs  # noqa: E402
-import stayturgid_device as dev  # noqa: E402
-import vlm_helpers as vh  # noqa: E402
+import fleet_health as fh
+import hd8_google_stack as hgs
+import stayturgid_device as dev
+import vlm_helpers as vh
 
-import control.lib.stats as stats  # noqa: E402
-from control.lib.site_logging import (  # noqa: E402
+import control.lib.stats as stats
+from control.lib.site_logging import (
     ERR,
     INFO,
     NOTICE,
@@ -100,7 +100,7 @@ def notify(title: str, message: str, sound: str | None = None) -> None:
 def read_devices(conf_path: str):
     try:
         from stayturgid_device import iter_monitor_hosts
-    except Exception:  # noqa: BLE001
+    except Exception:
         iter_monitor_hosts = None
     if iter_monitor_hosts is not None:
         yield from iter_monitor_hosts(conf_path)
@@ -310,7 +310,7 @@ def maybe_heal_hd8_google_stack(name: str) -> None:
                 "%s Google Play Services pinned (%s)" % (name, new_ver),
             )
             maybe_verify_hd8_google_closeout(name)
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         _fleet_log(INFO, "%s google-stack heal skipped: %s" % (name, e))
 
 
@@ -640,7 +640,7 @@ def main() -> int:
     for name, ts_ip, lan_ip in read_devices(CONF):
         try:
             check_device(name, ts_ip, lan_ip)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             _fleet_log(
                 ERR,
                 "%s via none: sshd=unknown issues=probe_error probe_error=%s" % (name, str(e).replace(" ", "_")[:120]),

--- a/control/bin/gui_audit.py
+++ b/control/bin/gui_audit.py
@@ -35,10 +35,10 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "lib"))
-import screen_control as sc  # noqa: E402
-import stayturgid_device as dev  # noqa: E402
-import ui_driver as uid  # noqa: E402
-import vlm_helpers as vh  # noqa: E402
+import screen_control as sc
+import stayturgid_device as dev
+import ui_driver as uid
+import vlm_helpers as vh
 
 ROOT = Path(os.path.expanduser("~")) / ".config" / "stayturgid"
 LOG = ROOT / "logs" / "gui-audit.log"
@@ -178,7 +178,7 @@ def reachable(host: str) -> tuple[bool, str]:
     """Return (ok, serial_or_reason)."""
     try:
         serial = dev.resolve_adb(host)
-    except Exception as e:  # noqa: BLE001 — soft skip
+    except Exception as e:  # soft skip
         return False, "resolve_failed:%s" % e
     if not serial:
         return False, "no_serial"
@@ -518,7 +518,7 @@ def audit_host(host: str, day_dir: Path) -> list[str]:
     except sc.ScreenControlError as e:
         issues.append("screen_control_failed")
         log("%s screen_control_error: %s" % (host, e))
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         issues.append("audit_exception")
         log("%s exception: %s" % (host, e))
 

--- a/control/bin/h2_confirm_ui.py
+++ b/control/bin/h2_confirm_ui.py
@@ -19,10 +19,10 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "lib"))
-import screen_control as sc  # noqa: E402
-import stayturgid_device as dev  # noqa: E402
-import ui_driver as uid  # noqa: E402
-import vlm_helpers as vh  # noqa: E402
+import screen_control as sc
+import stayturgid_device as dev
+import ui_driver as uid
+import vlm_helpers as vh
 
 OUT = REPO / "artifacts" / "h2-confirm"
 NEO = "com.machiav3lli.fdroid"

--- a/control/bin/harden_fleet_apps.py
+++ b/control/bin/harden_fleet_apps.py
@@ -22,8 +22,8 @@ COLLECTION = REPO_ROOT / "ansible_collections" / "stayturgid" / "android_common"
 
 sys.path.insert(0, str(REPO_ROOT / "control" / "lib"))
 sys.path.insert(0, str(COLLECTION / "plugins" / "module_utils"))
-import fleet_privileges as fp  # noqa: E402
-import stayturgid_device as dev  # noqa: E402
+import fleet_privileges as fp
+import stayturgid_device as dev
 
 
 def load_profiles() -> list[dict]:

--- a/control/bin/screen_lease.py
+++ b/control/bin/screen_lease.py
@@ -23,8 +23,8 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "lib"))
-import device_screen_lease as dsl  # noqa: E402
-import stayturgid_device as dev  # noqa: E402
+import device_screen_lease as dsl
+import stayturgid_device as dev
 
 
 def _ids(device: str) -> list[str]:
@@ -42,7 +42,7 @@ def _ids(device: str) -> list[str]:
                 ids.append("%s:5555" % ts_ip)
             if lan and lan != "-":
                 ids.append("%s:5555" % lan)
-    except Exception:  # noqa: BLE001
+    except Exception:
         pass
     return ids
 

--- a/control/bin/validate_site_identity.py
+++ b/control/bin/validate_site_identity.py
@@ -64,7 +64,7 @@ def _load_si():
     lib = root / "control" / "lib"
     if str(lib) not in sys.path:
         sys.path.insert(0, str(lib))
-    import site_identity as _si  # noqa: PLC0415
+    import site_identity as _si
 
     return _si
 
@@ -186,7 +186,7 @@ def load_overlay_patterns(root: Path) -> list[tuple[str, str]]:
     lib = root / "control" / "lib"
     if str(lib) not in sys.path:
         sys.path.insert(0, str(lib))
-    import ansible_context as ac  # noqa: PLC0415
+    import ansible_context as ac
 
     try:
         context = ac.resolve_ansible_context(root)

--- a/control/bin/verify_drift.py
+++ b/control/bin/verify_drift.py
@@ -17,7 +17,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PLAYBOOK = REPO_ROOT / "ansible" / "playbooks" / "fleet" / "verify-drift.yml"
 
 sys.path.insert(0, str(REPO_ROOT / "control" / "lib"))
-from ansible_context import (  # noqa: E402
+from ansible_context import (
     AnsibleConfigError,
     require_limit_hosts,
     resolve_ansible_context,

--- a/control/bin/verify_hd8_google.py
+++ b/control/bin/verify_hd8_google.py
@@ -27,11 +27,11 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "lib"))
-import hd8_google_stack as hgs  # noqa: E402
-import play_store_autoupdate as psa  # noqa: E402
-import stayturgid_device as dev  # noqa: E402
-import ui_driver as uid  # noqa: E402
-import vlm_gate as vlm  # noqa: E402
+import hd8_google_stack as hgs
+import play_store_autoupdate as psa
+import stayturgid_device as dev
+import ui_driver as uid
+import vlm_gate as vlm
 
 ART = Path.home() / ".config" / "stayturgid" / "artifacts" / "vlm-verify"
 

--- a/control/bin/verify_play_autoupdate.py
+++ b/control/bin/verify_play_autoupdate.py
@@ -23,10 +23,10 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "lib"))
-import play_store_autoupdate as psa  # noqa: E402
-import stayturgid_device as dev  # noqa: E402
-import ui_driver as uid  # noqa: E402
-import vlm_gate as vlm  # noqa: E402
+import play_store_autoupdate as psa
+import stayturgid_device as dev
+import ui_driver as uid
+import vlm_gate as vlm
 
 ART = Path.home() / ".config" / "stayturgid" / "artifacts" / "vlm-verify"
 

--- a/control/bin/vlm_check.py
+++ b/control/bin/vlm_check.py
@@ -11,8 +11,8 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "lib"))
 
-import vlm_cloud as cloud  # noqa: E402
-import vlm_gate as vlm  # noqa: E402
+import vlm_cloud as cloud
+import vlm_gate as vlm
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/control/landing/discover.py
+++ b/control/landing/discover.py
@@ -20,7 +20,7 @@ _REPO = Path(__file__).resolve().parents[2]
 _LIB = _REPO / "control" / "lib"
 sys.path.insert(0, str(_REPO))
 
-from control.landing import state  # noqa: E402
+from control.landing import state
 
 try:
     import yaml

--- a/control/landing/landing.py
+++ b/control/landing/landing.py
@@ -22,7 +22,7 @@ _TEMPLATES = _HERE / "templates"
 sys.path.insert(0, str(_REPO))
 from flask import Flask, render_template_string, request
 
-from control.landing import state  # noqa: E402
+from control.landing import state
 
 PORT = 8088  # Phase D4: was 8080 (collided with caddy-health); plists pass --port 8088
 app = Flask(__name__, template_folder=str(_TEMPLATES))

--- a/control/lib/adb_cli.py
+++ b/control/lib/adb_cli.py
@@ -12,7 +12,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT / "control" / "lib") not in sys.path:
     sys.path.insert(0, str(REPO_ROOT / "control" / "lib"))
 
-import stayturgid_device as dev  # noqa: E402
+import stayturgid_device as dev
 
 AUTOJS_PKG = "org.autojs.autojs6"
 AUTOJS_RUN = "org.autojs.autojs.external.open.RunIntentActivity"

--- a/control/lib/et_mac.py
+++ b/control/lib/et_mac.py
@@ -262,7 +262,7 @@ def hosts_from_devices_conf(path: Path | None = None) -> list[str]:
         from stayturgid_device import iter_devices_conf
 
         return [name for name, *_ in iter_devices_conf(str(conf))]
-    except (ImportError, AttributeError):  # noqa: BLE001
+    except (ImportError, AttributeError):
         pass
     hosts: list[str] = []
     try:

--- a/control/lib/fleet_health.py
+++ b/control/lib/fleet_health.py
@@ -161,7 +161,7 @@ def a11y_profile_missing(alias: str, a11y_list: str | None) -> list[str]:
     if not a11y_list or a11y_list in ("null", "unknown", ""):
         return []
     try:
-        import a11y_services as a11y  # noqa: WPS433
+        import a11y_services as a11y
     except ImportError:
         return []
     expected = a11y.profile_services(alias)

--- a/control/lib/hd8_google_stack.py
+++ b/control/lib/hd8_google_stack.py
@@ -71,7 +71,7 @@ def _adb() -> str:
         from stayturgid_device import adb_bin
 
         return adb_bin()
-    except Exception:  # noqa: BLE001
+    except Exception:
         return os.environ.get("STAYTURGID_ADB", "adb")
 
 

--- a/control/lib/play_store_autoupdate.py
+++ b/control/lib/play_store_autoupdate.py
@@ -50,10 +50,10 @@ def open_autoupdate_screen(hs: HandsetsSession, serial: str) -> bool:
     # No ScreenControlSession here (inversion breaks Play drawer); still pin
     # portrait so Fire/phone coords match Handsets assumptions.
     try:
-        import screen_control as sc  # noqa: WPS433 — optional fleet dep
+        import screen_control as sc  # optional fleet dep
 
         sc.apply_portrait_lock(serial)
-    except Exception:  # noqa: BLE001
+    except Exception:
         pass
     launch_play_store(serial)
     time.sleep(1.5)

--- a/control/lib/post_ui_remote.py
+++ b/control/lib/post_ui_remote.py
@@ -19,7 +19,7 @@ from typing import Callable
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 if REPO not in sys.path:
     sys.path.insert(0, os.path.join(REPO, "control", "lib"))
-import stayturgid_device as dev  # noqa: E402
+import stayturgid_device as dev
 
 SSH_OPTS = list(dev.SSH_OPTS)
 ON_DEVICE_BIN = "~/.stayturgid/bin"

--- a/control/lib/resolve_adb.py
+++ b/control/lib/resolve_adb.py
@@ -16,7 +16,7 @@ _HERE = Path(__file__).resolve().parent
 if str(_HERE) not in sys.path:
     sys.path.insert(0, str(_HERE))
 
-import stayturgid_device as dev  # noqa: E402
+import stayturgid_device as dev
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/control/lib/screen_control.py
+++ b/control/lib/screen_control.py
@@ -37,9 +37,9 @@ import time
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 if REPO not in sys.path:
     sys.path.insert(0, os.path.join(REPO, "control", "lib"))
-import device_screen_lease as dsl  # noqa: E402
-import stayturgid_device as dev  # noqa: E402
-import ui_clearance as uc  # noqa: E402
+import device_screen_lease as dsl
+import stayturgid_device as dev
+import ui_clearance as uc
 
 INPUT_PREFIXES = ("input",)
 INVERSION_KEY = "accessibility_display_inversion_enabled"
@@ -383,7 +383,7 @@ class ScreenControlSession:
                     ids.append("%s:5555" % ts_ip)
                 if lan and lan != "-":
                     ids.append("%s:5555" % lan)
-        except Exception:  # noqa: BLE001
+        except Exception:
             pass
         return ids
 
@@ -413,7 +413,7 @@ class ScreenControlSession:
             return
         try:
             dsl.release(self.host, session_id=self._lease_session_id)
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             sys.stderr.write("WARN: screen-lease release on %s: %s\n" % (self.host, e))
         self._lease_acquired = False
 
@@ -432,7 +432,7 @@ class ScreenControlSession:
                 if self._lease_acquired:
                     dsl.heartbeat(self.host, session_id=self._lease_session_id)
                 apply_portrait_lock(self.serial)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 sys.stderr.write("WARN: screen-control keepalive on %s: %s\n" % (self.host, e))
 
     def _start_keepalive(self):

--- a/control/lib/stayturgid_device.py
+++ b/control/lib/stayturgid_device.py
@@ -178,7 +178,7 @@ def resolve_ssh_host(alias, conf_path=None):
 _REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if _REPO not in sys.path:
     sys.path.insert(0, _REPO)
-from ui_parse import (  # noqa: F401, E402
+from ui_parse import (  # noqa: F401
     parse_button_center,
     parse_content_desc_center,
     parse_switch,

--- a/control/lib/termux_ssh_bootstrap.py
+++ b/control/lib/termux_ssh_bootstrap.py
@@ -16,7 +16,7 @@ _COLLECTION_UTILS = REPO_ROOT / "ansible_collections" / "stayturgid" / "termux" 
 if str(_COLLECTION_UTILS) not in sys.path:
     sys.path.insert(0, str(_COLLECTION_UTILS))
 
-import termux_run_as as tr  # noqa: E402
+import termux_run_as as tr
 
 SSH_OPTS = ["-o", "BatchMode=yes", "-o", "LogLevel=ERROR"]
 

--- a/control/lib/vlm_cloud.py
+++ b/control/lib/vlm_cloud.py
@@ -350,7 +350,7 @@ def ping_backends() -> dict[str, Any]:
                 payload = json.loads(resp.read().decode())
             text = payload["candidates"][0]["content"]["parts"][0]["text"]
             out["gemini"] = {"ok": True, "text": text[:120]}
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             out["gemini"] = {"ok": False, "error": str(e)[:200]}
     else:
         out["gemini"] = {"ok": False, "error": "no_key"}
@@ -381,7 +381,7 @@ def ping_backends() -> dict[str, Any]:
                 payload = json.loads(resp.read().decode())
             text = payload["content"][0]["text"]
             out["claude"] = {"ok": True, "text": text[:120]}
-        except Exception as e:  # noqa: BLE001
+        except Exception as e:
             out["claude"] = {"ok": False, "error": str(e)[:200]}
     else:
         out["claude"] = {"ok": False, "error": "no_key"}

--- a/control/lib/vlm_gate.py
+++ b/control/lib/vlm_gate.py
@@ -407,7 +407,7 @@ class VlmGate:
                     local_detail["cloud_attempt"] = detail
                     return True, local_detail
                 return ok, detail
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 if local_detail is not None:
                     local_detail = dict(local_detail)
                     local_detail["cloud_error"] = str(e)[:200]

--- a/control/tools/autojs6/deploy.py
+++ b/control/tools/autojs6/deploy.py
@@ -20,9 +20,9 @@ _COLLECTION_UTILS = REPO_ROOT / "ansible_collections" / "stayturgid" / "android_
 if str(_COLLECTION_UTILS) not in sys.path:
     sys.path.insert(0, str(_COLLECTION_UTILS))
 
-import adb_cli as adb  # noqa: E402
-import adb_shell  # noqa: E402
-import autojs6_deploy_util as deploy_util  # noqa: E402
+import adb_cli as adb
+import adb_shell
+import autojs6_deploy_util as deploy_util
 
 
 def _run_command(cmd):

--- a/control/tools/autojs6/enable_autojs6_shizuku.py
+++ b/control/tools/autojs6/enable_autojs6_shizuku.py
@@ -24,10 +24,10 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT / "control" / "lib"))
-import a11y_services as a11y  # noqa: E402
-import adb_cli  # noqa: E402
-import post_ui_remote as remote  # noqa: E402
-import stayturgid_device as dev  # noqa: E402
+import a11y_services as a11y
+import adb_cli
+import post_ui_remote as remote
+import stayturgid_device as dev
 
 AUTOJS_PKG = "org.autojs.autojs6"
 AUTOJS_RUN = "org.autojs.autojs.external.open.RunIntentActivity"

--- a/control/tools/autojs6/grant_shizuku.py
+++ b/control/tools/autojs6/grant_shizuku.py
@@ -13,7 +13,7 @@ import sys
 
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 sys.path.insert(0, os.path.join(REPO, "control", "lib"))
-import stayturgid_device as dev  # noqa: E402
+import stayturgid_device as dev
 
 AUTOJS_PKG = "org.autojs.autojs6"
 SHIZUKU_PERM = "moe.shizuku.manager.permission.API_V23"

--- a/control/tools/autojs6/run_test.py
+++ b/control/tools/autojs6/run_test.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT / "control" / "lib"))
-import adb_cli as adb  # noqa: E402
+import adb_cli as adb
 
 SCRIPTS_BASE = f"{adb.AUTOJS_PROJECT_BASE}/scripts"
 

--- a/control/tools/autojs6/set_automation_mode.py
+++ b/control/tools/autojs6/set_automation_mode.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT / "control" / "lib"))
-import adb_cli as adb  # noqa: E402
+import adb_cli as adb
 
 GRANT = Path(__file__).resolve().parent / "grant_shizuku.py"
 ENABLE = Path(__file__).resolve().parent / "enable_autojs6_shizuku.py"

--- a/control/tools/autojs6/setup_autojs6.py
+++ b/control/tools/autojs6/setup_autojs6.py
@@ -13,7 +13,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 TOOL_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(REPO_ROOT / "control" / "lib"))
-import adb_cli as adb  # noqa: E402
+import adb_cli as adb
 
 DL_DIR = Path(__import__("os").environ.get("TMPDIR", "/tmp")) / "stayturgid-autojs6"
 APK_NAME = "autojs6-v6.7.0-arm64-v8a-62db1ff8.apk"

--- a/control/tools/autojs6/start_watchdog.py
+++ b/control/tools/autojs6/start_watchdog.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT / "control" / "lib"))
-import adb_cli as adb  # noqa: E402
+import adb_cli as adb
 
 MAIN = f"{adb.AUTOJS_PROJECT_BASE}/main.js"
 

--- a/control/tools/autojs6/test_tailscale_down.py
+++ b/control/tools/autojs6/test_tailscale_down.py
@@ -15,8 +15,8 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT / "control" / "lib"))
-import adb_cli as adb  # noqa: E402
-import stayturgid_device as dev  # noqa: E402
+import adb_cli as adb
+import stayturgid_device as dev
 
 SCRIPT = f"{adb.AUTOJS_PROJECT_BASE}/scripts/test-tailscale-down-once.js"
 WATCHDOG_LOG = "/sdcard/stayturgid/logs/watchdog.log"

--- a/control/tools/obtainium/apply_updates.py
+++ b/control/tools/obtainium/apply_updates.py
@@ -18,7 +18,7 @@ import time
 
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 sys.path.insert(0, os.path.join(REPO, "control", "lib"))
-import stayturgid_device as dev  # noqa: E402
+import stayturgid_device as dev
 
 OBTAINIUM_PKG = "dev.imranr.obtainium"
 RESULT_FILE = "/data/data/%s/app_flutter/headless_result.json" % OBTAINIUM_PKG

--- a/control/tools/obtainium/enable_shizuku_installer.py
+++ b/control/tools/obtainium/enable_shizuku_installer.py
@@ -22,7 +22,7 @@ import time
 
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 sys.path.insert(0, os.path.join(REPO, "control", "lib"))
-import stayturgid_device as dev  # noqa: E402
+import stayturgid_device as dev
 
 OBTAINIUM_PKG = "dev.imranr.obtainium"
 SHIZUKU_PERM = "moe.shizuku.manager.permission.API_V23"

--- a/control/tools/obtainium/import_catalog.py
+++ b/control/tools/obtainium/import_catalog.py
@@ -17,7 +17,7 @@ import urllib.parse
 
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 sys.path.insert(0, os.path.join(REPO, "control", "lib"))
-import stayturgid_device as dev  # noqa: E402
+import stayturgid_device as dev
 
 OBTAINIUM_PKG = "dev.imranr.obtainium"
 CATALOGS = {

--- a/control/tools/obtainium/sync_to_device.py
+++ b/control/tools/obtainium/sync_to_device.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT / "control" / "lib"))
-import adb_cli as adb  # noqa: E402
+import adb_cli as adb
 
 OBTAINIUM_PKG = "dev.imranr.obtainium"
 IMPORT_SCRIPT = Path(__file__).resolve().parent / "import_catalog.py"

--- a/control/tools/play/configure_aurora.py
+++ b/control/tools/play/configure_aurora.py
@@ -17,10 +17,10 @@ import xml.sax.saxutils as saxutils
 
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 sys.path.insert(0, os.path.join(REPO, "control", "lib"))
-import post_ui_remote as remote  # noqa: E402
-import screen_control as sc  # noqa: E402
-import stayturgid_device as dev  # noqa: E402
-import ui_driver as uid  # noqa: E402
+import post_ui_remote as remote
+import screen_control as sc
+import stayturgid_device as dev
+import ui_driver as uid
 
 AURORA_PKG = "com.aurora.store"
 BACKGROUND_DIALOG_MARKERS = (

--- a/control/tools/play/open_play_app.py
+++ b/control/tools/play/open_play_app.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT / "control" / "lib"))
-import adb_cli as adb  # noqa: E402
+import adb_cli as adb
 
 AURORA = os.environ.get("AURORA_PKG", "com.aurora.store")
 

--- a/device/termux/py/stayturgid_agent_presence.py
+++ b/device/termux/py/stayturgid_agent_presence.py
@@ -37,11 +37,11 @@ if os.path.isfile(_ENV_FILE):
         pass
 
 # Prefer ~/.stayturgid/lib (deployed) then repo control/lib (dev / unit tests).
-import stayturgid_shell as sh  # noqa: E402
+import stayturgid_shell as sh
 
 sh.ensure_lib_path()
 try:
-    import termux_api as tapi  # noqa: E402
+    import termux_api as tapi
 except ImportError:
     tapi = None
 

--- a/device/termux/py/stayturgid_autojs6_guard.py
+++ b/device/termux/py/stayturgid_autojs6_guard.py
@@ -25,11 +25,11 @@ if os.path.isfile(_ENV_FILE):
     except OSError:
         pass
 
-import stayturgid_shell as sh  # noqa: E402
+import stayturgid_shell as sh
 
 sh.ensure_lib_path()
 try:
-    import termux_api as tapi  # noqa: E402
+    import termux_api as tapi
 except ImportError:
     tapi = None
 

--- a/device/termux/py/stayturgid_battery_alarm.py
+++ b/device/termux/py/stayturgid_battery_alarm.py
@@ -32,11 +32,11 @@ if os.path.isfile(_ENV_FILE):
     except OSError:
         pass
 
-import stayturgid_shell as sh  # noqa: E402
+import stayturgid_shell as sh
 
 sh.ensure_lib_path()
 try:
-    import termux_api as tapi  # noqa: E402
+    import termux_api as tapi
 except ImportError:
     tapi = None
 

--- a/device/termux/py/stayturgid_check_repo_version.py
+++ b/device/termux/py/stayturgid_check_repo_version.py
@@ -64,10 +64,10 @@ def main():
     changelog = _field(body, "changelog") or "Run control/bin/deploy_termux.py from your Mac"
     # Never SIGKILL termux-notification — orphan on hang (ResultReturner).
     try:
-        import stayturgid_shell as sh  # noqa: WPS433
+        import stayturgid_shell as sh
 
         sh.ensure_lib_path()
-        import termux_api as tapi  # noqa: WPS433
+        import termux_api as tapi
 
         tapi.notify(
             [

--- a/device/termux/py/stayturgid_configure_aurora.py
+++ b/device/termux/py/stayturgid_configure_aurora.py
@@ -15,9 +15,9 @@ import xml.sax.saxutils as saxutils
 import stayturgid_shell as sh
 
 sh.ensure_lib_path()
-import stayturgid_handsets as hs  # noqa: E402
-import stayturgid_screen_control as sc  # noqa: E402
-from ui_parse import parse_button_center, parse_text_center  # noqa: E402
+import stayturgid_handsets as hs
+import stayturgid_screen_control as sc
+from ui_parse import parse_button_center, parse_text_center
 
 _HS: hs.Session | None = None
 

--- a/device/termux/py/stayturgid_enable_autojs6.py
+++ b/device/termux/py/stayturgid_enable_autojs6.py
@@ -19,7 +19,7 @@ import time
 import stayturgid_shell as sh
 
 sh.ensure_lib_path()
-import a11y_services as a11y  # noqa: E402
+import a11y_services as a11y
 
 AUTOJS_PKG = "org.autojs.autojs6"
 AUTOJS_FLEET_ACTIVITY = "org.autojs.autojs.core.pref.fleet.FleetProfileActivity"

--- a/device/termux/py/stayturgid_peer_keepalive.py
+++ b/device/termux/py/stayturgid_peer_keepalive.py
@@ -116,7 +116,7 @@ def ensure_handsets() -> bool:
         _touch("handsets")
         _log(("OK" if ok else "FAIL") + " handsets start port=%d" % port)
         return ok
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         _touch("handsets")
         _log("FAIL handsets: %s" % e)
         return False

--- a/device/termux/py/stayturgid_screen_awake_guard.py
+++ b/device/termux/py/stayturgid_screen_awake_guard.py
@@ -28,11 +28,11 @@ if os.path.isfile(_ENV_FILE):
     except OSError:
         pass
 
-import stayturgid_shell as sh  # noqa: E402
+import stayturgid_shell as sh
 
 sh.ensure_lib_path()
 try:
-    import termux_api as tapi  # noqa: E402
+    import termux_api as tapi
 except ImportError:
     tapi = None
 

--- a/device/termux/py/stayturgid_screen_control.py
+++ b/device/termux/py/stayturgid_screen_control.py
@@ -21,7 +21,7 @@ sh.ensure_lib_path()
 try:
     import ui_clearance as uc
 except ImportError:
-    from shared import ui_clearance as uc  # noqa: E402
+    from shared import ui_clearance as uc
 
 INVERSION_KEY = "accessibility_display_inversion_enabled"
 ADB_KEYBOARD = "com.github.uiautomator/.AdbKeyboard"
@@ -284,7 +284,7 @@ class ScreenControlSession(object):
                 apply_portrait_lock()
                 if not self._skip:
                     local_presence("guard", self.label, self.agent)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 sys.stderr.write("WARN: screen-control keepalive: %s\n" % e)
 
     def _start_keepalive(self):

--- a/docs/research/bench_handsets_vs_u2.py
+++ b/docs/research/bench_handsets_vs_u2.py
@@ -23,8 +23,8 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 sys.path[:0] = [str(REPO / "control" / "lib")]
-import stayturgid_device as dev  # noqa: E402
-import ui_driver as uid  # noqa: E402
+import stayturgid_device as dev
+import ui_driver as uid
 
 U2_SITE = Path.home() / ".local/pipx/venvs/uiautomator2/lib/python3.14/site-packages"
 sys.path.insert(0, str(U2_SITE))

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -34,7 +34,7 @@ def _restore_host_env() -> None:
             os.environ[key] = value
 
 
-def pytest_collection_finish(session: pytest.Session) -> None:  # noqa: ARG001
+def pytest_collection_finish(session: pytest.Session) -> None:
     """Undo Termux boot-supervisor env mutations performed during collection."""
     _restore_host_env()
 

--- a/tests/python/test_a11y_services.py
+++ b/tests/python/test_a11y_services.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "lib"))
-import a11y_services as a11y  # noqa: E402
+import a11y_services as a11y
 
 
 def test_parse_services():

--- a/tests/python/test_access_monitor.py
+++ b/tests/python/test_access_monitor.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "mac"))
-import access_monitor as am  # noqa: E402
+import access_monitor as am
 
 
 def test_read_devices(tmp_path):

--- a/tests/python/test_adb_cli.py
+++ b/tests/python/test_adb_cli.py
@@ -6,7 +6,7 @@ import sys
 sys.path.insert(
     0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "control", "lib")
 )
-import adb_cli as ac  # noqa: E402
+import adb_cli as ac
 
 sys.path.insert(
     0,
@@ -14,7 +14,7 @@ sys.path.insert(
         os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "control", "tools", "obtainium"
     ),
 )
-import sync_to_device as sync  # noqa: E402
+import sync_to_device as sync
 
 
 def test_autojs_constants():

--- a/tests/python/test_adb_reconnect.py
+++ b/tests/python/test_adb_reconnect.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "mac"))
-import adb_reconnect as ar  # noqa: E402
+import adb_reconnect as ar
 
 
 def test_build_candidates_order_and_dedup():

--- a/tests/python/test_adb_resolve.py
+++ b/tests/python/test_adb_resolve.py
@@ -14,7 +14,7 @@ assert _spec.loader is not None
 _spec.loader.exec_module(adb_resolve)
 
 sys.path.insert(0, str(Path(REPO) / "control" / "lib"))
-import stayturgid_device as dev  # noqa: E402
+import stayturgid_device as dev
 
 
 def _devices_listing(*lines):

--- a/tests/python/test_ascii_paths.py
+++ b/tests/python/test_ascii_paths.py
@@ -11,7 +11,7 @@ sys.path.insert(
     0,
     str(REPO / "ansible_collections" / "stayturgid" / "android_common" / "plugins" / "module_utils"),
 )
-import autojs6_deploy_util as util  # noqa: E402
+import autojs6_deploy_util as util
 
 AUTOJS6 = REPO / "device" / "autojs6"
 NON_ASCII = re.compile(r"[^\x00-\x7F]")

--- a/tests/python/test_autojs6_deploy.py
+++ b/tests/python/test_autojs6_deploy.py
@@ -16,8 +16,8 @@ sys.path.insert(
     str(REPO / "ansible_collections" / "stayturgid" / "android_common" / "plugins" / "module_utils"),
 )
 
-import autojs6_deploy_util as deploy_util  # noqa: E402
-import deploy as deploy_mod  # noqa: E402
+import autojs6_deploy_util as deploy_util
+import deploy as deploy_mod
 
 
 def test_deploy_wipes_lib_scripts_before_push(monkeypatch, tmp_path):

--- a/tests/python/test_autojs6_guard.py
+++ b/tests/python/test_autojs6_guard.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "device" / "termux" / "py"))
 
-import stayturgid_autojs6_guard as guard  # noqa: E402
+import stayturgid_autojs6_guard as guard
 
 
 def _write_log(path: Path, lines: list[str]) -> None:

--- a/tests/python/test_check_fleet_health.py
+++ b/tests/python/test_check_fleet_health.py
@@ -9,7 +9,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "bin"))
 
-import check_fleet_health as cfh  # noqa: E402
+import check_fleet_health as cfh
 
 
 def test_latest_per_host(tmp_path):

--- a/tests/python/test_dashboard.py
+++ b/tests/python/test_dashboard.py
@@ -11,7 +11,7 @@ REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "bin"))
 
 pytest.importorskip("flask")
-import dashboard  # noqa: E402
+import dashboard
 
 
 def test_rish_probe_requires_uid_2000(monkeypatch):

--- a/tests/python/test_deploy_fleet.py
+++ b/tests/python/test_deploy_fleet.py
@@ -7,7 +7,7 @@ from typing import Any
 sys.path.insert(
     0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "control", "bin")
 )
-import deploy_fleet as df  # noqa: E402
+import deploy_fleet as df
 
 INVENTORY_JSON: dict[str, Any] = {
     "stayturgid": {

--- a/tests/python/test_device_screen_lease.py
+++ b/tests/python/test_device_screen_lease.py
@@ -13,7 +13,7 @@ sys.path.insert(
     0,
     str(Path(__file__).resolve().parents[2] / "control" / "lib"),
 )
-import device_screen_lease as dsl  # noqa: E402
+import device_screen_lease as dsl
 
 
 @pytest.fixture()

--- a/tests/python/test_device_tier.py
+++ b/tests/python/test_device_tier.py
@@ -9,7 +9,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "tests"))
-import device_tier as dt  # noqa: E402
+import device_tier as dt
 
 HEALTHY = """\
 ssh=ok

--- a/tests/python/test_enable_autojs6_a11y.py
+++ b/tests/python/test_enable_autojs6_a11y.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "lib"))
-import a11y_services as a11y  # noqa: E402
+import a11y_services as a11y
 
 A11Y_SVC = a11y.AUTOJS6_A11Y
 

--- a/tests/python/test_et_mac.py
+++ b/tests/python/test_et_mac.py
@@ -8,8 +8,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "control" / "lib"))
 
-import et_mac as em  # noqa: E402
-import ssh_marked_block as smb  # noqa: E402
+import et_mac as em
+import ssh_marked_block as smb
 
 
 def test_replace_marked_block_append():

--- a/tests/python/test_fire_peer_help.py
+++ b/tests/python/test_fire_peer_help.py
@@ -8,7 +8,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "bin"))
 
-import fire_peer_help as fph  # noqa: E402
+import fire_peer_help as fph
 
 
 def test_ssh_original_parses_verb(monkeypatch):

--- a/tests/python/test_fleet_app_privileges.py
+++ b/tests/python/test_fleet_app_privileges.py
@@ -10,8 +10,8 @@ ROOT = os.path.abspath(
 )
 sys.path.insert(0, os.path.join(ROOT, "plugins", "module_utils"))
 
-import adb_shell  # noqa: E402
-import fleet_privileges as fp  # noqa: E402
+import adb_shell
+import fleet_privileges as fp
 
 SAMPLE_DUMPSYS = """
 runtime permissions:

--- a/tests/python/test_fleet_entry_guards.py
+++ b/tests/python/test_fleet_entry_guards.py
@@ -18,9 +18,9 @@ _BIN = _ROOT / "control" / "bin"
 if str(_BIN) not in sys.path:
     sys.path.insert(0, str(_BIN))
 
-import deploy_termux as dt  # noqa: E402
-import verify_drift as vd  # noqa: E402
-from ansible_context import AnsibleConfigError, AnsibleContext  # noqa: E402
+import deploy_termux as dt
+import verify_drift as vd
+from ansible_context import AnsibleConfigError, AnsibleContext
 
 # ---------------------------------------------------------------------------
 # H1: no tracked file is a render/copy target of agents.yml

--- a/tests/python/test_fleet_health.py
+++ b/tests/python/test_fleet_health.py
@@ -11,8 +11,8 @@ REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "lib"))
 sys.path.insert(0, str(REPO / "control" / "bin"))
 
-import fleet_health as fh  # noqa: E402
-import fleet_health_monitor as fhm  # noqa: E402
+import fleet_health as fh
+import fleet_health_monitor as fhm
 
 
 def test_parse_kv():

--- a/tests/python/test_gui_audit.py
+++ b/tests/python/test_gui_audit.py
@@ -9,7 +9,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "bin"))
 
-import gui_audit as ga  # noqa: E402
+import gui_audit as ga
 
 
 def test_read_hosts(tmp_path):

--- a/tests/python/test_hd8_google_stack.py
+++ b/tests/python/test_hd8_google_stack.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "control" / "lib"))
-import hd8_google_stack as hgs  # noqa: E402
+import hd8_google_stack as hgs
 
 
 def test_parse_version_code():

--- a/tests/python/test_landing_state.py
+++ b/tests/python/test_landing_state.py
@@ -9,7 +9,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
-from control.landing import discover, state  # noqa: E402
+from control.landing import discover, state
 
 
 def test_first_use_migrates_legacy_observations(tmp_path, monkeypatch):

--- a/tests/python/test_olivetin_projection.py
+++ b/tests/python/test_olivetin_projection.py
@@ -18,9 +18,9 @@ import yaml
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
-from control.site_contract import olivetin_projection as op  # noqa: E402
-from control.site_contract import site_init as si  # noqa: E402
-from control.site_contract import site_sync as ss  # noqa: E402
+from control.site_contract import olivetin_projection as op
+from control.site_contract import site_init as si
+from control.site_contract import site_sync as ss
 
 FIXED_VERSION = "9.9.9-test"
 FIXED_COMMIT = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/tests/python/test_peer_bootstrap.py
+++ b/tests/python/test_peer_bootstrap.py
@@ -9,8 +9,8 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "device" / "termux" / "py"))
 
-import stayturgid_handsets as th  # noqa: E402
-import stayturgid_peer_bootstrap as pb  # noqa: E402
+import stayturgid_handsets as th
+import stayturgid_peer_bootstrap as pb
 
 
 def test_peer_endpoints_prefer_lan():

--- a/tests/python/test_peer_keepalive.py
+++ b/tests/python/test_peer_keepalive.py
@@ -8,7 +8,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "device" / "termux" / "py"))
 
-import stayturgid_peer_keepalive as pk  # noqa: E402
+import stayturgid_peer_keepalive as pk
 
 
 def test_no_local_adb_env(monkeypatch):

--- a/tests/python/test_post_ui_remote.py
+++ b/tests/python/test_post_ui_remote.py
@@ -11,7 +11,7 @@ sys.path.insert(
         "lib",
     ),
 )
-import post_ui_remote as remote  # noqa: E402
+import post_ui_remote as remote
 
 
 def test_hd8_uses_mac_usb(monkeypatch):

--- a/tests/python/test_screen_control.py
+++ b/tests/python/test_screen_control.py
@@ -8,7 +8,7 @@ import pytest
 sys.path.insert(
     0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "control", "lib")
 )
-import screen_control as sc  # noqa: E402
+import screen_control as sc
 
 
 def test_is_input_command_detects_tap():

--- a/tests/python/test_serverapps.py
+++ b/tests/python/test_serverapps.py
@@ -11,9 +11,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
-from control.site_contract import serverapps as sa  # noqa: E402
-from control.site_contract import site_init as si  # noqa: E402
-from control.site_contract import site_sync as ss  # noqa: E402
+from control.site_contract import serverapps as sa
+from control.site_contract import site_init as si
+from control.site_contract import site_sync as ss
 
 FIXED_VERSION = "9.9.9-test"
 FIXED_COMMIT = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"

--- a/tests/python/test_shell_libs.py
+++ b/tests/python/test_shell_libs.py
@@ -10,7 +10,7 @@ REPO = Path(__file__).resolve().parents[2]
 
 def test_stayturgid_root_finds_repo():
     sys.path.insert(0, str(REPO / "control" / "lib"))
-    import stayturgid_root as root_mod  # noqa: E402
+    import stayturgid_root as root_mod
 
     assert root_mod.stayturgid_root(REPO / "control/bin/deploy_fleet.py") == REPO
 

--- a/tests/python/test_shizuku_device.py
+++ b/tests/python/test_shizuku_device.py
@@ -11,7 +11,7 @@ sys.path.insert(
 import importlib.util
 from pathlib import Path
 
-import stayturgid_device as dev  # noqa: E402
+import stayturgid_device as dev
 
 _REPO = Path(__file__).resolve().parents[2]
 _MOD = _REPO / "ansible_collections/stayturgid/android_common/plugins/module_utils/adb_resolve.py"

--- a/tests/python/test_site_contract_entangled.py
+++ b/tests/python/test_site_contract_entangled.py
@@ -13,9 +13,9 @@ import pytest
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
-from control.site_contract import check_entangled as ce  # noqa: E402
-from control.site_contract import generate_registry_seeds as seeds  # noqa: E402
-from control.site_contract import site_init as si  # noqa: E402
+from control.site_contract import check_entangled as ce
+from control.site_contract import generate_registry_seeds as seeds
+from control.site_contract import site_init as si
 
 TEMPLATES = ROOT / "control" / "site_contract" / "templates"
 SITE_CONTRACT = ROOT / "SITE-CONTRACT.md"

--- a/tests/python/test_site_contract_templates.py
+++ b/tests/python/test_site_contract_templates.py
@@ -12,7 +12,7 @@ from jinja2 import Environment, StrictUndefined
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
-from control.site_contract import generate_registry_seeds as seeds  # noqa: E402
+from control.site_contract import generate_registry_seeds as seeds
 
 TEMPLATES = ROOT / "control" / "site_contract" / "templates"
 

--- a/tests/python/test_site_init.py
+++ b/tests/python/test_site_init.py
@@ -18,7 +18,7 @@ import yaml
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
-from control.site_contract import site_init as si  # noqa: E402
+from control.site_contract import site_init as si
 
 TEMPLATES = ROOT / "control" / "site_contract" / "templates"
 

--- a/tests/python/test_site_sync.py
+++ b/tests/python/test_site_sync.py
@@ -17,8 +17,8 @@ import yaml
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 
-from control.site_contract import site_init as si  # noqa: E402
-from control.site_contract import site_sync as ss  # noqa: E402
+from control.site_contract import site_init as si
+from control.site_contract import site_sync as ss
 
 FIXED_VERSION = "9.9.9-test"
 FIXED_COMMIT = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/tests/python/test_start_adb.py
+++ b/tests/python/test_start_adb.py
@@ -8,7 +8,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "device" / "termux" / "py"))
 
-import start_adb  # noqa: E402
+import start_adb
 
 
 def test_shell_transport_prefers_localhost_adb(monkeypatch):

--- a/tests/python/test_stayturgid_device_conf.py
+++ b/tests/python/test_stayturgid_device_conf.py
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "control" / "lib"))
-import stayturgid_device as sd  # noqa: E402
+import stayturgid_device as sd
 
 
 def test_iter_devices_conf_and_monitor_hosts(tmp_path):

--- a/tests/python/test_termux_api.py
+++ b/tests/python/test_termux_api.py
@@ -9,7 +9,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "lib"))
 
-import termux_api as tapi  # noqa: E402
+import termux_api as tapi
 
 
 def test_is_termux_api():

--- a/tests/python/test_termux_handsets.py
+++ b/tests/python/test_termux_handsets.py
@@ -9,7 +9,7 @@ REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "device" / "termux" / "py"))
 
 # Import module under test without stayturgid_shell connecting.
-import stayturgid_handsets as th  # noqa: E402
+import stayturgid_handsets as th
 
 
 def test_frame_pack():

--- a/tests/python/test_termux_rish.py
+++ b/tests/python/test_termux_rish.py
@@ -9,7 +9,7 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "device" / "termux" / "py"))
 
-import stayturgid_rish as rish  # noqa: E402
+import stayturgid_rish as rish
 
 
 def test_wrapper_body_sets_termux_app_id():

--- a/tests/python/test_termux_shell.py
+++ b/tests/python/test_termux_shell.py
@@ -6,7 +6,7 @@ import sys
 
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, os.path.join(REPO, "device", "termux", "py"))
-import stayturgid_shell as sh  # noqa: E402
+import stayturgid_shell as sh
 
 
 def test_privileged_shell_expected_false_from_profile(tmp_path, monkeypatch):

--- a/tests/python/test_termux_ssh_bootstrap.py
+++ b/tests/python/test_termux_ssh_bootstrap.py
@@ -16,7 +16,7 @@ _COLLECTION_UTILS = os.path.join(
 )
 sys.path.insert(0, _COLLECTION_UTILS)
 
-import termux_run_as as tr  # noqa: E402
+import termux_run_as as tr
 
 
 def test_discover_pubkey_paths_explicit(tmp_path):

--- a/tests/python/test_ui_clearance.py
+++ b/tests/python/test_ui_clearance.py
@@ -7,7 +7,7 @@ from pathlib import Path
 sys.path.insert(
     0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "control", "lib")
 )
-import ui_clearance as uc  # noqa: E402
+import ui_clearance as uc
 
 PINNED_STACK = """
 RootTask id=42 bounds=[800,1600][1080,1900] displayId=0 userId=0

--- a/tests/python/test_ui_driver.py
+++ b/tests/python/test_ui_driver.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "lib"))
 
-import ui_driver as ud  # noqa: E402
+import ui_driver as ud
 
 
 def test_port_for_defaults():

--- a/tests/python/test_verify_hd8_google.py
+++ b/tests/python/test_verify_hd8_google.py
@@ -10,8 +10,8 @@ REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "lib"))
 sys.path.insert(0, str(REPO / "control" / "bin"))
 
-import hd8_google_stack as hgs  # noqa: E402
-import verify_hd8_google as vhg  # noqa: E402
+import hd8_google_stack as hgs
+import verify_hd8_google as vhg
 
 
 def test_check_stack_ok(monkeypatch):

--- a/tests/python/test_vlm_cloud.py
+++ b/tests/python/test_vlm_cloud.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "control" / "lib"))
-import vlm_cloud as cloud  # noqa: E402
+import vlm_cloud as cloud
 
 
 def test_load_env_file(tmp_path, monkeypatch):

--- a/tests/python/test_vlm_gate.py
+++ b/tests/python/test_vlm_gate.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO / "control" / "lib"))
 
-import vlm_gate as vlm  # noqa: E402
+import vlm_gate as vlm
 
 
 def test_vlm_disabled_by_default(monkeypatch):


### PR DESCRIPTION
## Summary

Follow-up to the mypy PR. While explaining what `# noqa` comments are (prompted by the `stayturgid_verify.py` forward-reference bug hidden behind a wrong `# noqa: F821`), checked whether any of the other 213 noqa comments in the tree were similarly stale.

Verified via `ruff check --show-settings` (not just reading `pyproject.toml`) exactly which rule codes this project's ruff config actually enforces (`select = ["E", "F", "I", "W"]`, `ignore = ["E501", "E402"]`):

- **E402** (177 comments) — explicitly in ruff's own `ignore` list. Never enforced.
- **BLE001** (23) — not in ruff's rule set at all; this project doesn't run flake8-blind-except.
- **WPS433** (4), **PLC0415** (2), **ARG001** (1) — codes from wemake-python-styleguide and Pylint, tools this project's toolchain never runs.

Only **F401** (7, unused-import) is actually live and stayed.

207 dead noqa tags removed across 121 files. Comment-only change — reviewed the full diff to confirm every hunk is exactly "drop the trailing `# noqa: <dead-code>`," nothing else. One multi-code line (`# noqa: F401, E402`) narrowed to just `# noqa: F401`; one line with attached explanatory text (`# noqa: BLE001 — soft skip`) kept the explanation as a plain comment and dropped only the dead tag.

## Test plan

- [x] `ruff check .` / `ruff format --check .` — identical pass/fail before and after (confirms these rules were genuinely inert)
- [x] `mypy control/ device/termux/py/ ansible_collections/ tests/` — still 0 errors, 229 files
- [x] `just check` — exit 0
- [x] Full `just test` — 511 passed, 1 skipped (unchanged)
- [x] `just lint` — exit 0
- [x] Full `pre-commit run --all-files` — all hooks pass
- [ ] CI green on this PR (checking after push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed outdated lint-suppression annotations across scripts, libraries, and tests.
  * Standardized import setup after path configuration to improve lint compliance.
  * Preserved existing runtime behavior, exception handling, and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->