### PR TITLE
Rewrite device/autojs6 TypeScript in idiomatic, strictly-typed form

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,18 @@ repos:
             # wouldn't see it). Fail and name them rather than silently
             # `git add`-ing whatever changed — the developer reviews and
             # stages, same as ruff --fix.
-            dirty=$(git status --porcelain -- device/autojs6 tests/js just/tools docs/research | cut -c4- | grep -E '\.(js|ts)$' || true)
+            #
+            # Only flag what's NOT reflected in the index: unstaged edits to
+            # tracked files (git diff) plus brand-new untracked files (status
+            # `??`). Deliberately NOT `git status --porcelain` wholesale —
+            # that also matches files already staged for *this* commit,
+            # which is the normal, correct state right before committing.
+            dirty=$(
+              {
+                git diff --name-only -- device/autojs6 tests/js just/tools docs/research
+                git status --porcelain --untracked-files=normal -- device/autojs6 tests/js just/tools docs/research | grep '^??' | cut -c4-
+              } | sort -u | grep -E '\.(js|ts)$' || true
+            )
             if [ -n "$dirty" ]; then
               echo "error: TypeScript build produced unstaged changes:"
               echo "$dirty" | sed 's/^/  /'

--- a/device/autojs6/lib/comonitor.js
+++ b/device/autojs6/lib/comonitor.js
@@ -1,6 +1,10 @@
 // @generated
 "use strict";
-// @ts-nocheck
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.probeA11y = probeA11y;
+exports.probeSshd = probeSshd;
+exports.probeShizuku = probeShizuku;
+exports.run = run;
 // @heals: SSHD-RUNNING PORT5555-OPEN SHIZUKU-HEADLESS A11Y-AUTOJS6
 /**
  * AutoJs6 co-monitor — redundant health probes via Shizuku when Termux is
@@ -12,22 +16,20 @@
  *
  * Does NOT replace Termux-primary repair when the boot loop is healthy.
  */
-var config = require("./config.js");
-var log = require("./log.js");
-var notify = require("./notify.js");
-var shizukuShell = require("./shizuku_shell.js");
-var repair = require("./repair.js");
-var A11Y_SVC = config.AUTOJS6_A11Y;
+const config = require("./config.js");
+const log = require("./log.js");
+const notify = require("./notify.js");
+const shizukuShell = require("./shizuku_shell.js");
+const repair = require("./repair.js");
+const A11Y_SVC = config.AUTOJS6_A11Y;
 function sh(cmd) {
-  var r = shizukuShell.exec(cmd);
-  if (!r) return { code: -1, result: "" };
-  return {
-    code: typeof r.code === "number" ? r.code : -1,
-    result: String(r.result || r.stdout || "")
-      .replace(/\r/g, "")
-      .trim(),
-  };
+  const r = shizukuShell.exec(cmd);
+  return { code: r.code, result: r.result.replace(/\r/g, "").trim() };
 }
+// Notify at most once per engine process that a11y looks sticky (Settings ON,
+// auto.service null) — a module-level flag replaces the original's
+// probeA11y._stickyLogged function-property hack.
+let stickyA11yLogged = false;
 function probeA11y(split) {
   // Prefer live bind (auto.service). Settings-list alone false-positives sticky ON.
   try {
@@ -36,12 +38,12 @@ function probeA11y(split) {
       notify.clear("a11y-stale");
       return "up";
     }
-  } catch (e) {
+  } catch (_a) {
     /* fall through */
   }
-  var r = sh("settings get secure enabled_accessibility_services");
-  var list = (r.result || "").trim();
-  var listed = !!(list && list !== "null" && list.indexOf(A11Y_SVC) >= 0);
+  const r = sh("settings get secure enabled_accessibility_services");
+  const list = r.result.trim();
+  const listed = Boolean(list && list !== "null" && list.indexOf(A11Y_SVC) >= 0);
   // Sticky candidate: Settings ON but auto.service null. On some builds/devices
   // auto.service flickers null even while the engine is mid-cycle and listed
   // (s24 noise after debug APK). Treat as degraded, not hard FAILED, and notify
@@ -49,8 +51,8 @@ function probeA11y(split) {
   if (listed && typeof auto !== "undefined") {
     try {
       if (!auto.service) {
-        if (!probeA11y._stickyLogged) {
-          probeA11y._stickyLogged = true;
+        if (!stickyA11yLogged) {
+          stickyA11yLogged = true;
           log.append("[comonitor] A11Y STICKY candidate — listed ON but auto.service null (notify once; not FAILED)");
           notify.show(
             "AutoJs6 accessibility may be sticky",
@@ -60,7 +62,7 @@ function probeA11y(split) {
         }
         return "degraded";
       }
-    } catch (e2) {
+    } catch (_b) {
       /* fall through */
     }
   }
@@ -81,7 +83,7 @@ function probeA11y(split) {
   return "down";
 }
 function probeSshd() {
-  var r = sh("pgrep -x sshd >/dev/null 2>&1 || pgrep -f '[s]shd' >/dev/null 2>&1");
+  const r = sh("pgrep -x sshd >/dev/null 2>&1 || pgrep -f '[s]shd' >/dev/null 2>&1");
   return r.code === 0 ? "up" : "down";
 }
 function restartSshd() {
@@ -97,10 +99,10 @@ function restartSshd() {
 }
 function probeShizuku() {
   if (shizukuShell.isOperational()) return "up";
-  var r = sh("am broadcast -a moe.shizuku.privileged.api.HEADLESS_STATUS 2>/dev/null");
-  if (r && r.code === 0 && r.result && r.result.indexOf("result=1") >= 0) return "up";
+  const r = sh("am broadcast -a moe.shizuku.privileged.api.HEADLESS_STATUS 2>/dev/null");
+  if (r.code === 0 && r.result.indexOf("result=1") >= 0) return "up";
   // Samsung freezes the Java receiver; fall back to pgrep.
-  var p = sh("pgrep -f '[s]hizuku_server' >/dev/null 2>&1");
+  const p = sh("pgrep -f '[s]hizuku_server' >/dev/null 2>&1");
   if (p.code === 0) return "up";
   return "down";
 }
@@ -109,13 +111,13 @@ function probeShell5555(split, termuxStatus) {
   // Prefer fresh Termux STATUS — AutoJs6 shizuku() often lacks a working
   // `adb` binary/PATH, so a live adb probe false-fires CLOSED_NO_SHELL.
   if (termuxStatus && termuxStatus.port) {
-    var p = termuxStatus.port;
+    const p = termuxStatus.port;
     if (p === "open") return { port: "open", shell: "yes" };
     if (p === "skip") return { port: "skip", shell: "no" };
     if (p === "CLOSED_NO_SHELL") return { port: "CLOSED_NO_SHELL", shell: "no" };
   }
   // Live listen check (no adb client required).
-  var nc = sh("toybox nc -z 127.0.0.1 5555 >/dev/null 2>&1 || " + "nc -z 127.0.0.1 5555 >/dev/null 2>&1");
+  const nc = sh("toybox nc -z 127.0.0.1 5555 >/dev/null 2>&1 || nc -z 127.0.0.1 5555 >/dev/null 2>&1");
   if (nc.code === 0) return { port: "open", shell: "yes" };
   // Shizuku API up ⇒ privileged shell available even if adbd TCP is odd.
   if (shizukuShell.isOperational()) {
@@ -125,42 +127,41 @@ function probeShell5555(split, termuxStatus) {
 }
 function probeWifi(split, shellProbe) {
   if (split) return "skip";
-  var r = sh("settings get global adb_wifi_enabled");
-  var v = (r.result || "").trim();
+  const r = sh("settings get global adb_wifi_enabled");
+  const v = r.result.trim();
   if (v === "1" || v === "true") return "up";
   // Samsung: adb_wifi_enabled reads 0 but port 5555 works (Shizuku opens it).
   // Pixel Android 16: settings put blocked on this key. If shell works, skip write.
-  if (shellProbe && shellProbe.port === "open") return "up";
+  if (shellProbe.port === "open") return "up";
   sh("settings put global adb_wifi_enabled 1");
   sleep(1000);
-  var r2 = sh("settings get global adb_wifi_enabled");
-  var v2 = (r2.result || "").trim();
+  const r2 = sh("settings get global adb_wifi_enabled");
+  const v2 = r2.result.trim();
   if (v2 === "1" || v2 === "true") return "repaired";
   return "FAILED";
 }
-/**
-
- * Run co-monitor probes. Returns a STATUS-like object.
- * @param {object} profile
- * @param {{force?: boolean, reason?: string}} opts
- */
+/** Run co-monitor probes. Returns a STATUS-like object, or null when deferred. */
 function run(profile, opts) {
-  opts = opts || {};
-  profile = profile || config.detectDeviceProfile();
-  var split = config.splitStorage(profile);
-  var reason = opts.reason || (split ? "split-storage" : "termux-stale");
-  if (!opts.force && !log.isRepairLoopStale() && !config.splitStorage(profile)) {
+  const resolvedProfile = profile || config.detectDeviceProfile();
+  const split = config.splitStorage(resolvedProfile);
+  const reason =
+    (opts === null || opts === void 0 ? void 0 : opts.reason) || (split ? "split-storage" : "termux-stale");
+  if (
+    !(opts === null || opts === void 0 ? void 0 : opts.force) &&
+    !log.isRepairLoopStale() &&
+    !config.splitStorage(resolvedProfile)
+  ) {
     // Callers normally pass force=true (periodic fleet parity). Keep the
     // defer path for unit tests / ad-hoc imports.
     return null;
   }
   log.append("[comonitor] start reason=" + reason + " shizuku_api=" + (shizukuShell.isOperational() ? "yes" : "no"));
-  var sshd = probeSshd();
+  let sshd = probeSshd();
   // Shizuku pgrep is unreliable when the AutoJs6↔Shizuku binder is broken
   // (s24 "Unable to use Shizuku service") or on Fire split-storage. Prefer a
   // fresh Termux STATUS before restarting or notifying.
   if (sshd === "down" && !log.isRepairLoopStale()) {
-    var earlyTrust = log.latestRepairStatus();
+    const earlyTrust = log.latestRepairStatus();
     if (earlyTrust && earlyTrust.sshd === "up") {
       log.append("[comonitor] trusting fresh [repair] sshd=up over shizuku pgrep");
       sshd = "up";
@@ -173,23 +174,23 @@ function run(profile, opts) {
   } else if (sshd === "down" && split) {
     log.append("[comonitor] sshd probe down on split-storage — leave to Termux (no shizuku restart)");
   }
-  var shizuku = probeShizuku();
-  var termuxStatus = null;
+  let shizukuStatus = probeShizuku();
+  let termuxStatus = null;
   try {
     if (!log.isRepairLoopStale()) {
       termuxStatus = log.latestRepairStatus();
     }
-  } catch (e) {
+  } catch (_a) {
     /* best effort */
   }
-  var shellProbe = probeShell5555(split, termuxStatus);
-  var wifi = probeWifi(split, shellProbe);
-  var a11y = probeA11y(split);
+  let shellProbe = probeShell5555(split, termuxStatus);
+  const wifi = probeWifi(split, shellProbe);
+  const a11y = probeA11y(split);
   // Trust fresh Termux [repair] port=open over a flaky nc/adb probe.
   if (!split && shellProbe.port === "CLOSED_NO_SHELL" && !log.isRepairLoopStale()) {
-    var trust = log.latestRepairStatus();
+    const trust = log.latestRepairStatus();
     if (trust && trust.port === "open") {
-      shellProbe = { port: "open", shell: trust.shell || "yes" };
+      shellProbe = { port: "open", shell: trust.shell === "no" ? "no" : "yes" };
       log.append("[comonitor] trusting fresh [repair] port=open over shell probe");
     }
   }
@@ -208,32 +209,32 @@ function run(profile, opts) {
       "adb5555",
     );
     try {
-      repair.repairCatastrophic(profile);
+      repair.repairCatastrophic(resolvedProfile);
     } catch (e) {
       log.append("[comonitor] catastrophic error: " + e);
     }
     shellProbe = probeShell5555(false, null);
-    shizuku = probeShizuku();
-  } else if (shizuku === "down" && !split && profile.privilegedShellExpected !== false) {
+    shizukuStatus = probeShizuku();
+  } else if (shizukuStatus === "down" && !split && resolvedProfile.privilegedShellExpected !== false) {
     log.append("[comonitor] shizuku_server down — catastrophic Start path");
     try {
-      repair.repairCatastrophic(profile);
+      repair.repairCatastrophic(resolvedProfile);
     } catch (e) {
       log.append("[comonitor] shizuku start error: " + e);
     }
-    shizuku = probeShizuku();
-  } else if (shizuku === "down" && (split || profile.privilegedShellExpected === false)) {
+    shizukuStatus = probeShizuku();
+  } else if (shizukuStatus === "down" && (split || resolvedProfile.privilegedShellExpected === false)) {
     log.append("[comonitor] shizuku down — skip catastrophic on split/no-privileged-shell host (Termux is primary)");
   }
   // Trust fresh Termux [repair] sshd=up over a flaky shizuku pgrep (s24 spam).
-  if ((sshd === "down" || sshd === "FAILED") && !log.isRepairLoopStale()) {
-    var trustSsh = log.latestRepairStatus();
+  if (sshd === "down" && !log.isRepairLoopStale()) {
+    const trustSsh = log.latestRepairStatus();
     if (trustSsh && trustSsh.sshd === "up") {
       log.append("[comonitor] trusting fresh [repair] sshd=up over shizuku pgrep");
       sshd = "up";
     }
   }
-  if (sshd === "down" || sshd === "FAILED") {
+  if (sshd === "down") {
     notify.show(
       "⚠ SSH daemon down (co-monitor)",
       "sshd still down after AutoJs6 restart attempt — check Termux.",
@@ -242,27 +243,21 @@ function run(profile, opts) {
   } else {
     notify.clear("sshd");
   }
-  if (a11y === "FAILED") {
-    notify.show(
-      "stayturgid AutoJs6 degraded",
-      "Co-monitor could not re-enable accessibility — enable AutoJs6 a11y.",
-      "a11y-blocked",
-    );
-  } else if (a11y === "up" || a11y === "repaired" || a11y === "degraded") {
+  if (a11y === "up" || a11y === "degraded") {
     // degraded = sticky candidate already notified once under a11y-stale
     notify.clear("a11y-blocked");
-    if (a11y === "up" || a11y === "repaired") {
+    if (a11y === "up") {
       notify.clear("a11y-stale");
     }
   }
   if (shellProbe.port === "open" || shellProbe.port === "skip") {
     notify.clear("adb5555");
   }
-  var status =
+  const status =
     "STATUS port=" +
     shellProbe.port +
     " shizuku=" +
-    shizuku +
+    shizukuStatus +
     " sshd=" +
     sshd +
     " a11y=" +
@@ -276,29 +271,23 @@ function run(profile, opts) {
   try {
     log.writeState("comonitor", {
       port: shellProbe.port,
-      shizuku: shizuku,
-      sshd: sshd,
-      a11y: a11y,
+      shizuku: shizukuStatus,
+      sshd,
+      a11y,
       shell: shellProbe.shell,
-      wifi: wifi,
-      reason: reason,
+      wifi,
+      reason,
     });
-  } catch (we) {
+  } catch (_b) {
     /* best effort — state.json write failure must not break comonitor */
   }
   return {
     port: shellProbe.port,
-    shizuku: shizuku,
-    sshd: sshd,
-    a11y: a11y,
+    shizuku: shizukuStatus,
+    sshd,
+    a11y,
     shell: shellProbe.shell,
-    wifi: wifi,
-    reason: reason,
+    wifi,
+    reason,
   };
 }
-module.exports = {
-  run: run,
-  probeSshd: probeSshd,
-  probeShizuku: probeShizuku,
-  probeA11y: probeA11y,
-};

--- a/device/autojs6/lib/comonitor.ts
+++ b/device/autojs6/lib/comonitor.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 // @heals: SSHD-RUNNING PORT5555-OPEN SHIZUKU-HEADLESS A11Y-AUTOJS6
 /**
  * AutoJs6 co-monitor — redundant health probes via Shizuku when Termux is
@@ -10,26 +9,50 @@
  *
  * Does NOT replace Termux-primary repair when the boot loop is healthy.
  */
-var config = require("./config.js");
-var log = require("./log.js");
-var notify = require("./notify.js");
-var shizukuShell = require("./shizuku_shell.js");
-var repair = require("./repair.js");
+import config = require("./config.js");
+import log = require("./log.js");
+import notify = require("./notify.js");
+import shizukuShell = require("./shizuku_shell.js");
+import repair = require("./repair.js");
 
-var A11Y_SVC = config.AUTOJS6_A11Y;
+import type { DeviceProfile } from "./config.js";
 
-function sh(cmd) {
-  var r = shizukuShell.exec(cmd);
-  if (!r) return { code: -1, result: "" };
-  return {
-    code: typeof r.code === "number" ? r.code : -1,
-    result: String(r.result || r.stdout || "")
-      .replace(/\r/g, "")
-      .trim(),
-  };
+const A11Y_SVC = config.AUTOJS6_A11Y;
+
+type SshdStatus = "up" | "down" | "restarted";
+type ShizukuStatus = "up" | "down";
+/** unknown = split-storage without Shizuku operational (cannot probe). */
+type A11yStatus = "up" | "down" | "degraded" | "unknown";
+type PortStatus = "open" | "skip" | "CLOSED_NO_SHELL";
+type ShellFlag = "yes" | "no";
+type WifiStatus = "up" | "repaired" | "FAILED" | "skip";
+
+export interface ComonitorStatus {
+  port: PortStatus;
+  shizuku: ShizukuStatus;
+  sshd: SshdStatus;
+  a11y: A11yStatus;
+  shell: ShellFlag;
+  wifi: WifiStatus;
+  reason: string;
 }
 
-function probeA11y(split) {
+export interface ComonitorOptions {
+  force?: boolean;
+  reason?: string;
+}
+
+function sh(cmd: string): ShellResult {
+  const r = shizukuShell.exec(cmd);
+  return { code: r.code, result: r.result.replace(/\r/g, "").trim() };
+}
+
+// Notify at most once per engine process that a11y looks sticky (Settings ON,
+// auto.service null) — a module-level flag replaces the original's
+// probeA11y._stickyLogged function-property hack.
+let stickyA11yLogged = false;
+
+export function probeA11y(split: boolean): A11yStatus {
   // Prefer live bind (auto.service). Settings-list alone false-positives sticky ON.
   try {
     if (typeof auto !== "undefined" && auto.service) {
@@ -37,13 +60,13 @@ function probeA11y(split) {
       notify.clear("a11y-stale");
       return "up";
     }
-  } catch (e) {
+  } catch {
     /* fall through */
   }
 
-  var r = sh("settings get secure enabled_accessibility_services");
-  var list = (r.result || "").trim();
-  var listed = !!(list && list !== "null" && list.indexOf(A11Y_SVC) >= 0);
+  const r = sh("settings get secure enabled_accessibility_services");
+  const list = r.result.trim();
+  const listed = Boolean(list && list !== "null" && list.indexOf(A11Y_SVC) >= 0);
 
   // Sticky candidate: Settings ON but auto.service null. On some builds/devices
   // auto.service flickers null even while the engine is mid-cycle and listed
@@ -52,8 +75,8 @@ function probeA11y(split) {
   if (listed && typeof auto !== "undefined") {
     try {
       if (!auto.service) {
-        if (!probeA11y._stickyLogged) {
-          probeA11y._stickyLogged = true;
+        if (!stickyA11yLogged) {
+          stickyA11yLogged = true;
           log.append("[comonitor] A11Y STICKY candidate — listed ON but auto.service null (notify once; not FAILED)");
           notify.show(
             "AutoJs6 accessibility may be sticky",
@@ -63,7 +86,7 @@ function probeA11y(split) {
         }
         return "degraded";
       }
-    } catch (e2) {
+    } catch {
       /* fall through */
     }
   }
@@ -86,12 +109,12 @@ function probeA11y(split) {
   return "down";
 }
 
-function probeSshd() {
-  var r = sh("pgrep -x sshd >/dev/null 2>&1 || pgrep -f '[s]shd' >/dev/null 2>&1");
+export function probeSshd(): "up" | "down" {
+  const r = sh("pgrep -x sshd >/dev/null 2>&1 || pgrep -f '[s]shd' >/dev/null 2>&1");
   return r.code === 0 ? "up" : "down";
 }
 
-function restartSshd() {
+function restartSshd(): "up" | "down" {
   // Remove stale runit down file that silently blocks sshd from starting.
   sh("rm -f /data/data/com.termux/files/usr/var/service/sshd/down 2>/dev/null; true");
   sh(
@@ -103,28 +126,33 @@ function restartSshd() {
   return probeSshd();
 }
 
-function probeShizuku() {
+export function probeShizuku(): ShizukuStatus {
   if (shizukuShell.isOperational()) return "up";
-  var r = sh("am broadcast -a moe.shizuku.privileged.api.HEADLESS_STATUS 2>/dev/null");
-  if (r && r.code === 0 && r.result && r.result.indexOf("result=1") >= 0) return "up";
+  const r = sh("am broadcast -a moe.shizuku.privileged.api.HEADLESS_STATUS 2>/dev/null");
+  if (r.code === 0 && r.result.indexOf("result=1") >= 0) return "up";
   // Samsung freezes the Java receiver; fall back to pgrep.
-  var p = sh("pgrep -f '[s]hizuku_server' >/dev/null 2>&1");
+  const p = sh("pgrep -f '[s]hizuku_server' >/dev/null 2>&1");
   if (p.code === 0) return "up";
   return "down";
 }
 
-function probeShell5555(split, termuxStatus) {
+interface ShellProbe {
+  port: PortStatus;
+  shell: ShellFlag;
+}
+
+function probeShell5555(split: boolean, termuxStatus: log.RepairStatus | null): ShellProbe {
   if (split) return { port: "skip", shell: "no" };
   // Prefer fresh Termux STATUS — AutoJs6 shizuku() often lacks a working
   // `adb` binary/PATH, so a live adb probe false-fires CLOSED_NO_SHELL.
   if (termuxStatus && termuxStatus.port) {
-    var p = termuxStatus.port;
+    const p = termuxStatus.port;
     if (p === "open") return { port: "open", shell: "yes" };
     if (p === "skip") return { port: "skip", shell: "no" };
     if (p === "CLOSED_NO_SHELL") return { port: "CLOSED_NO_SHELL", shell: "no" };
   }
   // Live listen check (no adb client required).
-  var nc = sh("toybox nc -z 127.0.0.1 5555 >/dev/null 2>&1 || " + "nc -z 127.0.0.1 5555 >/dev/null 2>&1");
+  const nc = sh("toybox nc -z 127.0.0.1 5555 >/dev/null 2>&1 || nc -z 127.0.0.1 5555 >/dev/null 2>&1");
   if (nc.code === 0) return { port: "open", shell: "yes" };
   // Shizuku API up ⇒ privileged shell available even if adbd TCP is odd.
   if (shizukuShell.isOperational()) {
@@ -133,35 +161,29 @@ function probeShell5555(split, termuxStatus) {
   return { port: "CLOSED_NO_SHELL", shell: "no" };
 }
 
-function probeWifi(split, shellProbe) {
+function probeWifi(split: boolean, shellProbe: ShellProbe): WifiStatus {
   if (split) return "skip";
-  var r = sh("settings get global adb_wifi_enabled");
-  var v = (r.result || "").trim();
+  const r = sh("settings get global adb_wifi_enabled");
+  const v = r.result.trim();
   if (v === "1" || v === "true") return "up";
   // Samsung: adb_wifi_enabled reads 0 but port 5555 works (Shizuku opens it).
   // Pixel Android 16: settings put blocked on this key. If shell works, skip write.
-  if (shellProbe && shellProbe.port === "open") return "up";
+  if (shellProbe.port === "open") return "up";
   sh("settings put global adb_wifi_enabled 1");
   sleep(1000);
-  var r2 = sh("settings get global adb_wifi_enabled");
-  var v2 = (r2.result || "").trim();
+  const r2 = sh("settings get global adb_wifi_enabled");
+  const v2 = r2.result.trim();
   if (v2 === "1" || v2 === "true") return "repaired";
   return "FAILED";
 }
 
-/**
+/** Run co-monitor probes. Returns a STATUS-like object, or null when deferred. */
+export function run(profile: DeviceProfile, opts?: ComonitorOptions): ComonitorStatus | null {
+  const resolvedProfile = profile || config.detectDeviceProfile();
+  const split = config.splitStorage(resolvedProfile);
+  const reason = opts?.reason || (split ? "split-storage" : "termux-stale");
 
- * Run co-monitor probes. Returns a STATUS-like object.
- * @param {object} profile
- * @param {{force?: boolean, reason?: string}} opts
- */
-function run(profile, opts) {
-  opts = opts || {};
-  profile = profile || config.detectDeviceProfile();
-  var split = config.splitStorage(profile);
-  var reason = opts.reason || (split ? "split-storage" : "termux-stale");
-
-  if (!opts.force && !log.isRepairLoopStale() && !config.splitStorage(profile)) {
+  if (!opts?.force && !log.isRepairLoopStale() && !config.splitStorage(resolvedProfile)) {
     // Callers normally pass force=true (periodic fleet parity). Keep the
     // defer path for unit tests / ad-hoc imports.
     return null;
@@ -169,12 +191,12 @@ function run(profile, opts) {
 
   log.append("[comonitor] start reason=" + reason + " shizuku_api=" + (shizukuShell.isOperational() ? "yes" : "no"));
 
-  var sshd = probeSshd();
+  let sshd: SshdStatus = probeSshd();
   // Shizuku pgrep is unreliable when the AutoJs6↔Shizuku binder is broken
   // (s24 "Unable to use Shizuku service") or on Fire split-storage. Prefer a
   // fresh Termux STATUS before restarting or notifying.
   if (sshd === "down" && !log.isRepairLoopStale()) {
-    var earlyTrust = log.latestRepairStatus();
+    const earlyTrust = log.latestRepairStatus();
     if (earlyTrust && earlyTrust.sshd === "up") {
       log.append("[comonitor] trusting fresh [repair] sshd=up over shizuku pgrep");
       sshd = "up";
@@ -188,24 +210,24 @@ function run(profile, opts) {
     log.append("[comonitor] sshd probe down on split-storage — leave to Termux (no shizuku restart)");
   }
 
-  var shizuku = probeShizuku();
-  var termuxStatus = null;
+  let shizukuStatus = probeShizuku();
+  let termuxStatus: log.RepairStatus | null = null;
   try {
     if (!log.isRepairLoopStale()) {
       termuxStatus = log.latestRepairStatus();
     }
-  } catch (e) {
+  } catch {
     /* best effort */
   }
-  var shellProbe = probeShell5555(split, termuxStatus);
-  var wifi = probeWifi(split, shellProbe);
-  var a11y = probeA11y(split);
+  let shellProbe = probeShell5555(split, termuxStatus);
+  const wifi = probeWifi(split, shellProbe);
+  const a11y = probeA11y(split);
 
   // Trust fresh Termux [repair] port=open over a flaky nc/adb probe.
   if (!split && shellProbe.port === "CLOSED_NO_SHELL" && !log.isRepairLoopStale()) {
-    var trust = log.latestRepairStatus();
+    const trust = log.latestRepairStatus();
     if (trust && trust.port === "open") {
-      shellProbe = { port: "open", shell: trust.shell || "yes" };
+      shellProbe = { port: "open", shell: trust.shell === "no" ? "no" : "yes" };
       log.append("[comonitor] trusting fresh [repair] port=open over shell probe");
     }
   }
@@ -225,34 +247,34 @@ function run(profile, opts) {
       "adb5555",
     );
     try {
-      repair.repairCatastrophic(profile);
+      repair.repairCatastrophic(resolvedProfile);
     } catch (e) {
       log.append("[comonitor] catastrophic error: " + e);
     }
     shellProbe = probeShell5555(false, null);
-    shizuku = probeShizuku();
-  } else if (shizuku === "down" && !split && profile.privilegedShellExpected !== false) {
+    shizukuStatus = probeShizuku();
+  } else if (shizukuStatus === "down" && !split && resolvedProfile.privilegedShellExpected !== false) {
     log.append("[comonitor] shizuku_server down — catastrophic Start path");
     try {
-      repair.repairCatastrophic(profile);
+      repair.repairCatastrophic(resolvedProfile);
     } catch (e) {
       log.append("[comonitor] shizuku start error: " + e);
     }
-    shizuku = probeShizuku();
-  } else if (shizuku === "down" && (split || profile.privilegedShellExpected === false)) {
+    shizukuStatus = probeShizuku();
+  } else if (shizukuStatus === "down" && (split || resolvedProfile.privilegedShellExpected === false)) {
     log.append("[comonitor] shizuku down — skip catastrophic on split/no-privileged-shell host (Termux is primary)");
   }
 
   // Trust fresh Termux [repair] sshd=up over a flaky shizuku pgrep (s24 spam).
-  if ((sshd === "down" || sshd === "FAILED") && !log.isRepairLoopStale()) {
-    var trustSsh = log.latestRepairStatus();
+  if (sshd === "down" && !log.isRepairLoopStale()) {
+    const trustSsh = log.latestRepairStatus();
     if (trustSsh && trustSsh.sshd === "up") {
       log.append("[comonitor] trusting fresh [repair] sshd=up over shizuku pgrep");
       sshd = "up";
     }
   }
 
-  if (sshd === "down" || sshd === "FAILED") {
+  if (sshd === "down") {
     notify.show(
       "⚠ SSH daemon down (co-monitor)",
       "sshd still down after AutoJs6 restart attempt — check Termux.",
@@ -262,16 +284,10 @@ function run(profile, opts) {
     notify.clear("sshd");
   }
 
-  if (a11y === "FAILED") {
-    notify.show(
-      "stayturgid AutoJs6 degraded",
-      "Co-monitor could not re-enable accessibility — enable AutoJs6 a11y.",
-      "a11y-blocked",
-    );
-  } else if (a11y === "up" || a11y === "repaired" || a11y === "degraded") {
+  if (a11y === "up" || a11y === "degraded") {
     // degraded = sticky candidate already notified once under a11y-stale
     notify.clear("a11y-blocked");
-    if (a11y === "up" || a11y === "repaired") {
+    if (a11y === "up") {
       notify.clear("a11y-stale");
     }
   }
@@ -280,11 +296,11 @@ function run(profile, opts) {
     notify.clear("adb5555");
   }
 
-  var status =
+  const status =
     "STATUS port=" +
     shellProbe.port +
     " shizuku=" +
-    shizuku +
+    shizukuStatus +
     " sshd=" +
     sshd +
     " a11y=" +
@@ -298,30 +314,23 @@ function run(profile, opts) {
   try {
     log.writeState("comonitor", {
       port: shellProbe.port,
-      shizuku: shizuku,
-      sshd: sshd,
-      a11y: a11y,
+      shizuku: shizukuStatus,
+      sshd,
+      a11y,
       shell: shellProbe.shell,
-      wifi: wifi,
-      reason: reason,
+      wifi,
+      reason,
     });
-  } catch (we) {
+  } catch {
     /* best effort — state.json write failure must not break comonitor */
   }
   return {
     port: shellProbe.port,
-    shizuku: shizuku,
-    sshd: sshd,
-    a11y: a11y,
+    shizuku: shizukuStatus,
+    sshd,
+    a11y,
     shell: shellProbe.shell,
-    wifi: wifi,
-    reason: reason,
+    wifi,
+    reason,
   };
 }
-
-module.exports = {
-  run: run,
-  probeSshd: probeSshd,
-  probeShizuku: probeShizuku,
-  probeA11y: probeA11y,
-};

--- a/device/autojs6/lib/config.js
+++ b/device/autojs6/lib/config.js
@@ -1,6 +1,5 @@
 // @generated
 "use strict";
-// @ts-nocheck
 /** Shared constants and device profile resolution.
  *
  * The device profile is DATA, not code: Ansible renders
@@ -9,32 +8,52 @@
  * code names a specific device; without the JSON a generic profile applies
  * (no tap-coordinate fallback, no self-ping — degraded but functional).
  */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.PROFILE_DEFAULTS =
+  exports.AUTOJS6_A11Y =
+  exports.NOTIFY_CHANNEL =
+  exports.STALE_REPAIR_MS =
+  exports.INTERVAL_MS =
+  exports.REPAIR_SCRIPT =
+  exports.WATCHDOG_LOG =
+  exports.DEVICE_JSON =
+  exports.ENV_FILE =
+  exports.TERMUX_HOME =
+  exports.SD_ROOT =
+    void 0;
+exports.resolveSdRoot = resolveSdRoot;
+exports.pathsFor = pathsFor;
+exports.parentDir = parentDir;
+exports.ensureParentDir = ensureParentDir;
+exports.splitStorage = splitStorage;
+exports.ensureDirs = ensureDirs;
+exports.detectDeviceProfile = detectDeviceProfile;
 // Single stayturgid root per filesystem. SD_ROOT is created by the ensureDirs()
 // call below so a user-deleted directory self-heals before we read/write.
-var SD_ROOT = "/sdcard/stayturgid";
-var TERMUX_HOME = "/data/data/com.termux/files/home";
-var ENV_FILE = TERMUX_HOME + "/.stayturgid/env";
-var DEVICE_JSON = SD_ROOT + "/state/device.json";
-var WATCHDOG_LOG = SD_ROOT + "/logs/watchdog.log";
-var REPAIR_SCRIPT = TERMUX_HOME + "/.stayturgid/bin/stayturgid_repair.py";
+exports.SD_ROOT = "/sdcard/stayturgid";
+exports.TERMUX_HOME = "/data/data/com.termux/files/home";
+exports.ENV_FILE = exports.TERMUX_HOME + "/.stayturgid/env";
+exports.DEVICE_JSON = exports.SD_ROOT + "/state/device.json";
+exports.WATCHDOG_LOG = exports.SD_ROOT + "/logs/watchdog.log";
+exports.REPAIR_SCRIPT = exports.TERMUX_HOME + "/.stayturgid/bin/stayturgid_repair.py";
 /** Resolve shared-storage root (Fire OS uses ~/.stayturgid/shared). */
 function resolveSdRoot() {
   try {
-    if (files.exists(ENV_FILE)) {
-      var m = String(files.read(ENV_FILE)).match(/STAYTURGID_SD="([^"]+)"/);
+    if (files.exists(exports.ENV_FILE)) {
+      const m = String(files.read(exports.ENV_FILE)).match(/STAYTURGID_SD="([^"]+)"/);
       if (m && m[1]) return m[1];
     }
-  } catch (e) {
+  } catch (_a) {
     /* best effort */
   }
-  return SD_ROOT;
+  return exports.SD_ROOT;
 }
 function pathsFor(profile) {
-  var termuxRoot = profile && profile.sdRoot ? profile.sdRoot : resolveSdRoot();
-  var root = termuxRoot;
+  const termuxRoot = profile && profile.sdRoot ? profile.sdRoot : resolveSdRoot();
+  let root = termuxRoot;
   // AutoJs6 cannot write Termux-private paths (Fire OS shared-storage workaround).
-  if (root.indexOf(TERMUX_HOME) === 0) {
-    root = SD_ROOT;
+  if (root.indexOf(exports.TERMUX_HOME) === 0) {
+    root = exports.SD_ROOT;
   }
   return {
     sdRoot: root,
@@ -49,42 +68,42 @@ function pathsFor(profile) {
 }
 /** Return the directory portion of a file path without relying on AutoJs6 APIs. */
 function parentDir(filePath) {
-  var path = String(filePath);
+  let path = filePath;
   while (path.length > 1 && path.charAt(path.length - 1) === "/") {
     path = path.substring(0, path.length - 1);
   }
-  var slash = path.lastIndexOf("/");
+  const slash = path.lastIndexOf("/");
   if (slash < 0) return ".";
   if (slash === 0) return "/";
   return path.substring(0, slash);
 }
 /** Ensure the parent directory of a file exists, including deleted run/state dirs. */
 function ensureParentDir(filePath) {
-  var dir = parentDir(filePath);
+  const dir = parentDir(filePath);
   files.ensureDir(dir === "/" ? dir : dir + "/");
   return dir;
 }
 /** Fire OS: Termux state/logs live under private home; AutoJs6 uses /sdcard only. */
 function splitStorage(profile) {
-  var root = profile && profile.sdRoot ? profile.sdRoot : resolveSdRoot();
-  return root.indexOf(TERMUX_HOME) === 0;
+  const root = profile && profile.sdRoot ? profile.sdRoot : resolveSdRoot();
+  return root.indexOf(exports.TERMUX_HOME) === 0;
 }
 /** mkdir -p the shared-storage subdirs the watchdog writes (self-healing). */
 function ensureDirs(profile) {
-  var root = pathsFor(profile || {}).sdRoot;
-  ["state", "logs", "run", "tmp"].forEach(function (d) {
+  const root = pathsFor(profile || {}).sdRoot;
+  for (const d of ["state", "logs", "run", "tmp"]) {
     try {
       files.ensureDir(root + "/" + d + "/");
-    } catch (e) {
+    } catch (_a) {
       /* best effort */
     }
-  });
+  }
 }
-var INTERVAL_MS = 20 * 60 * 1000;
-var STALE_REPAIR_MS = 15 * 60 * 1000;
-var NOTIFY_CHANNEL = "stayturgid";
-var AUTOJS6_A11Y = "org.autojs.autojs6/org.autojs.autojs.core.accessibility.AccessibilityServiceUsher";
-var PROFILE_DEFAULTS = {
+exports.INTERVAL_MS = 20 * 60 * 1000;
+exports.STALE_REPAIR_MS = 15 * 60 * 1000;
+exports.NOTIFY_CHANNEL = "stayturgid";
+exports.AUTOJS6_A11Y = "org.autojs.autojs6/org.autojs.autojs.core.accessibility.AccessibilityServiceUsher";
+exports.PROFILE_DEFAULTS = {
   id: "generic",
   label: "unknown device",
   notifyTag: "",
@@ -97,33 +116,54 @@ var PROFILE_DEFAULTS = {
   tailscaleActivity: "com.tailscale.ipn.MainActivity",
   wirelessDebugUiFallback: false,
 };
-function detectDeviceProfile() {
-  var profile = {};
-  var profileSource = "";
-  var candidates = [
+function readDeviceJson() {
+  const candidates = [
     "/sdcard/stayturgid/state/device.json",
-    DEVICE_JSON,
-    TERMUX_HOME + "/.stayturgid/shared/state/device.json",
+    exports.DEVICE_JSON,
+    exports.TERMUX_HOME + "/.stayturgid/shared/state/device.json",
   ];
-  for (var i = 0; i < candidates.length; i++) {
+  for (const candidate of candidates) {
     try {
-      if (files.exists(candidates[i])) {
-        profile = JSON.parse(String(files.read(candidates[i]))) || {};
-        profileSource = candidates[i];
-        break;
+      if (files.exists(candidate)) {
+        const parsed = JSON.parse(String(files.read(candidate)));
+        return { profile: parsed || {}, source: candidate };
       }
     } catch (e) {
-      console.warn("[stayturgid] unreadable " + candidates[i] + ": " + e);
+      console.warn("[stayturgid] unreadable " + candidate + ": " + e);
     }
   }
-  var merged = {};
-  for (var k in PROFILE_DEFAULTS) {
-    merged[k] = profile[k] !== undefined && profile[k] !== null ? profile[k] : PROFILE_DEFAULTS[k];
-  }
+  return { profile: {}, source: "" };
+}
+function detectDeviceProfile() {
+  const { profile, source } = readDeviceJson();
+  const use = (key) => {
+    const value = profile[key];
+    return value !== undefined && value !== null ? value : exports.PROFILE_DEFAULTS[key];
+  };
+  const merged = {
+    id: use("id"),
+    label: use("label"),
+    notifyTag: use("notifyTag"),
+    shizukuPackage: use("shizukuPackage"),
+    shizukuActivity: use("shizukuActivity"),
+    shizukuStartCoords: use("shizukuStartCoords"),
+    tailscaleIp: use("tailscaleIp"),
+    tailscaleEnabled: use("tailscaleEnabled"),
+    tailscalePackage: use("tailscalePackage"),
+    tailscaleActivity: use("tailscaleActivity"),
+    wirelessDebugUiFallback: use("wirelessDebugUiFallback"),
+    samsungWirelessDebugFallback: false, // set below
+    usingGenericDefaults: false, // set below
+  };
   if (profile.sdRoot) {
     merged.sdRoot = profile.sdRoot;
   }
-  merged.usingGenericDefaults = !profileSource || !profile.id;
+  // NOTE: device.json's privilegedShellExpected is intentionally not copied
+  // here — this mirrors pre-existing behavior (only sdRoot ever got this
+  // post-loop treatment), so comonitor.ts's `profile.privilegedShellExpected`
+  // read is always undefined today. Preserved as-is; not this rewrite's call
+  // to fix silently.
+  merged.usingGenericDefaults = !source || !profile.id;
   if (merged.usingGenericDefaults) {
     console.warn(
       "[stayturgid] device.json missing or incomplete — run Ansible fleet deploy; device=generic (no tap coords)",
@@ -133,22 +173,3 @@ function detectDeviceProfile() {
   merged.samsungWirelessDebugFallback = merged.wirelessDebugUiFallback;
   return merged;
 }
-module.exports = {
-  SD_ROOT: SD_ROOT,
-  DEVICE_JSON: DEVICE_JSON,
-  WATCHDOG_LOG: WATCHDOG_LOG,
-  REPAIR_SCRIPT: REPAIR_SCRIPT,
-  TERMUX_HOME: TERMUX_HOME,
-  INTERVAL_MS: INTERVAL_MS,
-  STALE_REPAIR_MS: STALE_REPAIR_MS,
-  NOTIFY_CHANNEL: NOTIFY_CHANNEL,
-  AUTOJS6_A11Y: AUTOJS6_A11Y,
-  PROFILE_DEFAULTS: PROFILE_DEFAULTS,
-  ensureDirs: ensureDirs,
-  ensureParentDir: ensureParentDir,
-  parentDir: parentDir,
-  detectDeviceProfile: detectDeviceProfile,
-  pathsFor: pathsFor,
-  resolveSdRoot: resolveSdRoot,
-  splitStorage: splitStorage,
-};

--- a/device/autojs6/lib/config.ts
+++ b/device/autojs6/lib/config.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /** Shared constants and device profile resolution.
  *
  * The device profile is DATA, not code: Ansible renders
@@ -8,31 +7,65 @@
  * (no tap-coordinate fallback, no self-ping — degraded but functional).
  */
 
+/** A resolved device profile: PROFILE_DEFAULTS merged with device.json, if present. */
+export interface DeviceProfile {
+  id: string;
+  label: string;
+  notifyTag: string;
+  shizukuPackage: string;
+  shizukuActivity: string;
+  shizukuStartCoords: unknown;
+  tailscaleIp: string | null;
+  tailscaleEnabled: boolean;
+  tailscalePackage: string;
+  tailscaleActivity: string;
+  wirelessDebugUiFallback: boolean;
+  /** Legacy field name kept for shizuku.js compatibility; mirrors wirelessDebugUiFallback. */
+  samsungWirelessDebugFallback: boolean;
+  /** True when device.json expects a privileged (Shizuku) shell; absent means "assume yes". */
+  privilegedShellExpected?: boolean;
+  /** Present only when device.json overrides the shared-storage root (Fire OS). */
+  sdRoot?: string;
+  usingGenericDefaults: boolean;
+}
+
+/** Shared-storage paths derived from a DeviceProfile, resolved once per cycle. */
+export interface DevicePaths {
+  sdRoot: string;
+  termuxSdRoot: string;
+  deviceJson: string;
+  watchdogLog: string;
+  watchdogJsonl: string;
+  watchdogState: string;
+  watchdogStamp: string;
+  triggerFile: string;
+}
+
 // Single stayturgid root per filesystem. SD_ROOT is created by the ensureDirs()
 // call below so a user-deleted directory self-heals before we read/write.
-var SD_ROOT = "/sdcard/stayturgid";
-var TERMUX_HOME = "/data/data/com.termux/files/home";
-var ENV_FILE = TERMUX_HOME + "/.stayturgid/env";
-var DEVICE_JSON = SD_ROOT + "/state/device.json";
-var WATCHDOG_LOG = SD_ROOT + "/logs/watchdog.log";
-var REPAIR_SCRIPT = TERMUX_HOME + "/.stayturgid/bin/stayturgid_repair.py";
+export const SD_ROOT = "/sdcard/stayturgid";
+export const TERMUX_HOME = "/data/data/com.termux/files/home";
+export const ENV_FILE = TERMUX_HOME + "/.stayturgid/env";
+export const DEVICE_JSON = SD_ROOT + "/state/device.json";
+export const WATCHDOG_LOG = SD_ROOT + "/logs/watchdog.log";
+export const REPAIR_SCRIPT = TERMUX_HOME + "/.stayturgid/bin/stayturgid_repair.py";
 
 /** Resolve shared-storage root (Fire OS uses ~/.stayturgid/shared). */
-function resolveSdRoot() {
+export function resolveSdRoot(): string {
   try {
     if (files.exists(ENV_FILE)) {
-      var m = String(files.read(ENV_FILE)).match(/STAYTURGID_SD="([^"]+)"/);
+      const m = String(files.read(ENV_FILE)).match(/STAYTURGID_SD="([^"]+)"/);
       if (m && m[1]) return m[1];
     }
-  } catch (e) {
+  } catch {
     /* best effort */
   }
   return SD_ROOT;
 }
 
-function pathsFor(profile) {
-  var termuxRoot = profile && profile.sdRoot ? profile.sdRoot : resolveSdRoot();
-  var root = termuxRoot;
+export function pathsFor(profile: Pick<DeviceProfile, "sdRoot"> | null | undefined): DevicePaths {
+  const termuxRoot = profile && profile.sdRoot ? profile.sdRoot : resolveSdRoot();
+  let root = termuxRoot;
   // AutoJs6 cannot write Termux-private paths (Fire OS shared-storage workaround).
   if (root.indexOf(TERMUX_HOME) === 0) {
     root = SD_ROOT;
@@ -50,49 +83,49 @@ function pathsFor(profile) {
 }
 
 /** Return the directory portion of a file path without relying on AutoJs6 APIs. */
-function parentDir(filePath) {
-  var path = String(filePath);
+export function parentDir(filePath: string): string {
+  let path = filePath;
   while (path.length > 1 && path.charAt(path.length - 1) === "/") {
     path = path.substring(0, path.length - 1);
   }
-  var slash = path.lastIndexOf("/");
+  const slash = path.lastIndexOf("/");
   if (slash < 0) return ".";
   if (slash === 0) return "/";
   return path.substring(0, slash);
 }
 
 /** Ensure the parent directory of a file exists, including deleted run/state dirs. */
-function ensureParentDir(filePath) {
-  var dir = parentDir(filePath);
+export function ensureParentDir(filePath: string): string {
+  const dir = parentDir(filePath);
   files.ensureDir(dir === "/" ? dir : dir + "/");
   return dir;
 }
 
 /** Fire OS: Termux state/logs live under private home; AutoJs6 uses /sdcard only. */
-function splitStorage(profile) {
-  var root = profile && profile.sdRoot ? profile.sdRoot : resolveSdRoot();
+export function splitStorage(profile: Pick<DeviceProfile, "sdRoot"> | null | undefined): boolean {
+  const root = profile && profile.sdRoot ? profile.sdRoot : resolveSdRoot();
   return root.indexOf(TERMUX_HOME) === 0;
 }
 
 /** mkdir -p the shared-storage subdirs the watchdog writes (self-healing). */
-function ensureDirs(profile) {
-  var root = pathsFor(profile || {}).sdRoot;
-  ["state", "logs", "run", "tmp"].forEach(function (d) {
+export function ensureDirs(profile?: Pick<DeviceProfile, "sdRoot"> | null): void {
+  const root = pathsFor(profile || {}).sdRoot;
+  for (const d of ["state", "logs", "run", "tmp"]) {
     try {
       files.ensureDir(root + "/" + d + "/");
-    } catch (e) {
+    } catch {
       /* best effort */
     }
-  });
+  }
 }
 
-var INTERVAL_MS = 20 * 60 * 1000;
-var STALE_REPAIR_MS = 15 * 60 * 1000;
-var NOTIFY_CHANNEL = "stayturgid";
+export const INTERVAL_MS = 20 * 60 * 1000;
+export const STALE_REPAIR_MS = 15 * 60 * 1000;
+export const NOTIFY_CHANNEL = "stayturgid";
 
-var AUTOJS6_A11Y = "org.autojs.autojs6/org.autojs.autojs.core.accessibility.AccessibilityServiceUsher";
+export const AUTOJS6_A11Y = "org.autojs.autojs6/org.autojs.autojs.core.accessibility.AccessibilityServiceUsher";
 
-var PROFILE_DEFAULTS = {
+export const PROFILE_DEFAULTS: Omit<DeviceProfile, "usingGenericDefaults" | "samsungWirelessDebugFallback"> = {
   id: "generic",
   label: "unknown device",
   notifyTag: "",
@@ -106,33 +139,59 @@ var PROFILE_DEFAULTS = {
   wirelessDebugUiFallback: false,
 };
 
-function detectDeviceProfile() {
-  var profile = {};
-  var profileSource = "";
-  var candidates = [
+/** Parsed shape of device.json — a subset of DeviceProfile, all fields optional. */
+type DeviceJson = Partial<DeviceProfile>;
+
+function readDeviceJson(): { profile: DeviceJson; source: string } {
+  const candidates = [
     "/sdcard/stayturgid/state/device.json",
     DEVICE_JSON,
     TERMUX_HOME + "/.stayturgid/shared/state/device.json",
   ];
-  for (var i = 0; i < candidates.length; i++) {
+  for (const candidate of candidates) {
     try {
-      if (files.exists(candidates[i])) {
-        profile = JSON.parse(String(files.read(candidates[i]))) || {};
-        profileSource = candidates[i];
-        break;
+      if (files.exists(candidate)) {
+        const parsed = JSON.parse(String(files.read(candidate))) as DeviceJson;
+        return { profile: parsed || {}, source: candidate };
       }
     } catch (e) {
-      console.warn("[stayturgid] unreadable " + candidates[i] + ": " + e);
+      console.warn("[stayturgid] unreadable " + candidate + ": " + e);
     }
   }
-  var merged = {};
-  for (var k in PROFILE_DEFAULTS) {
-    merged[k] = profile[k] !== undefined && profile[k] !== null ? profile[k] : PROFILE_DEFAULTS[k];
-  }
+  return { profile: {}, source: "" };
+}
+
+export function detectDeviceProfile(): DeviceProfile {
+  const { profile, source } = readDeviceJson();
+  const use = <K extends keyof typeof PROFILE_DEFAULTS>(key: K): (typeof PROFILE_DEFAULTS)[K] => {
+    const value = profile[key];
+    return value !== undefined && value !== null ? value : PROFILE_DEFAULTS[key];
+  };
+
+  const merged: DeviceProfile = {
+    id: use("id"),
+    label: use("label"),
+    notifyTag: use("notifyTag"),
+    shizukuPackage: use("shizukuPackage"),
+    shizukuActivity: use("shizukuActivity"),
+    shizukuStartCoords: use("shizukuStartCoords"),
+    tailscaleIp: use("tailscaleIp"),
+    tailscaleEnabled: use("tailscaleEnabled"),
+    tailscalePackage: use("tailscalePackage"),
+    tailscaleActivity: use("tailscaleActivity"),
+    wirelessDebugUiFallback: use("wirelessDebugUiFallback"),
+    samsungWirelessDebugFallback: false, // set below
+    usingGenericDefaults: false, // set below
+  };
   if (profile.sdRoot) {
     merged.sdRoot = profile.sdRoot;
   }
-  merged.usingGenericDefaults = !profileSource || !profile.id;
+  // NOTE: device.json's privilegedShellExpected is intentionally not copied
+  // here — this mirrors pre-existing behavior (only sdRoot ever got this
+  // post-loop treatment), so comonitor.ts's `profile.privilegedShellExpected`
+  // read is always undefined today. Preserved as-is; not this rewrite's call
+  // to fix silently.
+  merged.usingGenericDefaults = !source || !profile.id;
   if (merged.usingGenericDefaults) {
     console.warn(
       "[stayturgid] device.json missing or incomplete — run Ansible fleet deploy; device=generic (no tap coords)",
@@ -142,23 +201,3 @@ function detectDeviceProfile() {
   merged.samsungWirelessDebugFallback = merged.wirelessDebugUiFallback;
   return merged;
 }
-
-module.exports = {
-  SD_ROOT: SD_ROOT,
-  DEVICE_JSON: DEVICE_JSON,
-  WATCHDOG_LOG: WATCHDOG_LOG,
-  REPAIR_SCRIPT: REPAIR_SCRIPT,
-  TERMUX_HOME: TERMUX_HOME,
-  INTERVAL_MS: INTERVAL_MS,
-  STALE_REPAIR_MS: STALE_REPAIR_MS,
-  NOTIFY_CHANNEL: NOTIFY_CHANNEL,
-  AUTOJS6_A11Y: AUTOJS6_A11Y,
-  PROFILE_DEFAULTS: PROFILE_DEFAULTS,
-  ensureDirs: ensureDirs,
-  ensureParentDir: ensureParentDir,
-  parentDir: parentDir,
-  detectDeviceProfile: detectDeviceProfile,
-  pathsFor: pathsFor,
-  resolveSdRoot: resolveSdRoot,
-  splitStorage: splitStorage,
-};

--- a/device/autojs6/lib/engine_guard.js
+++ b/device/autojs6/lib/engine_guard.js
@@ -1,56 +1,49 @@
 // @generated
 "use strict";
-// @ts-nocheck
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MAIN = void 0;
+exports.findMainEngines = findMainEngines;
+exports.dedupeMainEngines = dedupeMainEngines;
 /**
  * Ensure at most one stayturgid main.js engine is running.
  * Shared by main.js (startup) and boot-launcher.js.
  */
-var MAIN = "/sdcard/stayturgid/autojs6/main.js";
+exports.MAIN = "/sdcard/stayturgid/autojs6/main.js";
 function findMainEngines() {
-  var out = [];
-  var all = runtime.engines.all();
-  for (var i = 0; i < all.length; i++) {
-    var src = String(all[i].getSource() || "");
-    if (src.indexOf(MAIN) >= 0 || src.indexOf("stayturgid/autojs6/main.js") >= 0) {
-      out.push(all[i]);
-    }
-  }
-  return out;
+  return runtime.engines.all().filter((engine) => {
+    const src = engine.getSource() || "";
+    return src.indexOf(exports.MAIN) >= 0 || src.indexOf("stayturgid/autojs6/main.js") >= 0;
+  });
 }
 /**
  * Stop duplicate main.js engines. Keeps the current engine when identifiable.
- * @returns {number} engines force-stopped
+ * Returns the number of engines force-stopped.
  */
 function dedupeMainEngines() {
-  var self = null;
+  let self = null;
   try {
     self = engines.myEngine();
-  } catch (e) {
+  } catch (_a) {
     /* best effort */
   }
   if (!self) {
     return 0;
   }
-  var existing = findMainEngines();
+  const existing = findMainEngines();
   if (existing.length <= 1) {
     return 0;
   }
-  var stopped = 0;
-  for (var i = 0; i < existing.length; i++) {
-    if (self && existing[i].id === self.id) {
+  let stopped = 0;
+  for (const engine of existing) {
+    if (engine.id === self.id) {
       continue;
     }
     try {
-      existing[i].forceStop();
+      engine.forceStop();
       stopped++;
-    } catch (e2) {
+    } catch (_b) {
       /* ignore */
     }
   }
   return stopped;
 }
-module.exports = {
-  MAIN: MAIN,
-  findMainEngines: findMainEngines,
-  dedupeMainEngines: dedupeMainEngines,
-};

--- a/device/autojs6/lib/engine_guard.ts
+++ b/device/autojs6/lib/engine_guard.ts
@@ -1,57 +1,45 @@
-// @ts-nocheck
 /**
  * Ensure at most one stayturgid main.js engine is running.
  * Shared by main.js (startup) and boot-launcher.js.
  */
-var MAIN = "/sdcard/stayturgid/autojs6/main.js";
+export const MAIN = "/sdcard/stayturgid/autojs6/main.js";
 
-function findMainEngines() {
-  var out = [];
-  var all = runtime.engines.all();
-  for (var i = 0; i < all.length; i++) {
-    var src = String(all[i].getSource() || "");
-    if (src.indexOf(MAIN) >= 0 || src.indexOf("stayturgid/autojs6/main.js") >= 0) {
-      out.push(all[i]);
-    }
-  }
-  return out;
+export function findMainEngines(): Engine[] {
+  return runtime.engines.all().filter((engine) => {
+    const src = engine.getSource() || "";
+    return src.indexOf(MAIN) >= 0 || src.indexOf("stayturgid/autojs6/main.js") >= 0;
+  });
 }
 
 /**
  * Stop duplicate main.js engines. Keeps the current engine when identifiable.
- * @returns {number} engines force-stopped
+ * Returns the number of engines force-stopped.
  */
-function dedupeMainEngines() {
-  var self = null;
+export function dedupeMainEngines(): number {
+  let self: Engine | null = null;
   try {
     self = engines.myEngine();
-  } catch (e) {
+  } catch {
     /* best effort */
   }
   if (!self) {
     return 0;
   }
-  var existing = findMainEngines();
+  const existing = findMainEngines();
   if (existing.length <= 1) {
     return 0;
   }
-  var stopped = 0;
-  for (var i = 0; i < existing.length; i++) {
-    if (self && existing[i].id === self.id) {
+  let stopped = 0;
+  for (const engine of existing) {
+    if (engine.id === self.id) {
       continue;
     }
     try {
-      existing[i].forceStop();
+      engine.forceStop();
       stopped++;
-    } catch (e2) {
+    } catch {
       /* ignore */
     }
   }
   return stopped;
 }
-
-module.exports = {
-  MAIN: MAIN,
-  findMainEngines: findMainEngines,
-  dedupeMainEngines: dedupeMainEngines,
-};

--- a/device/autojs6/lib/guard.js
+++ b/device/autojs6/lib/guard.js
@@ -1,11 +1,35 @@
 // @generated
 "use strict";
-// @ts-nocheck
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.autoJs6AccessibilityEnabled = autoJs6AccessibilityEnabled;
+exports.isMalfunctioning = isMalfunctioning;
+exports.enforce = enforce;
+exports.statusReport = statusReport;
 // @heals: A11Y-AUTOJS6
-var config = require("./config.js");
-var notify = require("./notify.js");
-var termux = require("./termux.js");
-var log = require("./log.js");
+const config = require("./config.js");
+const notify = require("./notify.js");
+const termux = require("./termux.js");
+const log = require("./log.js");
+const comonitor = require("./comonitor.js");
+/** Run a shell probe on a worker thread with a timeout, so a hung settings daemon (seen on Fire OS) cannot block the watchdog cycle. */
+function probeAccessibilitySettings() {
+  const probe = { code: -1, result: "" };
+  try {
+    const thread = threads.start(() => {
+      try {
+        const r = shell("settings get secure enabled_accessibility_services", false);
+        probe.code = r.code;
+        probe.result = r.result;
+      } catch (_a) {
+        /* thread-local failure */
+      }
+    });
+    thread.join(5000);
+  } catch (_a) {
+    /* ignore */
+  }
+  return probe;
+}
 // Authoritative, permission-free check: AutoJs6's own accessibility service
 // instance is non-null exactly when the service is enabled AND bound.
 //
@@ -22,30 +46,14 @@ function autoJs6AccessibilityEnabled() {
       // would hide sticky ON (enabled but not running).
       return false;
     }
-  } catch (e) {
+  } catch (_a) {
     /* fall through to the settings probe only when `auto` is unavailable */
   }
   // Fallback (best effort): if a privileged read happens to work, use it.
-  // Run in a thread with a timeout to avoid blocking the watchdog cycle
-  // if the settings daemon hangs (observed on Fire OS).
-  try {
-    var shellResult = { code: -1, result: "" };
-    var t = threads.start(function () {
-      try {
-        var r = shell("settings get secure enabled_accessibility_services", false);
-        shellResult.code = r.code;
-        shellResult.result = String(r.result || "");
-      } catch (e) {
-        /* thread-local failure */
-      }
-    });
-    t.join(5000);
-    if (shellResult.code === 0) {
-      var list = shellResult.result.trim();
-      return list && list !== "null" && list.indexOf(config.AUTOJS6_A11Y) >= 0;
-    }
-  } catch (e2) {
-    /* ignore */
+  const probe = probeAccessibilitySettings();
+  if (probe.code === 0) {
+    const list = probe.result.trim();
+    return Boolean(list && list !== "null" && list.indexOf(config.AUTOJS6_A11Y) >= 0);
   }
   return false;
 }
@@ -53,29 +61,15 @@ function autoJs6AccessibilityEnabled() {
 function isMalfunctioning() {
   try {
     if (typeof auto === "undefined" || auto.service) return false;
-  } catch (e) {
+  } catch (_a) {
     return false;
   }
-  try {
-    var shellResult = { code: -1, result: "" };
-    var t = threads.start(function () {
-      try {
-        var r = shell("settings get secure enabled_accessibility_services", false);
-        shellResult.code = r.code;
-        shellResult.result = String(r.result || "");
-      } catch (e) {
-        /* ignore */
-      }
-    });
-    t.join(5000);
-    if (shellResult.code !== 0) return false;
-    var list = shellResult.result.trim();
-    return !!(list && list !== "null" && list.indexOf(config.AUTOJS6_A11Y) >= 0);
-  } catch (e2) {
-    return false;
-  }
+  const probe = probeAccessibilitySettings();
+  if (probe.code !== 0) return false;
+  const list = probe.result.trim();
+  return Boolean(list && list !== "null" && list.indexOf(config.AUTOJS6_A11Y) >= 0);
 }
-var A11Y_TOGGLE_MSG =
+const A11Y_TOGGLE_MSG =
   "Open Settings > Accessibility > AutoJs6: if already ON, turn OFF then ON again. " +
   "sshd/Tailscale self-heal still runs without a11y.";
 /**
@@ -90,21 +84,20 @@ var A11Y_TOGGLE_MSG =
  * restartService when WRITE_SECURE_SETTINGS is granted.
  */
 function enforce(profile) {
-  profile = profile || config.detectDeviceProfile();
+  const resolvedProfile = profile || config.detectDeviceProfile();
   if (autoJs6AccessibilityEnabled()) {
     notify.clear("a11y-blocked");
     notify.clear("a11y-stale");
     return;
   }
-  var sticky = isMalfunctioning();
+  const sticky = isMalfunctioning();
   if (sticky) {
     log.append("[watchdog] accessibility STICKY (Settings ON, service not bound) — user must toggle OFF then ON");
   }
-  if (config.splitStorage(profile)) {
+  if (config.splitStorage(resolvedProfile)) {
     log.append("[watchdog] split-storage: a11y off/sticky — co-monitor will probe via Shizuku");
     try {
-      var comonitor = require("./comonitor.js");
-      comonitor.run(profile, { force: true, reason: sticky ? "a11y-sticky-split" : "a11y-off-split" });
+      comonitor.run(resolvedProfile, { force: true, reason: sticky ? "a11y-sticky-split" : "a11y-off-split" });
     } catch (e) {
       log.append("[watchdog] comonitor a11y attempt failed: " + e);
     }
@@ -120,8 +113,8 @@ function enforce(profile) {
         : "[watchdog] accessibility disabled — checking repair status",
     );
     // Check if Termux repair already detected and logged this.
-    termux.invokeRepair(profile);
-    var deadline = Date.now() + 20000;
+    termux.invokeRepair(resolvedProfile);
+    const deadline = Date.now() + 20000;
     while (Date.now() < deadline && !autoJs6AccessibilityEnabled()) {
       sleep(2000);
     }
@@ -147,9 +140,3 @@ function statusReport() {
     autojs6A11yMalfunctioning: isMalfunctioning(),
   };
 }
-module.exports = {
-  enforce: enforce,
-  statusReport: statusReport,
-  autoJs6AccessibilityEnabled: autoJs6AccessibilityEnabled,
-  isMalfunctioning: isMalfunctioning,
-};

--- a/device/autojs6/lib/guard.ts
+++ b/device/autojs6/lib/guard.ts
@@ -1,9 +1,36 @@
-// @ts-nocheck
 // @heals: A11Y-AUTOJS6
-var config = require("./config.js");
-var notify = require("./notify.js");
-var termux = require("./termux.js");
-var log = require("./log.js");
+import config = require("./config.js");
+import notify = require("./notify.js");
+import termux = require("./termux.js");
+import log = require("./log.js");
+import comonitor = require("./comonitor.js");
+
+import type { DeviceProfile } from "./config.js";
+
+interface ShellProbeResult {
+  code: number;
+  result: string;
+}
+
+/** Run a shell probe on a worker thread with a timeout, so a hung settings daemon (seen on Fire OS) cannot block the watchdog cycle. */
+function probeAccessibilitySettings(): ShellProbeResult {
+  const probe: ShellProbeResult = { code: -1, result: "" };
+  try {
+    const thread = threads.start(() => {
+      try {
+        const r = shell("settings get secure enabled_accessibility_services", false);
+        probe.code = r.code;
+        probe.result = r.result;
+      } catch {
+        /* thread-local failure */
+      }
+    });
+    thread.join(5000);
+  } catch {
+    /* ignore */
+  }
+  return probe;
+}
 
 // Authoritative, permission-free check: AutoJs6's own accessibility service
 // instance is non-null exactly when the service is enabled AND bound.
@@ -13,7 +40,7 @@ var log = require("./log.js");
 // component listed (Settings switch ON) while the service is not bound — the
 // sticky/malfunctioning state. Trusting the settings list false-positives "up"
 // and skips the user OFF→ON notification.
-function autoJs6AccessibilityEnabled() {
+export function autoJs6AccessibilityEnabled(): boolean {
   try {
     if (typeof auto !== "undefined") {
       if (auto.service) return true;
@@ -21,62 +48,32 @@ function autoJs6AccessibilityEnabled() {
       // would hide sticky ON (enabled but not running).
       return false;
     }
-  } catch (e) {
+  } catch {
     /* fall through to the settings probe only when `auto` is unavailable */
   }
   // Fallback (best effort): if a privileged read happens to work, use it.
-  // Run in a thread with a timeout to avoid blocking the watchdog cycle
-  // if the settings daemon hangs (observed on Fire OS).
-  try {
-    var shellResult = { code: -1, result: "" };
-    var t = threads.start(function () {
-      try {
-        var r = shell("settings get secure enabled_accessibility_services", false);
-        shellResult.code = r.code;
-        shellResult.result = String(r.result || "");
-      } catch (e) {
-        /* thread-local failure */
-      }
-    });
-    t.join(5000);
-    if (shellResult.code === 0) {
-      var list = shellResult.result.trim();
-      return list && list !== "null" && list.indexOf(config.AUTOJS6_A11Y) >= 0;
-    }
-  } catch (e2) {
-    /* ignore */
+  const probe = probeAccessibilitySettings();
+  if (probe.code === 0) {
+    const list = probe.result.trim();
+    return Boolean(list && list !== "null" && list.indexOf(config.AUTOJS6_A11Y) >= 0);
   }
   return false;
 }
 
 /** True when Settings lists AutoJs6 but `auto.service` is not bound (sticky). */
-function isMalfunctioning() {
+export function isMalfunctioning(): boolean {
   try {
     if (typeof auto === "undefined" || auto.service) return false;
-  } catch (e) {
+  } catch {
     return false;
   }
-  try {
-    var shellResult = { code: -1, result: "" };
-    var t = threads.start(function () {
-      try {
-        var r = shell("settings get secure enabled_accessibility_services", false);
-        shellResult.code = r.code;
-        shellResult.result = String(r.result || "");
-      } catch (e) {
-        /* ignore */
-      }
-    });
-    t.join(5000);
-    if (shellResult.code !== 0) return false;
-    var list = shellResult.result.trim();
-    return !!(list && list !== "null" && list.indexOf(config.AUTOJS6_A11Y) >= 0);
-  } catch (e2) {
-    return false;
-  }
+  const probe = probeAccessibilitySettings();
+  if (probe.code !== 0) return false;
+  const list = probe.result.trim();
+  return Boolean(list && list !== "null" && list.indexOf(config.AUTOJS6_A11Y) >= 0);
 }
 
-var A11Y_TOGGLE_MSG =
+const A11Y_TOGGLE_MSG =
   "Open Settings > Accessibility > AutoJs6: if already ON, turn OFF then ON again. " +
   "sshd/Tailscale self-heal still runs without a11y.";
 
@@ -91,24 +88,23 @@ var A11Y_TOGGLE_MSG =
  * enable or cycle AutoJs6 in Settings. AutoJs6 fork may rebind via privileged
  * restartService when WRITE_SECURE_SETTINGS is granted.
  */
-function enforce(profile) {
-  profile = profile || config.detectDeviceProfile();
+export function enforce(profile?: DeviceProfile): void {
+  const resolvedProfile = profile || config.detectDeviceProfile();
   if (autoJs6AccessibilityEnabled()) {
     notify.clear("a11y-blocked");
     notify.clear("a11y-stale");
     return;
   }
 
-  var sticky = isMalfunctioning();
+  const sticky = isMalfunctioning();
   if (sticky) {
     log.append("[watchdog] accessibility STICKY (Settings ON, service not bound) — user must toggle OFF then ON");
   }
 
-  if (config.splitStorage(profile)) {
+  if (config.splitStorage(resolvedProfile)) {
     log.append("[watchdog] split-storage: a11y off/sticky — co-monitor will probe via Shizuku");
     try {
-      var comonitor = require("./comonitor.js");
-      comonitor.run(profile, { force: true, reason: sticky ? "a11y-sticky-split" : "a11y-off-split" });
+      comonitor.run(resolvedProfile, { force: true, reason: sticky ? "a11y-sticky-split" : "a11y-off-split" });
     } catch (e) {
       log.append("[watchdog] comonitor a11y attempt failed: " + e);
     }
@@ -124,8 +120,8 @@ function enforce(profile) {
         : "[watchdog] accessibility disabled — checking repair status",
     );
     // Check if Termux repair already detected and logged this.
-    termux.invokeRepair(profile);
-    var deadline = Date.now() + 20000;
+    termux.invokeRepair(resolvedProfile);
+    const deadline = Date.now() + 20000;
     while (Date.now() < deadline && !autoJs6AccessibilityEnabled()) {
       sleep(2000);
     }
@@ -147,16 +143,14 @@ function enforce(profile) {
   }
 }
 
-function statusReport() {
+export interface A11yStatusReport {
+  autojs6A11y: boolean;
+  autojs6A11yMalfunctioning: boolean;
+}
+
+export function statusReport(): A11yStatusReport {
   return {
     autojs6A11y: autoJs6AccessibilityEnabled(),
     autojs6A11yMalfunctioning: isMalfunctioning(),
   };
 }
-
-module.exports = {
-  enforce: enforce,
-  statusReport: statusReport,
-  autoJs6AccessibilityEnabled: autoJs6AccessibilityEnabled,
-  isMalfunctioning: isMalfunctioning,
-};

--- a/device/autojs6/lib/log.js
+++ b/device/autojs6/lib/log.js
@@ -1,54 +1,58 @@
 // @generated
 "use strict";
-// @ts-nocheck
-var config = require("./config.js");
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.append = append;
+exports.writeState = writeState;
+exports.readWatchdogLog = readWatchdogLog;
+exports.parseStatusLine = parseStatusLine;
+exports.latestRepairStatus = latestRepairStatus;
+exports.latestRepairTimestampMs = latestRepairTimestampMs;
+exports.isRepairLoopStale = isRepairLoopStale;
+const config = require("./config.js");
+function pad2(n) {
+  return (n < 10 ? "0" : "") + n;
+}
+function pad3(n) {
+  return (n < 10 ? "00" : n < 100 ? "0" : "") + n;
+}
 function ts() {
-  var d = new Date();
-  function pad(n) {
-    return (n < 10 ? "0" : "") + n;
-  }
-  var mon = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"][d.getMonth()];
-  return mon + " " + pad(d.getDate()) + " " + pad(d.getHours()) + ":" + pad(d.getMinutes()) + ":" + pad(d.getSeconds());
+  const d = new Date();
+  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  return `${months[d.getMonth()]} ${pad2(d.getDate())} ${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
 }
 /** ISO 8601 timestamp for JSONL/OTel schema. */
 function tsISO() {
-  var d = new Date();
-  function pad(n) {
-    return (n < 10 ? "0" : "") + n;
-  }
-  function pad3(n) {
-    return (n < 10 ? "00" : n < 100 ? "0" : "") + n;
-  }
+  const d = new Date();
   return (
     d.getFullYear() +
     "-" +
-    pad(d.getMonth() + 1) +
+    pad2(d.getMonth() + 1) +
     "-" +
-    pad(d.getDate()) +
+    pad2(d.getDate()) +
     "T" +
-    pad(d.getHours()) +
+    pad2(d.getHours()) +
     ":" +
-    pad(d.getMinutes()) +
+    pad2(d.getMinutes()) +
     ":" +
-    pad(d.getSeconds()) +
+    pad2(d.getSeconds()) +
     "." +
     pad3(d.getMilliseconds()) +
     "Z"
   );
 }
-var LOG_KEEP_LINES = 500;
-var LOG_TRIM_OVER = 1000;
+const LOG_KEEP_LINES = 500;
+const LOG_TRIM_OVER = 1000;
 function trimLogIfNeeded(logPath) {
   try {
     if (!files.exists(logPath)) return;
-    var content = String(files.read(logPath));
-    var lines = content.split("\n");
+    const content = String(files.read(logPath));
+    const lines = content.split("\n");
     // Drop trailing empty from final newline
     if (lines.length && lines[lines.length - 1] === "") lines.pop();
     if (lines.length <= LOG_TRIM_OVER) return;
-    var kept = lines.slice(-LOG_KEEP_LINES);
+    const kept = lines.slice(-LOG_KEEP_LINES);
     files.write(logPath, kept.join("\n") + "\n");
-  } catch (e) {
+  } catch (_a) {
     /* best effort */
   }
 }
@@ -57,28 +61,28 @@ function trimLogIfNeeded(logPath) {
  * Fields: timestamp, level, hostname, tag, pid, tid, message
  */
 function buildJsonlEntry(line, profile) {
-  var hostname = profile && profile.id ? profile.id : "unknown";
+  const hostname = profile && profile.id ? profile.id : "unknown";
   // Extract tag from [tag] pattern at the start of the message if present.
-  var tagMatch = String(line).match(/^\[([^\]]+)\]/);
-  var tag = tagMatch ? tagMatch[1] : "watchdog";
+  const tagMatch = line.match(/^\[([^\]]+)\]/);
+  const tag = tagMatch ? tagMatch[1] : "watchdog";
   return JSON.stringify({
     timestamp: tsISO(),
     level: "info",
-    hostname: hostname,
-    tag: tag,
+    hostname,
+    tag,
     pid: 0,
     tid: 0,
-    message: String(line),
+    message: line,
   });
 }
 function append(line) {
-  var msg = ts() + " " + line;
+  const msg = ts() + " " + line;
   console.log(msg);
   try {
-    var profile = config.detectDeviceProfile();
-    var paths = config.pathsFor(profile);
-    var logPath = paths.watchdogLog;
-    var logDir = String(logPath).replace(/\/[^/]+$/, "");
+    const profile = config.detectDeviceProfile();
+    const paths = config.pathsFor(profile);
+    const logPath = paths.watchdogLog;
+    const logDir = logPath.replace(/\/[^/]+$/, "");
     files.ensureDir(logDir + "/");
     // Dual-write: legacy text format
     files.append(logPath, msg + "\n");
@@ -105,80 +109,86 @@ function append(line) {
  */
 function writeState(source, statusObj) {
   try {
-    var profile = config.detectDeviceProfile();
-    var statePath = config.pathsFor(profile).watchdogState;
+    const profile = config.detectDeviceProfile();
+    const statePath = config.pathsFor(profile).watchdogState;
     config.ensureParentDir(statePath);
     // Read current state (may be empty/missing).
-    var current = {};
+    let current = {};
     try {
       if (files.exists(statePath)) {
         current = JSON.parse(String(files.read(statePath))) || {};
       }
-    } catch (pe) {
+    } catch (_a) {
       current = {};
     }
     // Merge the source namespace with a fresh timestamp.
-    var entry = {};
-    for (var k in statusObj) {
-      entry[k] = statusObj[k];
-    }
-    entry.timestamp = tsISO();
-    current[source] = entry;
+    current[source] = Object.assign(Object.assign({}, statusObj), { timestamp: tsISO() });
     // Write atomically: write to tmp then overwrite final path.
-    var tmpPath = statePath + ".tmp";
+    const tmpPath = statePath + ".tmp";
     files.write(tmpPath, JSON.stringify(current) + "\n");
     // AutoJs6 `files` has no rename; overwrite directly as best effort.
     files.write(statePath, JSON.stringify(current) + "\n");
-  } catch (e) {
+  } catch (_b) {
     /* best effort — state.json write failure must not break the watchdog */
   }
 }
 /** Read state.json; return parsed object or null. */
-function _readState() {
+function readState() {
   try {
-    var profile = config.detectDeviceProfile();
-    var statePath = config.pathsFor(profile).watchdogState;
+    const profile = config.detectDeviceProfile();
+    const statePath = config.pathsFor(profile).watchdogState;
     if (files.exists(statePath)) {
       return JSON.parse(String(files.read(statePath))) || null;
     }
-  } catch (e) {
+  } catch (_a) {
     /* ignore */
   }
   return null;
 }
 /** Read watchdog log; prefer a tail when the file is large (FUSE / battery). */
 function readWatchdogLog() {
-  var profile = config.detectDeviceProfile();
-  var logPath = config.pathsFor(profile).watchdogLog;
+  const profile = config.detectDeviceProfile();
+  const logPath = config.pathsFor(profile).watchdogLog;
   if (!files.exists(logPath)) return "";
   try {
-    var content = String(files.read(logPath));
-    var lines = content.split("\n");
+    const content = String(files.read(logPath));
+    const lines = content.split("\n");
     if (lines.length > LOG_TRIM_OVER) {
       return lines.slice(-LOG_KEEP_LINES).join("\n");
     }
     return content;
-  } catch (e) {
+  } catch (_a) {
     return "";
   }
 }
 function parseStatusLine(line) {
-  var s = String(line);
-  var m = s.match(/port=(\S+)\s+shizuku=(\S+)\s+sshd=(\S+)/);
+  const m = line.match(/port=(\S+)\s+shizuku=(\S+)\s+sshd=(\S+)/);
   if (!m) return null;
-  var out = { port: m[1], shizuku: m[2], sshd: m[3] };
-  var a11y = s.match(/\ba11y=(\S+)/);
-  var shell = s.match(/\bshell=(\S+)/);
-  var wifi = s.match(/\bwifi=(\S+)/);
+  const out = { port: m[1], shizuku: m[2], sshd: m[3] };
+  const a11y = line.match(/\ba11y=(\S+)/);
+  const shell = line.match(/\bshell=(\S+)/);
+  const wifi = line.match(/\bwifi=(\S+)/);
   if (a11y) out.a11y = a11y[1];
   if (shell) out.shell = shell[1];
   if (wifi) out.wifi = wifi[1];
   return out;
 }
-function _lineTimestampMs(line) {
-  var m = String(line).match(/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})/);
+function lineTimestampMs(line) {
+  const m = line.match(/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})/);
   if (!m) return null;
   return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]), Number(m[4]), Number(m[5]), Number(m[6])).getTime();
+}
+function statusFromState(state) {
+  const repair = state === null || state === void 0 ? void 0 : state.repair;
+  if (!repair || !repair.port || typeof repair.port !== "string") return null;
+  return {
+    port: repair.port,
+    shizuku: typeof repair.shizuku === "string" ? repair.shizuku : null,
+    sshd: typeof repair.sshd === "string" ? repair.sshd : null,
+    a11y: typeof repair.a11y === "string" ? repair.a11y : undefined,
+    shell: typeof repair.shell === "string" ? repair.shell : undefined,
+    wifi: typeof repair.wifi === "string" ? repair.wifi : undefined,
+  };
 }
 /**
  * Read the latest repair status.
@@ -187,23 +197,14 @@ function _lineTimestampMs(line) {
  */
 function latestRepairStatus() {
   // --- Primary: state.json ---
-  var state = _readState();
-  if (state && state.repair && state.repair.port) {
-    return {
-      port: state.repair.port,
-      shizuku: state.repair.shizuku || null,
-      sshd: state.repair.sshd || null,
-      a11y: state.repair.a11y || null,
-      shell: state.repair.shell || null,
-      wifi: state.repair.wifi || null,
-    };
-  }
+  const fromState = statusFromState(readState());
+  if (fromState) return fromState;
   // --- Fallback: legacy log scan ---
-  var content = readWatchdogLog();
+  const content = readWatchdogLog();
   if (!content) return null;
-  var lines = content.split("\n");
-  var comonitorFallback = null;
-  for (var i = lines.length - 1; i >= 0; i--) {
+  const lines = content.split("\n");
+  let comonitorFallback = null;
+  for (let i = lines.length - 1; i >= 0; i--) {
     // Prefer Termux [repair] STATUS for bridge decisions. A bad
     // [comonitor] STATUS must not trigger CLOSED_NO_SHELL UI repair.
     if (lines[i].indexOf("[repair]") >= 0 && lines[i].indexOf("STATUS") >= 0) {
@@ -220,41 +221,31 @@ function latestRepairStatus() {
  * Prefers state.json["repair"].timestamp; falls back to log-scan.
  */
 function latestRepairTimestampMs() {
+  var _a;
   // --- Primary: state.json ---
-  var state = _readState();
-  if (state && state.repair && state.repair.timestamp) {
-    try {
-      var t = new Date(state.repair.timestamp).getTime();
-      if (!isNaN(t)) return t;
-    } catch (e) {
-      /* fall through */
-    }
+  const state = readState();
+  const repairTimestamp =
+    (_a = state === null || state === void 0 ? void 0 : state.repair) === null || _a === void 0 ? void 0 : _a.timestamp;
+  if (typeof repairTimestamp === "string") {
+    const t = new Date(repairTimestamp).getTime();
+    if (!Number.isNaN(t)) return t;
   }
   // --- Fallback: legacy log scan ---
-  var content = readWatchdogLog();
+  const content = readWatchdogLog();
   if (!content) return null;
-  var lines = content.split("\n");
-  for (var i = lines.length - 1; i >= 0; i--) {
+  const lines = content.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
     // Termux [repair] is authoritative freshness; [comonitor] does not
     // count as "Termux alive" (would hide a dead boot loop).
     if (lines[i].indexOf("[repair]") >= 0) {
-      var lineTs = _lineTimestampMs(lines[i]);
+      const lineTs = lineTimestampMs(lines[i]);
       if (lineTs !== null) return lineTs;
     }
   }
   return null;
 }
 function isRepairLoopStale() {
-  var last = latestRepairTimestampMs();
+  const last = latestRepairTimestampMs();
   if (last === null) return true;
   return Date.now() - last > config.STALE_REPAIR_MS;
 }
-module.exports = {
-  append: append,
-  writeState: writeState,
-  readWatchdogLog: readWatchdogLog,
-  parseStatusLine: parseStatusLine,
-  latestRepairStatus: latestRepairStatus,
-  latestRepairTimestampMs: latestRepairTimestampMs,
-  isRepairLoopStale: isRepairLoopStale,
-};

--- a/device/autojs6/lib/log.ts
+++ b/device/autojs6/lib/log.ts
@@ -1,56 +1,56 @@
-// @ts-nocheck
-var config = require("./config.js");
+import config = require("./config.js");
 
-function ts() {
-  var d = new Date();
-  function pad(n) {
-    return (n < 10 ? "0" : "") + n;
-  }
-  var mon = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"][d.getMonth()];
-  return mon + " " + pad(d.getDate()) + " " + pad(d.getHours()) + ":" + pad(d.getMinutes()) + ":" + pad(d.getSeconds());
+import type { DeviceProfile } from "./config.js";
+
+function pad2(n: number): string {
+  return (n < 10 ? "0" : "") + n;
+}
+
+function pad3(n: number): string {
+  return (n < 10 ? "00" : n < 100 ? "0" : "") + n;
+}
+
+function ts(): string {
+  const d = new Date();
+  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  return `${months[d.getMonth()]} ${pad2(d.getDate())} ${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
 }
 
 /** ISO 8601 timestamp for JSONL/OTel schema. */
-function tsISO() {
-  var d = new Date();
-  function pad(n) {
-    return (n < 10 ? "0" : "") + n;
-  }
-  function pad3(n) {
-    return (n < 10 ? "00" : n < 100 ? "0" : "") + n;
-  }
+function tsISO(): string {
+  const d = new Date();
   return (
     d.getFullYear() +
     "-" +
-    pad(d.getMonth() + 1) +
+    pad2(d.getMonth() + 1) +
     "-" +
-    pad(d.getDate()) +
+    pad2(d.getDate()) +
     "T" +
-    pad(d.getHours()) +
+    pad2(d.getHours()) +
     ":" +
-    pad(d.getMinutes()) +
+    pad2(d.getMinutes()) +
     ":" +
-    pad(d.getSeconds()) +
+    pad2(d.getSeconds()) +
     "." +
     pad3(d.getMilliseconds()) +
     "Z"
   );
 }
 
-var LOG_KEEP_LINES = 500;
-var LOG_TRIM_OVER = 1000;
+const LOG_KEEP_LINES = 500;
+const LOG_TRIM_OVER = 1000;
 
-function trimLogIfNeeded(logPath) {
+function trimLogIfNeeded(logPath: string): void {
   try {
     if (!files.exists(logPath)) return;
-    var content = String(files.read(logPath));
-    var lines = content.split("\n");
+    const content = String(files.read(logPath));
+    const lines = content.split("\n");
     // Drop trailing empty from final newline
     if (lines.length && lines[lines.length - 1] === "") lines.pop();
     if (lines.length <= LOG_TRIM_OVER) return;
-    var kept = lines.slice(-LOG_KEEP_LINES);
+    const kept = lines.slice(-LOG_KEEP_LINES);
     files.write(logPath, kept.join("\n") + "\n");
-  } catch (e) {
+  } catch {
     /* best effort */
   }
 }
@@ -59,30 +59,30 @@ function trimLogIfNeeded(logPath) {
  * Build a JSONL entry conforming to the universal OTel log schema.
  * Fields: timestamp, level, hostname, tag, pid, tid, message
  */
-function buildJsonlEntry(line, profile) {
-  var hostname = profile && profile.id ? profile.id : "unknown";
+function buildJsonlEntry(line: string, profile: Pick<DeviceProfile, "id"> | null | undefined): string {
+  const hostname = profile && profile.id ? profile.id : "unknown";
   // Extract tag from [tag] pattern at the start of the message if present.
-  var tagMatch = String(line).match(/^\[([^\]]+)\]/);
-  var tag = tagMatch ? tagMatch[1] : "watchdog";
+  const tagMatch = line.match(/^\[([^\]]+)\]/);
+  const tag = tagMatch ? tagMatch[1] : "watchdog";
   return JSON.stringify({
     timestamp: tsISO(),
     level: "info",
-    hostname: hostname,
-    tag: tag,
+    hostname,
+    tag,
     pid: 0,
     tid: 0,
-    message: String(line),
+    message: line,
   });
 }
 
-function append(line) {
-  var msg = ts() + " " + line;
+export function append(line: string): string {
+  const msg = ts() + " " + line;
   console.log(msg);
   try {
-    var profile = config.detectDeviceProfile();
-    var paths = config.pathsFor(profile);
-    var logPath = paths.watchdogLog;
-    var logDir = String(logPath).replace(/\/[^/]+$/, "");
+    const profile = config.detectDeviceProfile();
+    const paths = config.pathsFor(profile);
+    const logPath = paths.watchdogLog;
+    const logDir = logPath.replace(/\/[^/]+$/, "");
     files.ensureDir(logDir + "/");
     // Dual-write: legacy text format
     files.append(logPath, msg + "\n");
@@ -99,6 +99,12 @@ function append(line) {
   return msg;
 }
 
+/** Namespaced status entry persisted into state.json by writeState(). */
+type StateEntry = Record<string, unknown> & { timestamp: string };
+
+/** state.json's shape: one entry per source namespace (e.g. "repair", "comonitor"). */
+type WatchdogState = Record<string, StateEntry>;
+
 /**
  * Atomically write or merge a status object into the shared state.json.
  * source: e.g. "repair" or "comonitor"
@@ -108,89 +114,106 @@ function append(line) {
  * In AutoJs6 we do not have fs.rename, so we use files.write directly
  * (best effort — partial writes are an extremely small window vs. the 20-min interval).
  */
-function writeState(source, statusObj) {
+export function writeState(source: string, statusObj: Record<string, unknown>): void {
   try {
-    var profile = config.detectDeviceProfile();
-    var statePath = config.pathsFor(profile).watchdogState;
+    const profile = config.detectDeviceProfile();
+    const statePath = config.pathsFor(profile).watchdogState;
     config.ensureParentDir(statePath);
 
     // Read current state (may be empty/missing).
-    var current = {};
+    let current: WatchdogState = {};
     try {
       if (files.exists(statePath)) {
-        current = JSON.parse(String(files.read(statePath))) || {};
+        current = (JSON.parse(String(files.read(statePath))) as WatchdogState) || {};
       }
-    } catch (pe) {
+    } catch {
       current = {};
     }
 
     // Merge the source namespace with a fresh timestamp.
-    var entry = {};
-    for (var k in statusObj) {
-      entry[k] = statusObj[k];
-    }
-    entry.timestamp = tsISO();
-    current[source] = entry;
+    current[source] = { ...statusObj, timestamp: tsISO() };
 
     // Write atomically: write to tmp then overwrite final path.
-    var tmpPath = statePath + ".tmp";
+    const tmpPath = statePath + ".tmp";
     files.write(tmpPath, JSON.stringify(current) + "\n");
     // AutoJs6 `files` has no rename; overwrite directly as best effort.
     files.write(statePath, JSON.stringify(current) + "\n");
-  } catch (e) {
+  } catch {
     /* best effort — state.json write failure must not break the watchdog */
   }
 }
 
 /** Read state.json; return parsed object or null. */
-function _readState() {
+function readState(): WatchdogState | null {
   try {
-    var profile = config.detectDeviceProfile();
-    var statePath = config.pathsFor(profile).watchdogState;
+    const profile = config.detectDeviceProfile();
+    const statePath = config.pathsFor(profile).watchdogState;
     if (files.exists(statePath)) {
-      return JSON.parse(String(files.read(statePath))) || null;
+      return (JSON.parse(String(files.read(statePath))) as WatchdogState) || null;
     }
-  } catch (e) {
+  } catch {
     /* ignore */
   }
   return null;
 }
 
 /** Read watchdog log; prefer a tail when the file is large (FUSE / battery). */
-function readWatchdogLog() {
-  var profile = config.detectDeviceProfile();
-  var logPath = config.pathsFor(profile).watchdogLog;
+export function readWatchdogLog(): string {
+  const profile = config.detectDeviceProfile();
+  const logPath = config.pathsFor(profile).watchdogLog;
   if (!files.exists(logPath)) return "";
   try {
-    var content = String(files.read(logPath));
-    var lines = content.split("\n");
+    const content = String(files.read(logPath));
+    const lines = content.split("\n");
     if (lines.length > LOG_TRIM_OVER) {
       return lines.slice(-LOG_KEEP_LINES).join("\n");
     }
     return content;
-  } catch (e) {
+  } catch {
     return "";
   }
 }
 
-function parseStatusLine(line) {
-  var s = String(line);
-  var m = s.match(/port=(\S+)\s+shizuku=(\S+)\s+sshd=(\S+)/);
+/** A STATUS line parsed from the watchdog log or state.json — fields are free-form parsed text, not verified enum members. */
+export interface RepairStatus {
+  port: string;
+  shizuku: string | null;
+  sshd: string | null;
+  a11y?: string;
+  shell?: string;
+  wifi?: string;
+}
+
+export function parseStatusLine(line: string): RepairStatus | null {
+  const m = line.match(/port=(\S+)\s+shizuku=(\S+)\s+sshd=(\S+)/);
   if (!m) return null;
-  var out = { port: m[1], shizuku: m[2], sshd: m[3] };
-  var a11y = s.match(/\ba11y=(\S+)/);
-  var shell = s.match(/\bshell=(\S+)/);
-  var wifi = s.match(/\bwifi=(\S+)/);
+  const out: RepairStatus = { port: m[1], shizuku: m[2], sshd: m[3] };
+  const a11y = line.match(/\ba11y=(\S+)/);
+  const shell = line.match(/\bshell=(\S+)/);
+  const wifi = line.match(/\bwifi=(\S+)/);
   if (a11y) out.a11y = a11y[1];
   if (shell) out.shell = shell[1];
   if (wifi) out.wifi = wifi[1];
   return out;
 }
 
-function _lineTimestampMs(line) {
-  var m = String(line).match(/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})/);
+function lineTimestampMs(line: string): number | null {
+  const m = line.match(/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})/);
   if (!m) return null;
   return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]), Number(m[4]), Number(m[5]), Number(m[6])).getTime();
+}
+
+function statusFromState(state: WatchdogState | null): RepairStatus | null {
+  const repair = state?.repair;
+  if (!repair || !repair.port || typeof repair.port !== "string") return null;
+  return {
+    port: repair.port,
+    shizuku: typeof repair.shizuku === "string" ? repair.shizuku : null,
+    sshd: typeof repair.sshd === "string" ? repair.sshd : null,
+    a11y: typeof repair.a11y === "string" ? repair.a11y : undefined,
+    shell: typeof repair.shell === "string" ? repair.shell : undefined,
+    wifi: typeof repair.wifi === "string" ? repair.wifi : undefined,
+  };
 }
 
 /**
@@ -198,26 +221,17 @@ function _lineTimestampMs(line) {
  * Prefers state.json["repair"] for O(1) read; falls back to log-scan for
  * backwards compatibility when the state file is absent or corrupt.
  */
-function latestRepairStatus() {
+export function latestRepairStatus(): RepairStatus | null {
   // --- Primary: state.json ---
-  var state = _readState();
-  if (state && state.repair && state.repair.port) {
-    return {
-      port: state.repair.port,
-      shizuku: state.repair.shizuku || null,
-      sshd: state.repair.sshd || null,
-      a11y: state.repair.a11y || null,
-      shell: state.repair.shell || null,
-      wifi: state.repair.wifi || null,
-    };
-  }
+  const fromState = statusFromState(readState());
+  if (fromState) return fromState;
 
   // --- Fallback: legacy log scan ---
-  var content = readWatchdogLog();
+  const content = readWatchdogLog();
   if (!content) return null;
-  var lines = content.split("\n");
-  var comonitorFallback = null;
-  for (var i = lines.length - 1; i >= 0; i--) {
+  const lines = content.split("\n");
+  let comonitorFallback: RepairStatus | null = null;
+  for (let i = lines.length - 1; i >= 0; i--) {
     // Prefer Termux [repair] STATUS for bridge decisions. A bad
     // [comonitor] STATUS must not trigger CLOSED_NO_SHELL UI repair.
     if (lines[i].indexOf("[repair]") >= 0 && lines[i].indexOf("STATUS") >= 0) {
@@ -234,45 +248,32 @@ function latestRepairStatus() {
  * Return the millisecond timestamp of the most recent Termux [repair] run.
  * Prefers state.json["repair"].timestamp; falls back to log-scan.
  */
-function latestRepairTimestampMs() {
+export function latestRepairTimestampMs(): number | null {
   // --- Primary: state.json ---
-  var state = _readState();
-  if (state && state.repair && state.repair.timestamp) {
-    try {
-      var t = new Date(state.repair.timestamp).getTime();
-      if (!isNaN(t)) return t;
-    } catch (e) {
-      /* fall through */
-    }
+  const state = readState();
+  const repairTimestamp = state?.repair?.timestamp;
+  if (typeof repairTimestamp === "string") {
+    const t = new Date(repairTimestamp).getTime();
+    if (!Number.isNaN(t)) return t;
   }
 
   // --- Fallback: legacy log scan ---
-  var content = readWatchdogLog();
+  const content = readWatchdogLog();
   if (!content) return null;
-  var lines = content.split("\n");
-  for (var i = lines.length - 1; i >= 0; i--) {
+  const lines = content.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
     // Termux [repair] is authoritative freshness; [comonitor] does not
     // count as "Termux alive" (would hide a dead boot loop).
     if (lines[i].indexOf("[repair]") >= 0) {
-      var lineTs = _lineTimestampMs(lines[i]);
+      const lineTs = lineTimestampMs(lines[i]);
       if (lineTs !== null) return lineTs;
     }
   }
   return null;
 }
 
-function isRepairLoopStale() {
-  var last = latestRepairTimestampMs();
+export function isRepairLoopStale(): boolean {
+  const last = latestRepairTimestampMs();
   if (last === null) return true;
   return Date.now() - last > config.STALE_REPAIR_MS;
 }
-
-module.exports = {
-  append: append,
-  writeState: writeState,
-  readWatchdogLog: readWatchdogLog,
-  parseStatusLine: parseStatusLine,
-  latestRepairStatus: latestRepairStatus,
-  latestRepairTimestampMs: latestRepairTimestampMs,
-  isRepairLoopStale: isRepairLoopStale,
-};

--- a/device/autojs6/lib/notify.js
+++ b/device/autojs6/lib/notify.js
@@ -1,27 +1,30 @@
 // @generated
 "use strict";
-// @ts-nocheck
-var config = require("./config.js");
-var _channelReady = false;
-var STATE_FILE = config.SD_ROOT + "/state/notify_state.json";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.show = show;
+exports.clear = clear;
+const config = require("./config.js");
+let channelReady = false;
+const STATE_FILE = config.SD_ROOT + "/state/notify_state.json";
 function ensureChannel() {
-  if (_channelReady) return;
+  if (channelReady) return;
   if (device.sdkInt >= 26) {
-    importClass(android.app.NotificationChannel);
-    importClass(android.app.NotificationManager);
-    var nm = context.getSystemService(context.NOTIFICATION_SERVICE);
-    var ch = new NotificationChannel(config.NOTIFY_CHANNEL, "stayturgid", NotificationManager.IMPORTANCE_HIGH);
-    ch.setDescription("stayturgid remote-access watchdog");
-    nm.createNotificationChannel(ch);
+    const nm = context.getSystemService(context.NOTIFICATION_SERVICE);
+    const channel = new android.app.NotificationChannel(
+      config.NOTIFY_CHANNEL,
+      "stayturgid",
+      android.app.NotificationManager.IMPORTANCE_HIGH,
+    );
+    channel.setDescription("stayturgid remote-access watchdog");
+    nm.createNotificationChannel(channel);
   }
-  _channelReady = true;
+  channelReady = true;
 }
 /** Stable notification id per key so repeats coalesce instead of piling up. */
 function idFor(key) {
-  var s = String(key);
-  var h = 0;
-  for (var i = 0; i < s.length; i++) {
-    h = (h * 31 + s.charCodeAt(i)) & 0x7fffffff;
+  let h = 0;
+  for (let i = 0; i < key.length; i++) {
+    h = (h * 31 + key.charCodeAt(i)) & 0x7fffffff;
   }
   return 5000 + (h % 100000);
 }
@@ -33,7 +36,7 @@ function readCounts() {
     if (files.exists(STATE_FILE)) {
       return JSON.parse(String(files.read(STATE_FILE))) || {};
     }
-  } catch (e) {
+  } catch (_a) {
     /* corrupt state — start over */
   }
   return {};
@@ -42,41 +45,38 @@ function writeCounts(counts) {
   try {
     config.ensureParentDir(STATE_FILE); // self-heal if the state dir was deleted
     files.write(STATE_FILE, JSON.stringify(counts));
-  } catch (e) {
+  } catch (_a) {
     /* best effort */
   }
 }
 function show(title, text, key) {
   ensureChannel();
-  key = key || String(title);
-  var counts = readCounts();
-  var n = (counts[key] || 0) + 1;
-  counts[key] = n;
+  const notificationKey = key || title;
+  const counts = readCounts();
+  const n = (counts[notificationKey] || 0) + 1;
+  counts[notificationKey] = n;
   writeCounts(counts);
-  if (n > 1) title = String(title) + " (" + n + "x)";
-  var nm = context.getSystemService(context.NOTIFICATION_SERVICE);
-  var builder;
-  if (device.sdkInt >= 26) {
-    builder = new android.app.Notification.Builder(context, config.NOTIFY_CHANNEL);
-  } else {
-    builder = new android.app.Notification.Builder(context);
-  }
+  const displayTitle = n > 1 ? `${title} (${n}x)` : title;
+  const nm = context.getSystemService(context.NOTIFICATION_SERVICE);
+  const builder =
+    device.sdkInt >= 26
+      ? new android.app.Notification.Builder(context, config.NOTIFY_CHANNEL)
+      : new android.app.Notification.Builder(context);
   builder
-    .setContentTitle(String(title))
-    .setContentText(String(text))
+    .setContentTitle(displayTitle)
+    .setContentText(text)
     .setSmallIcon(android.R.drawable.ic_dialog_alert)
     .setOnlyAlertOnce(false)
     .setAutoCancel(true);
-  nm.notify(idFor(key), builder.build());
+  nm.notify(idFor(notificationKey), builder.build());
 }
 /** Remove a previously shown alert and reset its repeat count (recovery). */
 function clear(key) {
-  var counts = readCounts();
+  const counts = readCounts();
   if (counts[key]) {
     delete counts[key];
     writeCounts(counts);
   }
-  var nm = context.getSystemService(context.NOTIFICATION_SERVICE);
+  const nm = context.getSystemService(context.NOTIFICATION_SERVICE);
   nm.cancel(idFor(key));
 }
-module.exports = { show: show, clear: clear };

--- a/device/autojs6/lib/notify.ts
+++ b/device/autojs6/lib/notify.ts
@@ -1,90 +1,88 @@
-// @ts-nocheck
-var config = require("./config.js");
+import config = require("./config.js");
 
-var _channelReady = false;
-var STATE_FILE = config.SD_ROOT + "/state/notify_state.json";
+let channelReady = false;
+const STATE_FILE = config.SD_ROOT + "/state/notify_state.json";
 
-function ensureChannel() {
-  if (_channelReady) return;
+function ensureChannel(): void {
+  if (channelReady) return;
   if (device.sdkInt >= 26) {
-    importClass(android.app.NotificationChannel);
-    importClass(android.app.NotificationManager);
-    var nm = context.getSystemService(context.NOTIFICATION_SERVICE);
-    var ch = new NotificationChannel(config.NOTIFY_CHANNEL, "stayturgid", NotificationManager.IMPORTANCE_HIGH);
-    ch.setDescription("stayturgid remote-access watchdog");
-    nm.createNotificationChannel(ch);
+    const nm = context.getSystemService(context.NOTIFICATION_SERVICE) as android.app.NotificationManager;
+    const channel = new android.app.NotificationChannel(
+      config.NOTIFY_CHANNEL,
+      "stayturgid",
+      android.app.NotificationManager.IMPORTANCE_HIGH,
+    );
+    channel.setDescription("stayturgid remote-access watchdog");
+    nm.createNotificationChannel(channel);
   }
-  _channelReady = true;
+  channelReady = true;
 }
 
 /** Stable notification id per key so repeats coalesce instead of piling up. */
-function idFor(key) {
-  var s = String(key);
-  var h = 0;
-  for (var i = 0; i < s.length; i++) {
-    h = (h * 31 + s.charCodeAt(i)) & 0x7fffffff;
+function idFor(key: string): number {
+  let h = 0;
+  for (let i = 0; i < key.length; i++) {
+    h = (h * 31 + key.charCodeAt(i)) & 0x7fffffff;
   }
   return 5000 + (h % 100000);
 }
 
+type RepeatCounts = Record<string, number>;
+
 // Repeat counts persist on /sdcard: engine restarts (the source of past
 // notification spam) must not reset them — one notification per key, ever,
 // with "(Nx)" and the most recent timestamp.
-function readCounts() {
+function readCounts(): RepeatCounts {
   try {
     if (files.exists(STATE_FILE)) {
-      return JSON.parse(String(files.read(STATE_FILE))) || {};
+      return (JSON.parse(String(files.read(STATE_FILE))) as RepeatCounts) || {};
     }
-  } catch (e) {
+  } catch {
     /* corrupt state — start over */
   }
   return {};
 }
 
-function writeCounts(counts) {
+function writeCounts(counts: RepeatCounts): void {
   try {
     config.ensureParentDir(STATE_FILE); // self-heal if the state dir was deleted
     files.write(STATE_FILE, JSON.stringify(counts));
-  } catch (e) {
+  } catch {
     /* best effort */
   }
 }
 
-function show(title, text, key) {
+export function show(title: string, text: string, key?: string): void {
   ensureChannel();
-  key = key || String(title);
+  const notificationKey = key || title;
 
-  var counts = readCounts();
-  var n = (counts[key] || 0) + 1;
-  counts[key] = n;
+  const counts = readCounts();
+  const n = (counts[notificationKey] || 0) + 1;
+  counts[notificationKey] = n;
   writeCounts(counts);
-  if (n > 1) title = String(title) + " (" + n + "x)";
+  const displayTitle = n > 1 ? `${title} (${n}x)` : title;
 
-  var nm = context.getSystemService(context.NOTIFICATION_SERVICE);
-  var builder;
-  if (device.sdkInt >= 26) {
-    builder = new android.app.Notification.Builder(context, config.NOTIFY_CHANNEL);
-  } else {
-    builder = new android.app.Notification.Builder(context);
-  }
+  const nm = context.getSystemService(context.NOTIFICATION_SERVICE) as android.app.NotificationManager;
+  const builder =
+    device.sdkInt >= 26
+      ? new android.app.Notification.Builder(context, config.NOTIFY_CHANNEL)
+      : new android.app.Notification.Builder(context);
   builder
-    .setContentTitle(String(title))
-    .setContentText(String(text))
+    .setContentTitle(displayTitle)
+    .setContentText(text)
     .setSmallIcon(android.R.drawable.ic_dialog_alert)
     .setOnlyAlertOnce(false)
     .setAutoCancel(true);
-  nm.notify(idFor(key), builder.build());
+  nm.notify(idFor(notificationKey), builder.build());
 }
 
 /** Remove a previously shown alert and reset its repeat count (recovery). */
-function clear(key) {
-  var counts = readCounts();
+export function clear(key: string): void {
+  const counts = readCounts();
   if (counts[key]) {
     delete counts[key];
     writeCounts(counts);
   }
-  var nm = context.getSystemService(context.NOTIFICATION_SERVICE);
+  const nm = context.getSystemService(context.NOTIFICATION_SERVICE) as android.app.NotificationManager;
   nm.cancel(idFor(key));
 }
-
-module.exports = { show: show, clear: clear };

--- a/device/autojs6/lib/repair.js
+++ b/device/autojs6/lib/repair.js
@@ -1,15 +1,15 @@
 // @generated
 "use strict";
-// @ts-nocheck
-var termux = require("./termux.js");
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.invokeTermuxRepair = void 0;
+exports.repairCatastrophic = repairCatastrophic;
+const termux = require("./termux.js");
+const shizuku = require("./shizuku.js");
 /**
  * Run the catastrophic repair path when port 5555 is down and no privileged shell
  * is reachable from Termux (CLOSED_NO_SHELL).
  */
 function repairCatastrophic(profile) {
-  return require("./shizuku.js").repairCatastrophic(profile);
+  return shizuku.repairCatastrophic(profile);
 }
-module.exports = {
-  repairCatastrophic: repairCatastrophic,
-  invokeTermuxRepair: termux.invokeRepair,
-};
+exports.invokeTermuxRepair = termux.invokeRepair;

--- a/device/autojs6/lib/repair.ts
+++ b/device/autojs6/lib/repair.ts
@@ -1,15 +1,14 @@
-// @ts-nocheck
-var termux = require("./termux.js");
+import termux = require("./termux.js");
+import shizuku = require("./shizuku.js");
+
+import type { DeviceProfile } from "./config.js";
 
 /**
  * Run the catastrophic repair path when port 5555 is down and no privileged shell
  * is reachable from Termux (CLOSED_NO_SHELL).
  */
-function repairCatastrophic(profile) {
-  return require("./shizuku.js").repairCatastrophic(profile);
+export function repairCatastrophic(profile: DeviceProfile): boolean {
+  return shizuku.repairCatastrophic(profile);
 }
 
-module.exports = {
-  repairCatastrophic: repairCatastrophic,
-  invokeTermuxRepair: termux.invokeRepair,
-};
+export const invokeTermuxRepair = termux.invokeRepair;

--- a/device/autojs6/lib/shizuku.js
+++ b/device/autojs6/lib/shizuku.js
@@ -1,18 +1,22 @@
 // @generated
 "use strict";
-// @ts-nocheck
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.headlessStart = headlessStart;
+exports.repairCatastrophic = repairCatastrophic;
+exports.serverRunning = serverRunning;
+exports.tryShellWirelessRepair = tryShellWirelessRepair;
 // @heals: PORT5555-OPEN SHIZUKU-HEADLESS
-var log = require("./log.js");
-var sh = require("./shizuku_shell.js");
+const log = require("./log.js");
+const sh = require("./shizuku_shell.js");
 function serverRunning() {
   // HEADLESS_STATUS on Samsung returns result=0 even when running
   // (Samsung freezes the Java broadcast receiver). Fall back to pgrep.
-  var r = sh.exec("am broadcast -a moe.shizuku.privileged.api.HEADLESS_STATUS 2>/dev/null");
-  if (r && r.code === 0 && r.result && r.result.indexOf("result=1") >= 0) {
+  const r = sh.exec("am broadcast -a moe.shizuku.privileged.api.HEADLESS_STATUS 2>/dev/null");
+  if (r.code === 0 && r.result.indexOf("result=1") >= 0) {
     return true;
   }
-  var p = sh.exec("pgrep -f '[s]hizuku_server'");
-  return p && p.code === 0 && String(p.result || "").trim().length > 0;
+  const p = sh.exec("pgrep -f '[s]hizuku_server'");
+  return p.code === 0 && p.result.trim().length > 0;
 }
 /**
  * Best-effort wireless-debug / adbd enable via Shizuku shell (no manager UI).
@@ -32,28 +36,28 @@ function tryShellWirelessRepair() {
   }
   log.append("[watchdog] shizuku shell: trying wireless-debug repair");
   // Read before write — avoid redundant settings triggers and adbd restart
-  var dev = sh.exec("settings get global development_settings_enabled");
-  if (!dev || String(dev.result || "").trim() !== "1") {
+  const dev = sh.exec("settings get global development_settings_enabled");
+  if (dev.result.trim() !== "1") {
     sh.exec("settings put global development_settings_enabled 1");
   }
-  var adbEn = sh.exec("settings get global adb_enabled");
-  if (!adbEn || String(adbEn.result || "").trim() !== "1") {
+  const adbEn = sh.exec("settings get global adb_enabled");
+  if (adbEn.result.trim() !== "1") {
     sh.exec("settings put global adb_enabled 1");
   }
-  var wifiEn = sh.exec("settings get global adb_wifi_enabled");
-  if (!wifiEn || String(wifiEn.result || "").trim() !== "1") {
+  const wifiEn = sh.exec("settings get global adb_wifi_enabled");
+  if (wifiEn.result.trim() !== "1") {
     sh.exec("settings put global adb_wifi_enabled 1");
   }
-  var curPort = sh.exec("getprop service.adb.tcp.port");
-  if (!curPort || String(curPort.result || "").trim() !== "5555") {
+  const curPort = sh.exec("getprop service.adb.tcp.port");
+  if (curPort.result.trim() !== "5555") {
     sh.exec("setprop service.adb.tcp.port 5555");
     sleep(1000);
   }
   sleep(2000);
   sh.exec("adb connect 127.0.0.1:5555");
   sleep(1000);
-  var uid = sh.exec("adb -s localhost:5555 shell id -u");
-  if (uid && uid.code === 0 && String(uid.result || "").trim() === "2000") {
+  const uid = sh.exec("adb -s localhost:5555 shell id -u");
+  if (uid.code === 0 && uid.result.trim() === "2000") {
     log.append("[watchdog] shizuku shell: localhost:5555 shell uid 2000");
     return true;
   }
@@ -75,8 +79,11 @@ function headlessStart() {
 /**
  * Catastrophic path: shell repair, then HEADLESS_START broadcast
  * (with built-in retry logic in the fork).
+ *
+ * NOTE: `profile` is accepted for interface parity with repair.ts's caller
+ * but unused — pre-existing behavior, not this rewrite's call to change.
  */
-function repairCatastrophic(profile) {
+function repairCatastrophic(_profile) {
   if (serverRunning() && tryShellWirelessRepair()) {
     return true;
   }
@@ -93,9 +100,3 @@ function repairCatastrophic(profile) {
   log.append("[watchdog] shizuku headless start failed after retries");
   return false;
 }
-module.exports = {
-  headlessStart: headlessStart,
-  repairCatastrophic: repairCatastrophic,
-  tryShellWirelessRepair: tryShellWirelessRepair,
-  serverRunning: serverRunning,
-};

--- a/device/autojs6/lib/shizuku.ts
+++ b/device/autojs6/lib/shizuku.ts
@@ -1,17 +1,18 @@
-// @ts-nocheck
 // @heals: PORT5555-OPEN SHIZUKU-HEADLESS
-var log = require("./log.js");
-var sh = require("./shizuku_shell.js");
+import log = require("./log.js");
+import sh = require("./shizuku_shell.js");
 
-function serverRunning() {
+import type { DeviceProfile } from "./config.js";
+
+function serverRunning(): boolean {
   // HEADLESS_STATUS on Samsung returns result=0 even when running
   // (Samsung freezes the Java broadcast receiver). Fall back to pgrep.
-  var r = sh.exec("am broadcast -a moe.shizuku.privileged.api.HEADLESS_STATUS 2>/dev/null");
-  if (r && r.code === 0 && r.result && r.result.indexOf("result=1") >= 0) {
+  const r = sh.exec("am broadcast -a moe.shizuku.privileged.api.HEADLESS_STATUS 2>/dev/null");
+  if (r.code === 0 && r.result.indexOf("result=1") >= 0) {
     return true;
   }
-  var p = sh.exec("pgrep -f '[s]hizuku_server'");
-  return p && p.code === 0 && String(p.result || "").trim().length > 0;
+  const p = sh.exec("pgrep -f '[s]hizuku_server'");
+  return p.code === 0 && p.result.trim().length > 0;
 }
 
 /**
@@ -26,34 +27,34 @@ function serverRunning() {
  *   5. Connect local ADB client to the local adbd.
  *   6. Verify shell uid 2000 on localhost:5555.
  */
-function tryShellWirelessRepair() {
+function tryShellWirelessRepair(): boolean {
   if (!sh.isOperational()) {
     return false;
   }
   log.append("[watchdog] shizuku shell: trying wireless-debug repair");
   // Read before write — avoid redundant settings triggers and adbd restart
-  var dev = sh.exec("settings get global development_settings_enabled");
-  if (!dev || String(dev.result || "").trim() !== "1") {
+  const dev = sh.exec("settings get global development_settings_enabled");
+  if (dev.result.trim() !== "1") {
     sh.exec("settings put global development_settings_enabled 1");
   }
-  var adbEn = sh.exec("settings get global adb_enabled");
-  if (!adbEn || String(adbEn.result || "").trim() !== "1") {
+  const adbEn = sh.exec("settings get global adb_enabled");
+  if (adbEn.result.trim() !== "1") {
     sh.exec("settings put global adb_enabled 1");
   }
-  var wifiEn = sh.exec("settings get global adb_wifi_enabled");
-  if (!wifiEn || String(wifiEn.result || "").trim() !== "1") {
+  const wifiEn = sh.exec("settings get global adb_wifi_enabled");
+  if (wifiEn.result.trim() !== "1") {
     sh.exec("settings put global adb_wifi_enabled 1");
   }
-  var curPort = sh.exec("getprop service.adb.tcp.port");
-  if (!curPort || String(curPort.result || "").trim() !== "5555") {
+  const curPort = sh.exec("getprop service.adb.tcp.port");
+  if (curPort.result.trim() !== "5555") {
     sh.exec("setprop service.adb.tcp.port 5555");
     sleep(1000);
   }
   sleep(2000);
   sh.exec("adb connect 127.0.0.1:5555");
   sleep(1000);
-  var uid = sh.exec("adb -s localhost:5555 shell id -u");
-  if (uid && uid.code === 0 && String(uid.result || "").trim() === "2000") {
+  const uid = sh.exec("adb -s localhost:5555 shell id -u");
+  if (uid.code === 0 && uid.result.trim() === "2000") {
     log.append("[watchdog] shizuku shell: localhost:5555 shell uid 2000");
     return true;
   }
@@ -64,7 +65,7 @@ function tryShellWirelessRepair() {
  * Headless start via operator/Shizuku HEADLESS_START broadcast.
  * The fork has built-in retry logic (3 attempts, 5s delay).
  */
-function headlessStart() {
+function headlessStart(): boolean {
   if (!sh.isOperational()) {
     return false;
   }
@@ -77,8 +78,11 @@ function headlessStart() {
 /**
  * Catastrophic path: shell repair, then HEADLESS_START broadcast
  * (with built-in retry logic in the fork).
+ *
+ * NOTE: `profile` is accepted for interface parity with repair.ts's caller
+ * but unused — pre-existing behavior, not this rewrite's call to change.
  */
-function repairCatastrophic(profile) {
+function repairCatastrophic(_profile: DeviceProfile): boolean {
   if (serverRunning() && tryShellWirelessRepair()) {
     return true;
   }
@@ -96,9 +100,4 @@ function repairCatastrophic(profile) {
   return false;
 }
 
-module.exports = {
-  headlessStart: headlessStart,
-  repairCatastrophic: repairCatastrophic,
-  tryShellWirelessRepair: tryShellWirelessRepair,
-  serverRunning: serverRunning,
-};
+export { headlessStart, repairCatastrophic, serverRunning, tryShellWirelessRepair };

--- a/device/autojs6/lib/shizuku_shell.js
+++ b/device/autojs6/lib/shizuku_shell.js
@@ -1,7 +1,9 @@
 // @generated
 "use strict";
-// @ts-nocheck
-var log = require("./log.js");
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.isOperational = isOperational;
+exports.exec = exec;
+const log = require("./log.js");
 /**
  * Run a shell command via AutoJs6's Shizuku API when operational, else shell().
  * Requires Shizuku drawer toggle ON in AutoJs6 (see docs/modules/autojs6.md).
@@ -15,17 +17,17 @@ function isOperational() {
       return shizuku.isOperational();
     }
     if (typeof shizuku.state !== "undefined") {
-      var st = shizuku.state;
+      const st = shizuku.state;
       return st === true || st === "ready" || st === "operational";
     }
-    var probe = shizuku("true");
-    return probe && probe.code === 0;
-  } catch (e) {
+    const probe = shizuku("true");
+    return probe.code === 0;
+  } catch (_a) {
     return false;
   }
 }
 function exec(cmd) {
-  if (isOperational()) {
+  if (isOperational() && shizuku) {
     try {
       return shizuku(cmd);
     } catch (e) {
@@ -34,7 +36,3 @@ function exec(cmd) {
   }
   return shell(cmd, false);
 }
-module.exports = {
-  isOperational: isOperational,
-  exec: exec,
-};

--- a/device/autojs6/lib/shizuku_shell.ts
+++ b/device/autojs6/lib/shizuku_shell.ts
@@ -1,11 +1,10 @@
-// @ts-nocheck
-var log = require("./log.js");
+import log = require("./log.js");
 
 /**
  * Run a shell command via AutoJs6's Shizuku API when operational, else shell().
  * Requires Shizuku drawer toggle ON in AutoJs6 (see docs/modules/autojs6.md).
  */
-function isOperational() {
+export function isOperational(): boolean {
   try {
     if (typeof shizuku === "undefined" || typeof shizuku !== "function") {
       return false;
@@ -14,18 +13,18 @@ function isOperational() {
       return shizuku.isOperational();
     }
     if (typeof shizuku.state !== "undefined") {
-      var st = shizuku.state;
+      const st = shizuku.state;
       return st === true || st === "ready" || st === "operational";
     }
-    var probe = shizuku("true");
-    return probe && probe.code === 0;
-  } catch (e) {
+    const probe = shizuku("true");
+    return probe.code === 0;
+  } catch {
     return false;
   }
 }
 
-function exec(cmd) {
-  if (isOperational()) {
+export function exec(cmd: string): ShellResult {
+  if (isOperational() && shizuku) {
     try {
       return shizuku(cmd);
     } catch (e) {
@@ -34,8 +33,3 @@ function exec(cmd) {
   }
   return shell(cmd, false);
 }
-
-module.exports = {
-  isOperational: isOperational,
-  exec: exec,
-};

--- a/device/autojs6/lib/tailscale.js
+++ b/device/autojs6/lib/tailscale.js
@@ -1,22 +1,25 @@
 // @generated
 "use strict";
-// @ts-nocheck
-var log = require("./log.js");
-var sh = require("./shizuku_shell.js");
-var DEFAULT_PKG = "com.tailscale.ipn";
-var DEFAULT_ACTIVITY = "com.tailscale.ipn.MainActivity";
-var COORD_PING_HOST = "100.100.100.100";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.COORD_PING_HOST = void 0;
+exports.check = check;
+exports.relaunch = relaunch;
+const log = require("./log.js");
+const sh = require("./shizuku_shell.js");
+exports.COORD_PING_HOST = "100.100.100.100";
+const DEFAULT_PKG = "com.tailscale.ipn";
+const DEFAULT_ACTIVITY = "com.tailscale.ipn.MainActivity";
 function isTunUp(profile) {
-  var ip = sh.exec("ip -4 addr show tun0 2>/dev/null");
-  if (ip.code === 0 && ip.result && String(ip.result).indexOf("inet ") >= 0) {
+  const ip = sh.exec("ip -4 addr show tun0 2>/dev/null");
+  if (ip.code === 0 && ip.result && ip.result.indexOf("inet ") >= 0) {
     return true;
   }
-  var proc = sh.exec("cat /proc/net/dev");
-  if (proc.result && String(proc.result).indexOf("tun0:") >= 0) {
+  const proc = sh.exec("cat /proc/net/dev");
+  if (proc.result && proc.result.indexOf("tun0:") >= 0) {
     return true;
   }
-  if (profile && profile.tailscaleIp) {
-    var selfPing = sh.exec("ping -c 1 -W 2 " + profile.tailscaleIp);
+  if (profile.tailscaleIp) {
+    const selfPing = sh.exec("ping -c 1 -W 2 " + profile.tailscaleIp);
     return selfPing.code === 0;
   }
   return false;
@@ -25,9 +28,9 @@ function isTunUp(profile) {
  * Check Tailscale tunnel health: tun0 has traffic + coord server pings.
  */
 function check(profile) {
-  var tunUp = isTunUp(profile);
-  var ping = sh.exec("ping -c 1 -W 2 " + COORD_PING_HOST);
-  var pingOk = ping.code === 0;
+  const tunUp = isTunUp(profile);
+  const ping = sh.exec("ping -c 1 -W 2 " + exports.COORD_PING_HOST);
+  const pingOk = ping.code === 0;
   return {
     up: tunUp && pingOk,
     tun: tunUp,
@@ -36,8 +39,8 @@ function check(profile) {
 }
 /** Relaunch Tailscale so always-on VPN can re-establish tun0. */
 function relaunch(profile) {
-  var pkg = (profile && profile.tailscalePackage) || DEFAULT_PKG;
-  var cls = (profile && profile.tailscaleActivity) || DEFAULT_ACTIVITY;
+  const pkg = profile.tailscalePackage || DEFAULT_PKG;
+  const cls = profile.tailscaleActivity || DEFAULT_ACTIVITY;
   try {
     app.startActivity({
       packageName: pkg,
@@ -47,7 +50,7 @@ function relaunch(profile) {
     log.append("[watchdog] tailscale relaunch via " + pkg + "/" + cls);
     return true;
   } catch (e) {
-    var r = sh.exec("am start -n " + pkg + "/" + cls);
+    const r = sh.exec("am start -n " + pkg + "/" + cls);
     if (r.code === 0) {
       log.append("[watchdog] tailscale relaunch via shizuku/am start");
       return true;
@@ -56,8 +59,3 @@ function relaunch(profile) {
     return false;
   }
 }
-module.exports = {
-  check: check,
-  relaunch: relaunch,
-  COORD_PING_HOST: COORD_PING_HOST,
-};

--- a/device/autojs6/lib/tailscale.ts
+++ b/device/autojs6/lib/tailscale.ts
@@ -1,34 +1,43 @@
-// @ts-nocheck
-var log = require("./log.js");
-var sh = require("./shizuku_shell.js");
+import log = require("./log.js");
+import sh = require("./shizuku_shell.js");
 
-var DEFAULT_PKG = "com.tailscale.ipn";
-var DEFAULT_ACTIVITY = "com.tailscale.ipn.MainActivity";
-var COORD_PING_HOST = "100.100.100.100";
+import type { DeviceProfile } from "./config.js";
 
-function isTunUp(profile) {
-  var ip = sh.exec("ip -4 addr show tun0 2>/dev/null");
-  if (ip.code === 0 && ip.result && String(ip.result).indexOf("inet ") >= 0) {
+export const COORD_PING_HOST = "100.100.100.100";
+const DEFAULT_PKG = "com.tailscale.ipn";
+const DEFAULT_ACTIVITY = "com.tailscale.ipn.MainActivity";
+
+type TailscaleProfile = Pick<DeviceProfile, "tailscaleIp" | "tailscalePackage" | "tailscaleActivity">;
+
+function isTunUp(profile: TailscaleProfile): boolean {
+  const ip = sh.exec("ip -4 addr show tun0 2>/dev/null");
+  if (ip.code === 0 && ip.result && ip.result.indexOf("inet ") >= 0) {
     return true;
   }
-  var proc = sh.exec("cat /proc/net/dev");
-  if (proc.result && String(proc.result).indexOf("tun0:") >= 0) {
+  const proc = sh.exec("cat /proc/net/dev");
+  if (proc.result && proc.result.indexOf("tun0:") >= 0) {
     return true;
   }
-  if (profile && profile.tailscaleIp) {
-    var selfPing = sh.exec("ping -c 1 -W 2 " + profile.tailscaleIp);
+  if (profile.tailscaleIp) {
+    const selfPing = sh.exec("ping -c 1 -W 2 " + profile.tailscaleIp);
     return selfPing.code === 0;
   }
   return false;
 }
 
+export interface TailscaleHealth {
+  up: boolean;
+  tun: boolean;
+  ping: boolean;
+}
+
 /**
  * Check Tailscale tunnel health: tun0 has traffic + coord server pings.
  */
-function check(profile) {
-  var tunUp = isTunUp(profile);
-  var ping = sh.exec("ping -c 1 -W 2 " + COORD_PING_HOST);
-  var pingOk = ping.code === 0;
+export function check(profile: TailscaleProfile): TailscaleHealth {
+  const tunUp = isTunUp(profile);
+  const ping = sh.exec("ping -c 1 -W 2 " + COORD_PING_HOST);
+  const pingOk = ping.code === 0;
   return {
     up: tunUp && pingOk,
     tun: tunUp,
@@ -37,9 +46,9 @@ function check(profile) {
 }
 
 /** Relaunch Tailscale so always-on VPN can re-establish tun0. */
-function relaunch(profile) {
-  var pkg = (profile && profile.tailscalePackage) || DEFAULT_PKG;
-  var cls = (profile && profile.tailscaleActivity) || DEFAULT_ACTIVITY;
+export function relaunch(profile: TailscaleProfile): boolean {
+  const pkg = profile.tailscalePackage || DEFAULT_PKG;
+  const cls = profile.tailscaleActivity || DEFAULT_ACTIVITY;
   try {
     app.startActivity({
       packageName: pkg,
@@ -49,7 +58,7 @@ function relaunch(profile) {
     log.append("[watchdog] tailscale relaunch via " + pkg + "/" + cls);
     return true;
   } catch (e) {
-    var r = sh.exec("am start -n " + pkg + "/" + cls);
+    const r = sh.exec("am start -n " + pkg + "/" + cls);
     if (r.code === 0) {
       log.append("[watchdog] tailscale relaunch via shizuku/am start");
       return true;
@@ -58,9 +67,3 @@ function relaunch(profile) {
     return false;
   }
 }
-
-module.exports = {
-  check: check,
-  relaunch: relaunch,
-  COORD_PING_HOST: COORD_PING_HOST,
-};

--- a/device/autojs6/lib/termux.js
+++ b/device/autojs6/lib/termux.js
@@ -1,88 +1,21 @@
 // @generated
 "use strict";
-// @ts-nocheck
-var config = require("./config.js");
-var log = require("./log.js");
-var TERMUX_PKG = "com.termux";
-var RUN_SERVICE = "com.termux.app.RunCommandService";
-var RUN_ACTION = "com.termux.RUN_COMMAND";
-/**
- * Invoke stayturgid_repair.py in Termux.
- *
- * Primary: RUN_COMMAND intent (needs AutoJs6 v6.4.1+ with
- * com.termux.permission.RUN_COMMAND granted + allow-external-apps=true).
- * Fallback: touch <sd>/run/repair_now for bridges.py --mode repair (2s poll).
- */
-function invokeRepair(profile) {
-  profile = profile || config.detectDeviceProfile();
-  var paths = config.pathsFor(profile);
-  var triggerFile = paths.triggerFile;
-  var beforeMs = log.latestRepairTimestampMs() || 0;
-  var start = Date.now();
-  var triggeredViaShizuku = false;
-  // 1. Always arm the trigger file immediately (non-intrusive)
-  tryTriggerFile(triggerFile);
-  // 2. Try direct background execution via Shizuku shell if operational
-  var shizukuShell = require("./shizuku_shell.js");
-  if (shizukuShell.isOperational()) {
-    try {
-      var cmd =
-        "run-as com.termux /data/data/com.termux/files/usr/bin/bash -c '" +
-        "export PATH=/data/data/com.termux/files/usr/bin:/data/data/com.termux/files/usr/sbin:$PATH; " +
-        "export HOME=/data/data/com.termux/files/home; " +
-        "export PREFIX=/data/data/com.termux/files/usr; " +
-        "export TMPDIR=/data/data/com.termux/files/usr/tmp; " +
-        "python3 " +
-        config.REPAIR_SCRIPT +
-        " " +
-        "&'";
-      shizukuShell.exec(cmd);
-      triggeredViaShizuku = true;
-      log.append("[watchdog] termux bridge: triggered repair directly via Shizuku shell");
-    } catch (e) {
-      log.append("[watchdog] termux bridge: Shizuku direct trigger failed: " + e);
-    }
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.invokeRepair = invokeRepair;
+exports.bridgeFailed = bridgeFailed;
+const config = require("./config.js");
+const log = require("./log.js");
+const shizukuShell = require("./shizuku_shell.js");
+const TERMUX_PKG = "com.termux";
+const RUN_SERVICE = "com.termux.app.RunCommandService";
+const RUN_ACTION = "com.termux.RUN_COMMAND";
+function tryTriggerFile(triggerFile) {
+  try {
+    config.ensureParentDir(triggerFile); // self-heal if run/ was deleted
+    files.write(triggerFile, String(Date.now()));
+  } catch (e) {
+    log.append("[watchdog] trigger file write failed: " + e);
   }
-  // 3. Loop and wait to see if the background/Shizuku execution succeeds
-  var deadline = Date.now() + 12000;
-  while (Date.now() < deadline) {
-    sleep(500);
-    var afterMs = log.latestRepairTimestampMs();
-    if (afterMs !== null && afterMs > beforeMs) {
-      return {
-        ok: true,
-        fresh: true,
-        method: triggeredViaShizuku ? "shizuku_shell" : "trigger_file",
-        beforeMs: beforeMs,
-        afterMs: afterMs,
-      };
-    }
-  }
-  // 4. Fallback: Only use com.termux.RUN_COMMAND intent as a last resort
-  log.append("[watchdog] termux bridge: background triggers timed out. Falling back to RUN_COMMAND.");
-  var runCommand = tryRunCommand();
-  if (runCommand.started) {
-    var fallbackDeadline = Date.now() + 8000;
-    while (Date.now() < fallbackDeadline) {
-      sleep(500);
-      var afterMsFallback = log.latestRepairTimestampMs();
-      if (afterMsFallback !== null && afterMsFallback > beforeMs) {
-        return {
-          ok: true,
-          fresh: true,
-          method: "run_command",
-          beforeMs: beforeMs,
-          afterMs: afterMsFallback,
-        };
-      }
-    }
-  }
-  log.append(
-    "[watchdog] termux bridge timeout method=" +
-      (runCommand.started ? "run_command" : "trigger_file") +
-      (runCommand.error ? " err=" + runCommand.error : ""),
-  );
-  return { ok: false, fresh: false, method: runCommand.started ? "run_command" : "trigger_file" };
 }
 function tryRunCommand() {
   try {
@@ -101,19 +34,83 @@ function tryRunCommand() {
     return { started: false, error: String(e) };
   }
 }
-function tryTriggerFile(triggerFile) {
-  try {
-    config.ensureParentDir(triggerFile); // self-heal if run/ was deleted
-    files.write(triggerFile, String(Date.now()));
-  } catch (e) {
-    log.append("[watchdog] trigger file write failed: " + e);
+/**
+ * Invoke stayturgid_repair.py in Termux.
+ *
+ * Primary: RUN_COMMAND intent (needs AutoJs6 v6.4.1+ with
+ * com.termux.permission.RUN_COMMAND granted + allow-external-apps=true).
+ * Fallback: touch <sd>/run/repair_now for bridges.py --mode repair (2s poll).
+ */
+function invokeRepair(profile) {
+  const resolvedProfile = profile || config.detectDeviceProfile();
+  const paths = config.pathsFor(resolvedProfile);
+  const triggerFile = paths.triggerFile;
+  const beforeMs = log.latestRepairTimestampMs() || 0;
+  let triggeredViaShizuku = false;
+  // 1. Always arm the trigger file immediately (non-intrusive)
+  tryTriggerFile(triggerFile);
+  // 2. Try direct background execution via Shizuku shell if operational
+  if (shizukuShell.isOperational()) {
+    try {
+      const cmd =
+        "run-as com.termux /data/data/com.termux/files/usr/bin/bash -c '" +
+        "export PATH=/data/data/com.termux/files/usr/bin:/data/data/com.termux/files/usr/sbin:$PATH; " +
+        "export HOME=/data/data/com.termux/files/home; " +
+        "export PREFIX=/data/data/com.termux/files/usr; " +
+        "export TMPDIR=/data/data/com.termux/files/usr/tmp; " +
+        "python3 " +
+        config.REPAIR_SCRIPT +
+        " " +
+        "&'";
+      shizukuShell.exec(cmd);
+      triggeredViaShizuku = true;
+      log.append("[watchdog] termux bridge: triggered repair directly via Shizuku shell");
+    } catch (e) {
+      log.append("[watchdog] termux bridge: Shizuku direct trigger failed: " + e);
+    }
   }
+  // 3. Loop and wait to see if the background/Shizuku execution succeeds
+  const deadline = Date.now() + 12000;
+  while (Date.now() < deadline) {
+    sleep(500);
+    const afterMs = log.latestRepairTimestampMs();
+    if (afterMs !== null && afterMs > beforeMs) {
+      return {
+        ok: true,
+        fresh: true,
+        method: triggeredViaShizuku ? "shizuku_shell" : "trigger_file",
+        beforeMs,
+        afterMs,
+      };
+    }
+  }
+  // 4. Fallback: Only use com.termux.RUN_COMMAND intent as a last resort
+  log.append("[watchdog] termux bridge: background triggers timed out. Falling back to RUN_COMMAND.");
+  const runCommand = tryRunCommand();
+  if (runCommand.started) {
+    const fallbackDeadline = Date.now() + 8000;
+    while (Date.now() < fallbackDeadline) {
+      sleep(500);
+      const afterMsFallback = log.latestRepairTimestampMs();
+      if (afterMsFallback !== null && afterMsFallback > beforeMs) {
+        return {
+          ok: true,
+          fresh: true,
+          method: "run_command",
+          beforeMs,
+          afterMs: afterMsFallback,
+        };
+      }
+    }
+  }
+  log.append(
+    "[watchdog] termux bridge timeout method=" +
+      (runCommand.started ? "run_command" : "trigger_file") +
+      (runCommand.error ? " err=" + runCommand.error : ""),
+  );
+  return { ok: false, fresh: false, method: runCommand.started ? "run_command" : "trigger_file" };
 }
 function bridgeFailed(invokeResult) {
   if (!invokeResult || !invokeResult.fresh) return true;
   return log.latestRepairStatus() === null;
 }
-module.exports = {
-  invokeRepair: invokeRepair,
-  bridgeFailed: bridgeFailed,
-};

--- a/device/autojs6/lib/termux.ts
+++ b/device/autojs6/lib/termux.ts
@@ -1,10 +1,55 @@
-// @ts-nocheck
-var config = require("./config.js");
-var log = require("./log.js");
+import config = require("./config.js");
+import log = require("./log.js");
+import shizukuShell = require("./shizuku_shell.js");
 
-var TERMUX_PKG = "com.termux";
-var RUN_SERVICE = "com.termux.app.RunCommandService";
-var RUN_ACTION = "com.termux.RUN_COMMAND";
+import type { DeviceProfile } from "./config.js";
+
+const TERMUX_PKG = "com.termux";
+const RUN_SERVICE = "com.termux.app.RunCommandService";
+const RUN_ACTION = "com.termux.RUN_COMMAND";
+
+/** Outcome of invokeRepair(): either a fresh STATUS was observed, or every path timed out. */
+export type InvokeRepairResult =
+  | {
+      ok: true;
+      fresh: true;
+      method: "shizuku_shell" | "trigger_file" | "run_command";
+      beforeMs: number;
+      afterMs: number;
+    }
+  | { ok: false; fresh: false; method: "trigger_file" | "run_command" };
+
+function tryTriggerFile(triggerFile: string): void {
+  try {
+    config.ensureParentDir(triggerFile); // self-heal if run/ was deleted
+    files.write(triggerFile, String(Date.now()));
+  } catch (e) {
+    log.append("[watchdog] trigger file write failed: " + e);
+  }
+}
+
+interface RunCommandOutcome {
+  started: boolean;
+  error?: string;
+}
+
+function tryRunCommand(): RunCommandOutcome {
+  try {
+    app.startService({
+      action: RUN_ACTION,
+      packageName: TERMUX_PKG,
+      className: RUN_SERVICE,
+      extras: {
+        "com.termux.RUN_COMMAND_PATH": config.REPAIR_SCRIPT,
+        "com.termux.RUN_COMMAND_BACKGROUND": "true",
+        "com.termux.RUN_COMMAND_WORKDIR": config.TERMUX_HOME,
+      },
+    });
+    return { started: true };
+  } catch (e) {
+    return { started: false, error: String(e) };
+  }
+}
 
 /**
  * Invoke stayturgid_repair.py in Termux.
@@ -13,22 +58,20 @@ var RUN_ACTION = "com.termux.RUN_COMMAND";
  * com.termux.permission.RUN_COMMAND granted + allow-external-apps=true).
  * Fallback: touch <sd>/run/repair_now for bridges.py --mode repair (2s poll).
  */
-function invokeRepair(profile) {
-  profile = profile || config.detectDeviceProfile();
-  var paths = config.pathsFor(profile);
-  var triggerFile = paths.triggerFile;
-  var beforeMs = log.latestRepairTimestampMs() || 0;
-  var start = Date.now();
-  var triggeredViaShizuku = false;
+export function invokeRepair(profile?: DeviceProfile): InvokeRepairResult {
+  const resolvedProfile = profile || config.detectDeviceProfile();
+  const paths = config.pathsFor(resolvedProfile);
+  const triggerFile = paths.triggerFile;
+  const beforeMs = log.latestRepairTimestampMs() || 0;
+  let triggeredViaShizuku = false;
 
   // 1. Always arm the trigger file immediately (non-intrusive)
   tryTriggerFile(triggerFile);
 
   // 2. Try direct background execution via Shizuku shell if operational
-  var shizukuShell = require("./shizuku_shell.js");
   if (shizukuShell.isOperational()) {
     try {
-      var cmd =
+      const cmd =
         "run-as com.termux /data/data/com.termux/files/usr/bin/bash -c '" +
         "export PATH=/data/data/com.termux/files/usr/bin:/data/data/com.termux/files/usr/sbin:$PATH; " +
         "export HOME=/data/data/com.termux/files/home; " +
@@ -47,35 +90,35 @@ function invokeRepair(profile) {
   }
 
   // 3. Loop and wait to see if the background/Shizuku execution succeeds
-  var deadline = Date.now() + 12000;
+  const deadline = Date.now() + 12000;
   while (Date.now() < deadline) {
     sleep(500);
-    var afterMs = log.latestRepairTimestampMs();
+    const afterMs = log.latestRepairTimestampMs();
     if (afterMs !== null && afterMs > beforeMs) {
       return {
         ok: true,
         fresh: true,
         method: triggeredViaShizuku ? "shizuku_shell" : "trigger_file",
-        beforeMs: beforeMs,
-        afterMs: afterMs,
+        beforeMs,
+        afterMs,
       };
     }
   }
 
   // 4. Fallback: Only use com.termux.RUN_COMMAND intent as a last resort
   log.append("[watchdog] termux bridge: background triggers timed out. Falling back to RUN_COMMAND.");
-  var runCommand = tryRunCommand();
+  const runCommand = tryRunCommand();
   if (runCommand.started) {
-    var fallbackDeadline = Date.now() + 8000;
+    const fallbackDeadline = Date.now() + 8000;
     while (Date.now() < fallbackDeadline) {
       sleep(500);
-      var afterMsFallback = log.latestRepairTimestampMs();
+      const afterMsFallback = log.latestRepairTimestampMs();
       if (afterMsFallback !== null && afterMsFallback > beforeMs) {
         return {
           ok: true,
           fresh: true,
           method: "run_command",
-          beforeMs: beforeMs,
+          beforeMs,
           afterMs: afterMsFallback,
         };
       }
@@ -90,39 +133,7 @@ function invokeRepair(profile) {
   return { ok: false, fresh: false, method: runCommand.started ? "run_command" : "trigger_file" };
 }
 
-function tryRunCommand() {
-  try {
-    app.startService({
-      action: RUN_ACTION,
-      packageName: TERMUX_PKG,
-      className: RUN_SERVICE,
-      extras: {
-        "com.termux.RUN_COMMAND_PATH": config.REPAIR_SCRIPT,
-        "com.termux.RUN_COMMAND_BACKGROUND": "true",
-        "com.termux.RUN_COMMAND_WORKDIR": config.TERMUX_HOME,
-      },
-    });
-    return { started: true };
-  } catch (e) {
-    return { started: false, error: String(e) };
-  }
-}
-
-function tryTriggerFile(triggerFile) {
-  try {
-    config.ensureParentDir(triggerFile); // self-heal if run/ was deleted
-    files.write(triggerFile, String(Date.now()));
-  } catch (e) {
-    log.append("[watchdog] trigger file write failed: " + e);
-  }
-}
-
-function bridgeFailed(invokeResult) {
+export function bridgeFailed(invokeResult: InvokeRepairResult | null | undefined): boolean {
   if (!invokeResult || !invokeResult.fresh) return true;
   return log.latestRepairStatus() === null;
 }
-
-module.exports = {
-  invokeRepair: invokeRepair,
-  bridgeFailed: bridgeFailed,
-};

--- a/device/autojs6/lib/watchdog.js
+++ b/device/autojs6/lib/watchdog.js
@@ -1,14 +1,15 @@
 // @generated
 "use strict";
-// @ts-nocheck
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.runCycle = runCycle;
 // @heals: TAILSCALE-VPN
-var config = require("./config.js");
-var log = require("./log.js");
-var notify = require("./notify.js");
-var termux = require("./termux.js");
-var repair = require("./repair.js");
-var tailscale = require("./tailscale.js");
-var comonitor = require("./comonitor.js");
+const config = require("./config.js");
+const log = require("./log.js");
+const notify = require("./notify.js");
+const termux = require("./termux.js");
+const repair = require("./repair.js");
+const tailscale = require("./tailscale.js");
+const comonitor = require("./comonitor.js");
 /**
  * One watchdog cycle — Termux-primary + AutoJs6 co-monitor redundancy:
  *   Termux boot loop  → routine repair every 5 min (authoritative when healthy)
@@ -17,18 +18,18 @@ var comonitor = require("./comonitor.js");
  *                       via shizuku() on every host (parity across the fleet).
  */
 function runCycle(trigger, profile) {
-  var tag = profile.notifyTag || "";
-  var split = config.splitStorage(profile);
-  var time = log.append("[watchdog] cycle start trigger=" + trigger + " (autojs6)");
+  const tag = profile.notifyTag || "";
+  const split = config.splitStorage(profile);
+  const time = log.append("[watchdog] cycle start trigger=" + trigger + " (autojs6)");
   try {
-    var p = config.pathsFor(profile);
-    files.ensureDir(String(p.watchdogStamp).replace(/\/[^/]+$/, "") + "/");
+    const p = config.pathsFor(profile);
+    files.ensureDir(p.watchdogStamp.replace(/\/[^/]+$/, "") + "/");
     files.write(p.watchdogStamp, time + " trigger=" + trigger + "\n");
   } catch (e) {
     log.append("[watchdog] stamp write failed: " + e);
   }
-  var termuxStale = log.isRepairLoopStale();
-  var comonitorReason = "periodic";
+  const termuxStale = log.isRepairLoopStale();
+  let comonitorReason = "periodic";
   if (split) {
     notify.clear("stale");
     notify.clear("bridge");
@@ -39,28 +40,24 @@ function runCycle(trigger, profile) {
       notify.show(
         "⚠ Repair loop stale " + tag,
         time +
-          " — No [repair] log line in 15+ min; Termux boot loop may be dead. " +
-          "AutoJs6 co-monitor will probe via Shizuku.",
+          " — No [repair] log line in 15+ min; Termux boot loop may be dead. AutoJs6 co-monitor will probe via Shizuku.",
         "stale",
       );
       comonitorReason = "termux-stale";
     } else {
       notify.clear("stale");
     }
-    var status = log.latestRepairStatus();
-    var port = status ? status.port : null;
-    var sshd = status ? status.sshd : "unknown";
+    let status = log.latestRepairStatus();
+    const port = status ? status.port : null;
     if (port === "CLOSED_NO_SHELL") {
       notify.show(
         "⚠ ADB 5555 down — auto-repairing " + tag,
-        time +
-          " — port 5555 unreachable + no shell. Trying Shizuku shell, " +
-          "then UI Start tap. If it persists, reboot.",
+        time + " — port 5555 unreachable + no shell. Trying Shizuku shell, then UI Start tap. If it persists, reboot.",
         "adb5555",
       );
       repair.repairCatastrophic(profile);
       termux.invokeRepair(profile);
-      var after = log.latestRepairStatus();
+      const after = log.latestRepairStatus();
       if (after && after.port === "CLOSED_NO_SHELL") {
         log.append("[watchdog] catastrophic repair finished but port still CLOSED_NO_SHELL");
         comonitorReason = "closed-no-shell";
@@ -68,31 +65,31 @@ function runCycle(trigger, profile) {
     } else {
       notify.clear("adb5555");
       if (termuxStale) {
-        var invoke = termux.invokeRepair(profile);
+        const invoke = termux.invokeRepair(profile);
         status = invoke.fresh ? log.latestRepairStatus() : status;
-        port = status ? status.port : "BRIDGE_FAIL";
-        sshd = status ? status.sshd : "unknown";
+        const invokedPort = status ? status.port : "BRIDGE_FAIL";
+        const invokedSshd = status ? status.sshd : "unknown";
         log.append(
           "[watchdog] port=" +
-            port +
+            invokedPort +
             " sshd=" +
-            sshd +
+            invokedSshd +
             " invoke=" +
             (invoke.ok ? "ok" : "fail") +
             " method=" +
-            (invoke.method || "?") +
+            invoke.method +
             " (autojs6 stale-loop)",
         );
-        if (!invoke.ok || port === "BRIDGE_FAIL" || termux.bridgeFailed(invoke)) {
+        if (!invoke.ok || invokedPort === "BRIDGE_FAIL" || termux.bridgeFailed(invoke)) {
           notify.show(
             "⚠ Watchdog bridge failed " + tag,
-            time + " — Termux RUN_COMMAND returned no fresh STATUS; " + "co-monitor taking over via Shizuku.",
+            time + " — Termux RUN_COMMAND returned no fresh STATUS; co-monitor taking over via Shizuku.",
             "bridge",
           );
           comonitorReason = "bridge-fail";
         } else {
           notify.clear("bridge");
-          if (sshd === "down" || sshd === "FAILED" || (status && status.shizuku === "down")) {
+          if (invokedSshd === "down" || (status && status.shizuku === "down")) {
             comonitorReason = "post-bridge-unhealthy";
           }
         }
@@ -103,22 +100,21 @@ function runCycle(trigger, profile) {
     }
   }
   // Fleet parity: every host runs the same Shizuku co-monitor each cycle.
-  status = comonitor.run(profile, { force: true, reason: comonitorReason });
-  if (status && (status.sshd === "down" || status.sshd === "FAILED")) {
+  const comonitorStatus = comonitor.run(profile, { force: true, reason: comonitorReason });
+  if (comonitorStatus && comonitorStatus.sshd === "down") {
     notify.show(
       "⚠ SSH daemon down " + tag,
-      time + " — Fresh co-monitor probe still sees sshd down. " + "SSH in via ADB/Tailscale and run: sshd",
+      time + " — Fresh co-monitor probe still sees sshd down. SSH in via ADB/Tailscale and run: sshd",
       "sshd",
     );
   } else {
     notify.clear("sshd");
   }
-  var ts;
   if (profile.tailscaleEnabled === false) {
     notify.clear("tailscale");
     log.append("[watchdog] tailscale checks disabled (not on tailnet yet) (autojs6)");
   } else {
-    ts = tailscale.check(profile);
+    const ts = tailscale.check(profile);
     log.append("[watchdog] tailscale tun=" + ts.tun + " ping=" + ts.ping + " up=" + ts.up);
     if (!ts.up) {
       notify.show(
@@ -132,4 +128,3 @@ function runCycle(trigger, profile) {
     }
   }
 }
-module.exports = { runCycle: runCycle };

--- a/device/autojs6/lib/watchdog.js
+++ b/device/autojs6/lib/watchdog.js
@@ -89,7 +89,11 @@ function runCycle(trigger, profile) {
           comonitorReason = "bridge-fail";
         } else {
           notify.clear("bridge");
-          if (invokedSshd === "down" || (status && status.shizuku === "down")) {
+          // invokedSshd comes from Termux's stayturgid_repair.py STATUS line
+          // (via log.latestRepairStatus()), which can genuinely write
+          // sshd=FAILED (see device/termux/py/stayturgid_repair.py) — unlike
+          // comonitor.ts's own SshdStatus below, this is not a closed union.
+          if (invokedSshd === "down" || invokedSshd === "FAILED" || (status && status.shizuku === "down")) {
             comonitorReason = "post-bridge-unhealthy";
           }
         }

--- a/device/autojs6/lib/watchdog.ts
+++ b/device/autojs6/lib/watchdog.ts
@@ -1,12 +1,13 @@
-// @ts-nocheck
 // @heals: TAILSCALE-VPN
-var config = require("./config.js");
-var log = require("./log.js");
-var notify = require("./notify.js");
-var termux = require("./termux.js");
-var repair = require("./repair.js");
-var tailscale = require("./tailscale.js");
-var comonitor = require("./comonitor.js");
+import config = require("./config.js");
+import log = require("./log.js");
+import notify = require("./notify.js");
+import termux = require("./termux.js");
+import repair = require("./repair.js");
+import tailscale = require("./tailscale.js");
+import comonitor = require("./comonitor.js");
+
+import type { DeviceProfile } from "./config.js";
 
 /**
  * One watchdog cycle — Termux-primary + AutoJs6 co-monitor redundancy:
@@ -15,19 +16,19 @@ var comonitor = require("./comonitor.js");
  *                       comonitor.js always re-probes the same STATUS surface
  *                       via shizuku() on every host (parity across the fleet).
  */
-function runCycle(trigger, profile) {
-  var tag = profile.notifyTag || "";
-  var split = config.splitStorage(profile);
-  var time = log.append("[watchdog] cycle start trigger=" + trigger + " (autojs6)");
+export function runCycle(trigger: string, profile: DeviceProfile): void {
+  const tag = profile.notifyTag || "";
+  const split = config.splitStorage(profile);
+  const time = log.append("[watchdog] cycle start trigger=" + trigger + " (autojs6)");
   try {
-    var p = config.pathsFor(profile);
-    files.ensureDir(String(p.watchdogStamp).replace(/\/[^/]+$/, "") + "/");
+    const p = config.pathsFor(profile);
+    files.ensureDir(p.watchdogStamp.replace(/\/[^/]+$/, "") + "/");
     files.write(p.watchdogStamp, time + " trigger=" + trigger + "\n");
   } catch (e) {
     log.append("[watchdog] stamp write failed: " + e);
   }
-  var termuxStale = log.isRepairLoopStale();
-  var comonitorReason = "periodic";
+  const termuxStale = log.isRepairLoopStale();
+  let comonitorReason = "periodic";
 
   if (split) {
     notify.clear("stale");
@@ -39,8 +40,7 @@ function runCycle(trigger, profile) {
       notify.show(
         "⚠ Repair loop stale " + tag,
         time +
-          " — No [repair] log line in 15+ min; Termux boot loop may be dead. " +
-          "AutoJs6 co-monitor will probe via Shizuku.",
+          " — No [repair] log line in 15+ min; Termux boot loop may be dead. AutoJs6 co-monitor will probe via Shizuku.",
         "stale",
       );
       comonitorReason = "termux-stale";
@@ -48,21 +48,18 @@ function runCycle(trigger, profile) {
       notify.clear("stale");
     }
 
-    var status = log.latestRepairStatus();
-    var port = status ? status.port : null;
-    var sshd = status ? status.sshd : "unknown";
+    let status = log.latestRepairStatus();
+    const port = status ? status.port : null;
 
     if (port === "CLOSED_NO_SHELL") {
       notify.show(
         "⚠ ADB 5555 down — auto-repairing " + tag,
-        time +
-          " — port 5555 unreachable + no shell. Trying Shizuku shell, " +
-          "then UI Start tap. If it persists, reboot.",
+        time + " — port 5555 unreachable + no shell. Trying Shizuku shell, then UI Start tap. If it persists, reboot.",
         "adb5555",
       );
       repair.repairCatastrophic(profile);
       termux.invokeRepair(profile);
-      var after = log.latestRepairStatus();
+      const after = log.latestRepairStatus();
       if (after && after.port === "CLOSED_NO_SHELL") {
         log.append("[watchdog] catastrophic repair finished but port still CLOSED_NO_SHELL");
         comonitorReason = "closed-no-shell";
@@ -71,31 +68,31 @@ function runCycle(trigger, profile) {
       notify.clear("adb5555");
 
       if (termuxStale) {
-        var invoke = termux.invokeRepair(profile);
+        const invoke = termux.invokeRepair(profile);
         status = invoke.fresh ? log.latestRepairStatus() : status;
-        port = status ? status.port : "BRIDGE_FAIL";
-        sshd = status ? status.sshd : "unknown";
+        const invokedPort = status ? status.port : "BRIDGE_FAIL";
+        const invokedSshd = status ? status.sshd : "unknown";
         log.append(
           "[watchdog] port=" +
-            port +
+            invokedPort +
             " sshd=" +
-            sshd +
+            invokedSshd +
             " invoke=" +
             (invoke.ok ? "ok" : "fail") +
             " method=" +
-            (invoke.method || "?") +
+            invoke.method +
             " (autojs6 stale-loop)",
         );
-        if (!invoke.ok || port === "BRIDGE_FAIL" || termux.bridgeFailed(invoke)) {
+        if (!invoke.ok || invokedPort === "BRIDGE_FAIL" || termux.bridgeFailed(invoke)) {
           notify.show(
             "⚠ Watchdog bridge failed " + tag,
-            time + " — Termux RUN_COMMAND returned no fresh STATUS; " + "co-monitor taking over via Shizuku.",
+            time + " — Termux RUN_COMMAND returned no fresh STATUS; co-monitor taking over via Shizuku.",
             "bridge",
           );
           comonitorReason = "bridge-fail";
         } else {
           notify.clear("bridge");
-          if (sshd === "down" || sshd === "FAILED" || (status && status.shizuku === "down")) {
+          if (invokedSshd === "down" || (status && status.shizuku === "down")) {
             comonitorReason = "post-bridge-unhealthy";
           }
         }
@@ -107,23 +104,22 @@ function runCycle(trigger, profile) {
   }
 
   // Fleet parity: every host runs the same Shizuku co-monitor each cycle.
-  status = comonitor.run(profile, { force: true, reason: comonitorReason });
-  if (status && (status.sshd === "down" || status.sshd === "FAILED")) {
+  const comonitorStatus = comonitor.run(profile, { force: true, reason: comonitorReason });
+  if (comonitorStatus && comonitorStatus.sshd === "down") {
     notify.show(
       "⚠ SSH daemon down " + tag,
-      time + " — Fresh co-monitor probe still sees sshd down. " + "SSH in via ADB/Tailscale and run: sshd",
+      time + " — Fresh co-monitor probe still sees sshd down. SSH in via ADB/Tailscale and run: sshd",
       "sshd",
     );
   } else {
     notify.clear("sshd");
   }
 
-  var ts;
   if (profile.tailscaleEnabled === false) {
     notify.clear("tailscale");
     log.append("[watchdog] tailscale checks disabled (not on tailnet yet) (autojs6)");
   } else {
-    ts = tailscale.check(profile);
+    const ts = tailscale.check(profile);
     log.append("[watchdog] tailscale tun=" + ts.tun + " ping=" + ts.ping + " up=" + ts.up);
     if (!ts.up) {
       notify.show(
@@ -137,5 +133,3 @@ function runCycle(trigger, profile) {
     }
   }
 }
-
-module.exports = { runCycle: runCycle };

--- a/device/autojs6/lib/watchdog.ts
+++ b/device/autojs6/lib/watchdog.ts
@@ -92,7 +92,11 @@ export function runCycle(trigger: string, profile: DeviceProfile): void {
           comonitorReason = "bridge-fail";
         } else {
           notify.clear("bridge");
-          if (invokedSshd === "down" || (status && status.shizuku === "down")) {
+          // invokedSshd comes from Termux's stayturgid_repair.py STATUS line
+          // (via log.latestRepairStatus()), which can genuinely write
+          // sshd=FAILED (see device/termux/py/stayturgid_repair.py) — unlike
+          // comonitor.ts's own SshdStatus below, this is not a closed union.
+          if (invokedSshd === "down" || invokedSshd === "FAILED" || (status && status.shizuku === "down")) {
             comonitorReason = "post-bridge-unhealthy";
           }
         }

--- a/device/autojs6/main.js
+++ b/device/autojs6/main.js
@@ -1,6 +1,5 @@
 // @generated
 "use strict";
-// @ts-nocheck
 /**
  * stayturgid AutoJs6 watchdog — entry point.
  *
@@ -8,20 +7,19 @@
  * Optional: AutoJs6 timed task every 20 min + run on boot for main.js.
  */
 "auto";
-var config = require("./lib/config.js");
-var guard = require("./lib/guard.js");
-var watchdog = require("./lib/watchdog.js");
-var log = require("./lib/log.js");
-var engineGuard = require("./lib/engine_guard.js");
-var profile;
-try {
-  profile = config.detectDeviceProfile();
-} catch (e) {
-  profile = {};
-}
+Object.defineProperty(exports, "__esModule", { value: true });
+const config = require("./lib/config.js");
+const guard = require("./lib/guard.js");
+const watchdog = require("./lib/watchdog.js");
+const log = require("./lib/log.js");
+const engineGuard = require("./lib/engine_guard.js");
+// detectDeviceProfile() cannot throw (its only internal try/catch is around
+// the device.json file read, which it already swallows) — no defensive
+// try/catch needed around this call.
+const profile = config.detectDeviceProfile();
 try {
   config.ensureDirs(profile); // create shared dirs (self-heal)
-} catch (e) {
+} catch (_a) {
   /* best effort — cycles mkdir on demand too */
 }
 if (profile.usingGenericDefaults) {
@@ -45,15 +43,15 @@ function safeCycle(trigger) {
   }
 }
 log.append("[watchdog] stayturgid AutoJs6 started device=" + (profile.id || "?"));
-var stopped = engineGuard.dedupeMainEngines();
+const stopped = engineGuard.dedupeMainEngines();
 if (stopped > 0) {
   log.append("[watchdog] stopped " + stopped + " duplicate main.js engine(s)");
 }
 safeCycle("boot"); // covers manual launch + boot auto-start
 // Every 20 minutes — the loop is ALWAYS established, even if the boot cycle
 // above hit trouble, so the watchdog self-recovers on the next tick.
-setInterval(function () {
+setInterval(() => {
   safeCycle("interval");
 }, config.INTERVAL_MS);
 // Keep the script process alive (AutoJs6 stops when the main thread exits)
-setInterval(function () {}, 60000);
+setInterval(() => {}, 60000);

--- a/device/autojs6/main.ts
+++ b/device/autojs6/main.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * stayturgid AutoJs6 watchdog — entry point.
  *
@@ -7,22 +6,20 @@
  */
 "auto";
 
-var config = require("./lib/config.js");
-var guard = require("./lib/guard.js");
-var watchdog = require("./lib/watchdog.js");
-var log = require("./lib/log.js");
-var engineGuard = require("./lib/engine_guard.js");
+import config = require("./lib/config.js");
+import guard = require("./lib/guard.js");
+import watchdog = require("./lib/watchdog.js");
+import log = require("./lib/log.js");
+import engineGuard = require("./lib/engine_guard.js");
 
-var profile;
-try {
-  profile = config.detectDeviceProfile();
-} catch (e) {
-  profile = {};
-}
+// detectDeviceProfile() cannot throw (its only internal try/catch is around
+// the device.json file read, which it already swallows) — no defensive
+// try/catch needed around this call.
+const profile = config.detectDeviceProfile();
 
 try {
   config.ensureDirs(profile); // create shared dirs (self-heal)
-} catch (e) {
+} catch {
   /* best effort — cycles mkdir on demand too */
 }
 
@@ -40,7 +37,7 @@ try {
 }
 
 // Run one guarded cycle.
-function safeCycle(trigger) {
+function safeCycle(trigger: string): void {
   try {
     guard.enforce(profile);
     watchdog.runCycle(trigger, profile);
@@ -50,7 +47,7 @@ function safeCycle(trigger) {
 }
 
 log.append("[watchdog] stayturgid AutoJs6 started device=" + (profile.id || "?"));
-var stopped = engineGuard.dedupeMainEngines();
+const stopped = engineGuard.dedupeMainEngines();
 if (stopped > 0) {
   log.append("[watchdog] stopped " + stopped + " duplicate main.js engine(s)");
 }
@@ -58,9 +55,9 @@ safeCycle("boot"); // covers manual launch + boot auto-start
 
 // Every 20 minutes — the loop is ALWAYS established, even if the boot cycle
 // above hit trouble, so the watchdog self-recovers on the next tick.
-setInterval(function () {
+setInterval(() => {
   safeCycle("interval");
 }, config.INTERVAL_MS);
 
 // Keep the script process alive (AutoJs6 stops when the main thread exits)
-setInterval(function () {}, 60000);
+setInterval(() => {}, 60000);

--- a/device/autojs6/scripts/boot-launcher.js
+++ b/device/autojs6/scripts/boot-launcher.js
@@ -1,6 +1,5 @@
 // @generated
 "use strict";
-// @ts-nocheck
 /**
  * Boot helper: start main.js if not already running.
  * Invoked from Termux:Boot (start-autojs6-watchdog.sh), bridges.py --mode autojs6
@@ -8,18 +7,19 @@
  *
  * No "auto" directive: this launcher doesn't need accessibility.
  */
-var engineGuard = require("../lib/engine_guard.js");
-var config = require("../lib/config.js");
-var MAIN = engineGuard.MAIN;
-var STALE_WATCHDOG_MS = 25 * 60 * 1000;
+Object.defineProperty(exports, "__esModule", { value: true });
+const engineGuard = require("../lib/engine_guard.js");
+const config = require("../lib/config.js");
+const MAIN = engineGuard.MAIN;
+const STALE_WATCHDOG_MS = 25 * 60 * 1000;
 function latestWatchdogCycleMs() {
-  var logPath = config.WATCHDOG_LOG;
+  const logPath = config.WATCHDOG_LOG;
   if (!files.exists(logPath)) return null;
   try {
-    var lines = String(files.read(logPath)).split("\n");
-    for (var i = lines.length - 1; i >= 0; i--) {
+    const lines = String(files.read(logPath)).split("\n");
+    for (let i = lines.length - 1; i >= 0; i--) {
       if (lines[i].indexOf("[watchdog] cycle start") >= 0) {
-        var m = lines[i].match(/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})/);
+        const m = lines[i].match(/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})/);
         if (m) {
           return new Date(
             Number(m[1]),
@@ -32,18 +32,18 @@ function latestWatchdogCycleMs() {
         }
       }
     }
-  } catch (e) {
+  } catch (_a) {
     /* best effort */
   }
   return null;
 }
 function watchdogStale() {
-  var last = latestWatchdogCycleMs();
+  const last = latestWatchdogCycleMs();
   if (last === null) return true;
   return Date.now() - last > STALE_WATCHDOG_MS;
 }
 function launchIfNeeded() {
-  var existing = engineGuard.findMainEngines();
+  const existing = engineGuard.findMainEngines();
   if (existing.length === 1 && !watchdogStale()) {
     return;
   }
@@ -56,7 +56,7 @@ function launchIfNeeded() {
   // directory.  main.js loads ./lib/*, so give the child its own directory
   // explicitly instead of letting every relative require resolve one level
   // too low.
-  var childConfig = new org.autojs.autojs.execution.ExecutionConfig();
+  const childConfig = new org.autojs.autojs.execution.ExecutionConfig();
   childConfig.setWorkingDirectory(MAIN.substring(0, MAIN.lastIndexOf("/")));
   engines.execScriptFile(MAIN, childConfig);
 }

--- a/device/autojs6/scripts/boot-launcher.ts
+++ b/device/autojs6/scripts/boot-launcher.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Boot helper: start main.js if not already running.
  * Invoked from Termux:Boot (start-autojs6-watchdog.sh), bridges.py --mode autojs6
@@ -7,19 +6,20 @@
  * No "auto" directive: this launcher doesn't need accessibility.
  */
 
-var engineGuard = require("../lib/engine_guard.js");
-var config = require("../lib/config.js");
-var MAIN = engineGuard.MAIN;
-var STALE_WATCHDOG_MS = 25 * 60 * 1000;
+import engineGuard = require("../lib/engine_guard.js");
+import config = require("../lib/config.js");
 
-function latestWatchdogCycleMs() {
-  var logPath = config.WATCHDOG_LOG;
+const MAIN = engineGuard.MAIN;
+const STALE_WATCHDOG_MS = 25 * 60 * 1000;
+
+function latestWatchdogCycleMs(): number | null {
+  const logPath = config.WATCHDOG_LOG;
   if (!files.exists(logPath)) return null;
   try {
-    var lines = String(files.read(logPath)).split("\n");
-    for (var i = lines.length - 1; i >= 0; i--) {
+    const lines = String(files.read(logPath)).split("\n");
+    for (let i = lines.length - 1; i >= 0; i--) {
       if (lines[i].indexOf("[watchdog] cycle start") >= 0) {
-        var m = lines[i].match(/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})/);
+        const m = lines[i].match(/^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})/);
         if (m) {
           return new Date(
             Number(m[1]),
@@ -32,20 +32,20 @@ function latestWatchdogCycleMs() {
         }
       }
     }
-  } catch (e) {
+  } catch {
     /* best effort */
   }
   return null;
 }
 
-function watchdogStale() {
-  var last = latestWatchdogCycleMs();
+function watchdogStale(): boolean {
+  const last = latestWatchdogCycleMs();
   if (last === null) return true;
   return Date.now() - last > STALE_WATCHDOG_MS;
 }
 
-function launchIfNeeded() {
-  var existing = engineGuard.findMainEngines();
+function launchIfNeeded(): void {
+  const existing = engineGuard.findMainEngines();
   if (existing.length === 1 && !watchdogStale()) {
     return;
   }
@@ -58,7 +58,7 @@ function launchIfNeeded() {
   // directory.  main.js loads ./lib/*, so give the child its own directory
   // explicitly instead of letting every relative require resolve one level
   // too low.
-  var childConfig = new org.autojs.autojs.execution.ExecutionConfig();
+  const childConfig = new org.autojs.autojs.execution.ExecutionConfig();
   childConfig.setWorkingDirectory(MAIN.substring(0, MAIN.lastIndexOf("/")));
   engines.execScriptFile(MAIN, childConfig);
 }

--- a/device/autojs6/scripts/shizuku-probe.js
+++ b/device/autojs6/scripts/shizuku-probe.js
@@ -1,15 +1,15 @@
 // @generated
 "use strict";
-// @ts-nocheck
+Object.defineProperty(exports, "__esModule", { value: true });
 /**
  * One-shot setup probe — logs Shizuku operational state to watchdog.log.
  * Invoked from control/tools/autojs6/enable_autojs6_shizuku.py during fleet setup only.
  */
-var log = require("../lib/log.js");
-var sh = require("../lib/shizuku_shell.js");
-var hasPerm = false;
-var running = false;
-var operational = false;
+const log = require("../lib/log.js");
+const sh = require("../lib/shizuku_shell.js");
+let hasPerm = false;
+let running = false;
+let operational = false;
 try {
   if (typeof shizuku !== "undefined") {
     if (typeof shizuku.hasPermission === "function") {

--- a/device/autojs6/scripts/shizuku-probe.ts
+++ b/device/autojs6/scripts/shizuku-probe.ts
@@ -1,14 +1,13 @@
-// @ts-nocheck
 /**
  * One-shot setup probe — logs Shizuku operational state to watchdog.log.
  * Invoked from control/tools/autojs6/enable_autojs6_shizuku.py during fleet setup only.
  */
-var log = require("../lib/log.js");
-var sh = require("../lib/shizuku_shell.js");
+import log = require("../lib/log.js");
+import sh = require("../lib/shizuku_shell.js");
 
-var hasPerm = false;
-var running = false;
-var operational = false;
+let hasPerm = false;
+let running = false;
+let operational = false;
 try {
   if (typeof shizuku !== "undefined") {
     if (typeof shizuku.hasPermission === "function") {

--- a/device/autojs6/scripts/switch-to-autojs6.js
+++ b/device/autojs6/scripts/switch-to-autojs6.js
@@ -1,14 +1,14 @@
 // @generated
 "use strict";
-// @ts-nocheck
+Object.defineProperty(exports, "__esModule", { value: true });
 /**
  * One-shot helper: write legacy mode marker and show next steps.
  * Run from AutoJs6 when setting up a new device.
  */
-var config = require("../lib/config.js");
-var notify = require("../lib/notify.js");
+const config = require("../lib/config.js");
+const notify = require("../lib/notify.js");
 config.ensureDirs();
 files.write(config.SD_ROOT + "/state/automation_mode.txt", "autojs6\n");
-var msg = "stayturgid: enable AutoJs6 accessibility, then run main.js (or rely on Termux:Boot).";
+const msg = "stayturgid: enable AutoJs6 accessibility, then run main.js (or rely on Termux:Boot).";
 toast(msg);
 notify.show("stayturgid AutoJs6", msg);

--- a/device/autojs6/scripts/switch-to-autojs6.ts
+++ b/device/autojs6/scripts/switch-to-autojs6.ts
@@ -1,13 +1,12 @@
-// @ts-nocheck
 /**
  * One-shot helper: write legacy mode marker and show next steps.
  * Run from AutoJs6 when setting up a new device.
  */
-var config = require("../lib/config.js");
-var notify = require("../lib/notify.js");
+import config = require("../lib/config.js");
+import notify = require("../lib/notify.js");
 
 config.ensureDirs();
 files.write(config.SD_ROOT + "/state/automation_mode.txt", "autojs6\n");
-var msg = "stayturgid: enable AutoJs6 accessibility, then run main.js (or rely on Termux:Boot).";
+const msg = "stayturgid: enable AutoJs6 accessibility, then run main.js (or rely on Termux:Boot).";
 toast(msg);
 notify.show("stayturgid AutoJs6", msg);

--- a/device/autojs6/scripts/test-catastrophic-once.js
+++ b/device/autojs6/scripts/test-catastrophic-once.js
@@ -1,6 +1,5 @@
 // @generated
 "use strict";
-// @ts-nocheck
 /**
  * Validate catastrophic UI repair (Shizuku Start tap) without breaking port 5555.
  * Mirrors the CLOSED_NO_SHELL branch in watchdog.js — use when 5555 cannot be
@@ -9,14 +8,16 @@
  * Requires: unlocked screen, AutoJs6 accessibility, mode=autojs6.
  */
 "auto";
-var config = require("../lib/config.js");
-var guard = require("../lib/guard.js");
-var log = require("../lib/log.js");
-var repair = require("../lib/repair.js");
+Object.defineProperty(exports, "__esModule", { value: true });
+const config = require("../lib/config.js");
+const guard = require("../lib/guard.js");
+const log = require("../lib/log.js");
+const repair = require("../lib/repair.js");
 guard.enforce();
+// The "auto" directive above guarantees AutoJs6 has populated this global.
 auto.waitFor();
-var profile = config.detectDeviceProfile();
+const profile = config.detectDeviceProfile();
 log.append("[watchdog] catastrophic UI test start (autojs6)");
-var ok = repair.repairCatastrophic(profile);
+const ok = repair.repairCatastrophic(profile);
 log.append("[watchdog] catastrophic UI test finished ok=" + ok + " (autojs6)");
 toast("catastrophic UI test done ok=" + ok + " — check watchdog log");

--- a/device/autojs6/scripts/test-catastrophic-once.ts
+++ b/device/autojs6/scripts/test-catastrophic-once.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Validate catastrophic UI repair (Shizuku Start tap) without breaking port 5555.
  * Mirrors the CLOSED_NO_SHELL branch in watchdog.js — use when 5555 cannot be
@@ -8,16 +7,17 @@
  */
 "auto";
 
-var config = require("../lib/config.js");
-var guard = require("../lib/guard.js");
-var log = require("../lib/log.js");
-var repair = require("../lib/repair.js");
+import config = require("../lib/config.js");
+import guard = require("../lib/guard.js");
+import log = require("../lib/log.js");
+import repair = require("../lib/repair.js");
 
 guard.enforce();
-auto.waitFor();
+// The "auto" directive above guarantees AutoJs6 has populated this global.
+auto!.waitFor();
 
-var profile = config.detectDeviceProfile();
+const profile = config.detectDeviceProfile();
 log.append("[watchdog] catastrophic UI test start (autojs6)");
-var ok = repair.repairCatastrophic(profile);
+const ok = repair.repairCatastrophic(profile);
 log.append("[watchdog] catastrophic UI test finished ok=" + ok + " (autojs6)");
 toast("catastrophic UI test done ok=" + ok + " — check watchdog log");

--- a/device/autojs6/scripts/test-stale-loop-once.js
+++ b/device/autojs6/scripts/test-stale-loop-once.js
@@ -1,6 +1,5 @@
 // @generated
 "use strict";
-// @ts-nocheck
 /**
  * Validate stale repair-loop detection without a 15-minute wait.
  * Injects a synthetic [repair] log line 20 minutes in the past, then runs one
@@ -9,17 +8,19 @@
  * Requires: mode=autojs6, accessibility enabled.
  */
 "auto";
-var config = require("../lib/config.js");
-var guard = require("../lib/guard.js");
-var log = require("../lib/log.js");
-var watchdog = require("../lib/watchdog.js");
+Object.defineProperty(exports, "__esModule", { value: true });
+const config = require("../lib/config.js");
+const guard = require("../lib/guard.js");
+const log = require("../lib/log.js");
+const watchdog = require("../lib/watchdog.js");
 guard.enforce();
+// The "auto" directive above guarantees AutoJs6 has populated this global.
 auto.waitFor();
 function pad(n) {
   return (n < 10 ? "0" : "") + n;
 }
-var stale = new Date(Date.now() - 20 * 60 * 1000);
-var stamp =
+const stale = new Date(Date.now() - 20 * 60 * 1000);
+const stamp =
   stale.getFullYear() +
   "-" +
   pad(stale.getMonth() + 1) +
@@ -31,16 +32,14 @@ var stamp =
   pad(stale.getMinutes()) +
   ":" +
   pad(stale.getSeconds());
-var synthetic = stamp + " [repair] STATUS port=open shizuku=up sshd=up shell=yes (synthetic-stale-test)";
-var prior = log.readWatchdogLog();
-var kept = prior.split("\n").filter(function (line) {
-  return line.length > 0 && line.indexOf("[repair]") < 0;
-});
+const synthetic = stamp + " [repair] STATUS port=open shizuku=up sshd=up shell=yes (synthetic-stale-test)";
+const prior = log.readWatchdogLog();
+const kept = prior.split("\n").filter((line) => line.length > 0 && line.indexOf("[repair]") < 0);
 kept.push(synthetic);
 files.write(config.WATCHDOG_LOG, kept.join("\n") + "\n");
 log.append("[watchdog] stale-loop test injected line at " + stamp + " isStaleBefore=" + log.isRepairLoopStale());
-var profile = config.detectDeviceProfile();
+const profile = config.detectDeviceProfile();
 watchdog.runCycle("stale-loop-test", profile);
-var staleAfter = log.isRepairLoopStale();
+const staleAfter = log.isRepairLoopStale();
 log.append("[watchdog] stale-loop test finished isStaleAfterInvoke=" + staleAfter);
 toast("stale-loop test done — expect Repair loop stale notification");

--- a/device/autojs6/scripts/test-stale-loop-once.ts
+++ b/device/autojs6/scripts/test-stale-loop-once.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Validate stale repair-loop detection without a 15-minute wait.
  * Injects a synthetic [repair] log line 20 minutes in the past, then runs one
@@ -8,20 +7,21 @@
  */
 "auto";
 
-var config = require("../lib/config.js");
-var guard = require("../lib/guard.js");
-var log = require("../lib/log.js");
-var watchdog = require("../lib/watchdog.js");
+import config = require("../lib/config.js");
+import guard = require("../lib/guard.js");
+import log = require("../lib/log.js");
+import watchdog = require("../lib/watchdog.js");
 
 guard.enforce();
-auto.waitFor();
+// The "auto" directive above guarantees AutoJs6 has populated this global.
+auto!.waitFor();
 
-function pad(n) {
+function pad(n: number): string {
   return (n < 10 ? "0" : "") + n;
 }
 
-var stale = new Date(Date.now() - 20 * 60 * 1000);
-var stamp =
+const stale = new Date(Date.now() - 20 * 60 * 1000);
+const stamp =
   stale.getFullYear() +
   "-" +
   pad(stale.getMonth() + 1) +
@@ -34,17 +34,15 @@ var stamp =
   ":" +
   pad(stale.getSeconds());
 
-var synthetic = stamp + " [repair] STATUS port=open shizuku=up sshd=up shell=yes (synthetic-stale-test)";
-var prior = log.readWatchdogLog();
-var kept = prior.split("\n").filter(function (line) {
-  return line.length > 0 && line.indexOf("[repair]") < 0;
-});
+const synthetic = stamp + " [repair] STATUS port=open shizuku=up sshd=up shell=yes (synthetic-stale-test)";
+const prior = log.readWatchdogLog();
+const kept = prior.split("\n").filter((line) => line.length > 0 && line.indexOf("[repair]") < 0);
 kept.push(synthetic);
 files.write(config.WATCHDOG_LOG, kept.join("\n") + "\n");
 log.append("[watchdog] stale-loop test injected line at " + stamp + " isStaleBefore=" + log.isRepairLoopStale());
 
-var profile = config.detectDeviceProfile();
+const profile = config.detectDeviceProfile();
 watchdog.runCycle("stale-loop-test", profile);
-var staleAfter = log.isRepairLoopStale();
+const staleAfter = log.isRepairLoopStale();
 log.append("[watchdog] stale-loop test finished isStaleAfterInvoke=" + staleAfter);
 toast("stale-loop test done — expect Repair loop stale notification");

--- a/device/autojs6/scripts/test-tailscale-down-once.js
+++ b/device/autojs6/scripts/test-tailscale-down-once.js
@@ -1,6 +1,5 @@
 // @generated
 "use strict";
-// @ts-nocheck
 /**
  * Tailscale-down probe + relaunch (Mac script force-stops first).
  * Pair with: control/tools/autojs6/test_tailscale_down.py
@@ -9,26 +8,27 @@
  * so the Mac driver gets log lines within ~60s (relaunch + waitForUp only).
  */
 "auto";
-var config = require("../lib/config.js");
-var log = require("../lib/log.js");
-var tailscale = require("../lib/tailscale.js");
-var profile = config.detectDeviceProfile();
+Object.defineProperty(exports, "__esModule", { value: true });
+const config = require("../lib/config.js");
+const log = require("../lib/log.js");
+const tailscale = require("../lib/tailscale.js");
+const profile = config.detectDeviceProfile();
 config.ensureDirs(profile);
 function waitForUp(maxMs) {
-  var deadline = Date.now() + maxMs;
+  const deadline = Date.now() + maxMs;
   while (Date.now() < deadline) {
-    var ts = tailscale.check(profile);
+    const ts = tailscale.check(profile);
     if (ts.up) return ts;
     sleep(2000);
   }
   return tailscale.check(profile);
 }
 log.append("[watchdog] tailscale-down-test probe start (autojs6)");
-var down = tailscale.check(profile);
+const down = tailscale.check(profile);
 log.append("[watchdog] tailscale-down-test probe tun=" + down.tun + " ping=" + down.ping + " up=" + down.up);
-var relaunched = tailscale.relaunch(profile);
+const relaunched = tailscale.relaunch(profile);
 sleep(2000);
-var after = waitForUp(45000);
+const after = waitForUp(45000);
 log.append(
   "[watchdog] tailscale-down-test after-relaunch tun=" +
     after.tun +

--- a/device/autojs6/scripts/test-tailscale-down-once.ts
+++ b/device/autojs6/scripts/test-tailscale-down-once.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Tailscale-down probe + relaunch (Mac script force-stops first).
  * Pair with: control/tools/autojs6/test_tailscale_down.py
@@ -8,17 +7,19 @@
  */
 "auto";
 
-var config = require("../lib/config.js");
-var log = require("../lib/log.js");
-var tailscale = require("../lib/tailscale.js");
+import config = require("../lib/config.js");
+import log = require("../lib/log.js");
+import tailscale = require("../lib/tailscale.js");
 
-var profile = config.detectDeviceProfile();
+import type { TailscaleHealth } from "../lib/tailscale.js";
+
+const profile = config.detectDeviceProfile();
 config.ensureDirs(profile);
 
-function waitForUp(maxMs) {
-  var deadline = Date.now() + maxMs;
+function waitForUp(maxMs: number): TailscaleHealth {
+  const deadline = Date.now() + maxMs;
   while (Date.now() < deadline) {
-    var ts = tailscale.check(profile);
+    const ts = tailscale.check(profile);
     if (ts.up) return ts;
     sleep(2000);
   }
@@ -27,12 +28,12 @@ function waitForUp(maxMs) {
 
 log.append("[watchdog] tailscale-down-test probe start (autojs6)");
 
-var down = tailscale.check(profile);
+const down = tailscale.check(profile);
 log.append("[watchdog] tailscale-down-test probe tun=" + down.tun + " ping=" + down.ping + " up=" + down.up);
 
-var relaunched = tailscale.relaunch(profile);
+const relaunched = tailscale.relaunch(profile);
 sleep(2000);
-var after = waitForUp(45000);
+const after = waitForUp(45000);
 
 log.append(
   "[watchdog] tailscale-down-test after-relaunch tun=" +

--- a/device/autojs6/scripts/test-tailscale-probe-once.js
+++ b/device/autojs6/scripts/test-tailscale-probe-once.js
@@ -1,17 +1,17 @@
 // @generated
 "use strict";
-// @ts-nocheck
 /**
  * Log Tailscale probe results (tun0 + coord ping) and optional relaunch dry-run.
  * Usage: run from AutoJs6 while mode=autojs6.
  */
 "auto";
-var config = require("../lib/config.js");
-var guard = require("../lib/guard.js");
-var log = require("../lib/log.js");
-var tailscale = require("../lib/tailscale.js");
+Object.defineProperty(exports, "__esModule", { value: true });
+const config = require("../lib/config.js");
+const guard = require("../lib/guard.js");
+const log = require("../lib/log.js");
+const tailscale = require("../lib/tailscale.js");
 guard.enforce();
-var profile = config.detectDeviceProfile();
-var ts = tailscale.check(profile);
+const profile = config.detectDeviceProfile();
+const ts = tailscale.check(profile);
 log.append("[watchdog] tailscale-probe-test tun=" + ts.tun + " ping=" + ts.ping + " up=" + ts.up);
 toast("tailscale probe up=" + ts.up + " tun=" + ts.tun + " ping=" + ts.ping);

--- a/device/autojs6/scripts/test-tailscale-probe-once.ts
+++ b/device/autojs6/scripts/test-tailscale-probe-once.ts
@@ -1,18 +1,17 @@
-// @ts-nocheck
 /**
  * Log Tailscale probe results (tun0 + coord ping) and optional relaunch dry-run.
  * Usage: run from AutoJs6 while mode=autojs6.
  */
 "auto";
 
-var config = require("../lib/config.js");
-var guard = require("../lib/guard.js");
-var log = require("../lib/log.js");
-var tailscale = require("../lib/tailscale.js");
+import config = require("../lib/config.js");
+import guard = require("../lib/guard.js");
+import log = require("../lib/log.js");
+import tailscale = require("../lib/tailscale.js");
 
 guard.enforce();
 
-var profile = config.detectDeviceProfile();
-var ts = tailscale.check(profile);
+const profile = config.detectDeviceProfile();
+const ts = tailscale.check(profile);
 log.append("[watchdog] tailscale-probe-test tun=" + ts.tun + " ping=" + ts.ping + " up=" + ts.up);
 toast("tailscale probe up=" + ts.up + " tun=" + ts.tun + " ping=" + ts.ping);

--- a/device/autojs6/scripts/test-termux-bridge.js
+++ b/device/autojs6/scripts/test-termux-bridge.js
@@ -1,17 +1,17 @@
 // @generated
 "use strict";
-// @ts-nocheck
 /**
  * Test the Termux repair bridge in isolation (bridge only, not the full watchdog).
  */
 "auto";
-var termux = require("../lib/termux.js");
-var log = require("../lib/log.js");
+Object.defineProperty(exports, "__esModule", { value: true });
+const termux = require("../lib/termux.js");
+const log = require("../lib/log.js");
 toast("Testing Termux bridge…");
-var result = termux.invokeRepair();
-var status = log.latestRepairStatus();
-var line = log.append(
-  "[test] bridge ok=" + result.ok + " method=" + (result.method || "?") + " status=" + (status ? status.port : "none"),
+const result = termux.invokeRepair();
+const status = log.latestRepairStatus();
+const line = log.append(
+  "[test] bridge ok=" + result.ok + " method=" + result.method + " status=" + (status ? status.port : "none"),
 );
 toast(result.ok ? "Bridge OK: " + result.method : "Bridge FAIL");
 console.log(line);

--- a/device/autojs6/scripts/test-termux-bridge.ts
+++ b/device/autojs6/scripts/test-termux-bridge.ts
@@ -1,17 +1,16 @@
-// @ts-nocheck
 /**
  * Test the Termux repair bridge in isolation (bridge only, not the full watchdog).
  */
 "auto";
 
-var termux = require("../lib/termux.js");
-var log = require("../lib/log.js");
+import termux = require("../lib/termux.js");
+import log = require("../lib/log.js");
 
 toast("Testing Termux bridge…");
-var result = termux.invokeRepair();
-var status = log.latestRepairStatus();
-var line = log.append(
-  "[test] bridge ok=" + result.ok + " method=" + (result.method || "?") + " status=" + (status ? status.port : "none"),
+const result = termux.invokeRepair();
+const status = log.latestRepairStatus();
+const line = log.append(
+  "[test] bridge ok=" + result.ok + " method=" + result.method + " status=" + (status ? status.port : "none"),
 );
 
 toast(result.ok ? "Bridge OK: " + result.method : "Bridge FAIL");

--- a/device/autojs6/scripts/test-watchdog-once.js
+++ b/device/autojs6/scripts/test-watchdog-once.js
@@ -1,16 +1,17 @@
 // @generated
 "use strict";
-// @ts-nocheck
 /**
  * Run a single watchdog cycle (no 20-min interval). For manual testing.
  * Usage: run from AutoJs6 while mode=autojs6 and accessibility is enabled.
  */
 "auto";
-var config = require("../lib/config.js");
-var guard = require("../lib/guard.js");
-var watchdog = require("../lib/watchdog.js");
+Object.defineProperty(exports, "__esModule", { value: true });
+const config = require("../lib/config.js");
+const guard = require("../lib/guard.js");
+const watchdog = require("../lib/watchdog.js");
 guard.enforce();
+// The "auto" directive above guarantees AutoJs6 has populated this global.
 auto.waitFor();
-var profile = config.detectDeviceProfile();
+const profile = config.detectDeviceProfile();
 watchdog.runCycle("manual-test", profile);
 toast("stayturgid watchdog test cycle done — check /sdcard/stayturgid/logs/watchdog.log");

--- a/device/autojs6/scripts/test-watchdog-once.ts
+++ b/device/autojs6/scripts/test-watchdog-once.ts
@@ -1,17 +1,17 @@
-// @ts-nocheck
 /**
  * Run a single watchdog cycle (no 20-min interval). For manual testing.
  * Usage: run from AutoJs6 while mode=autojs6 and accessibility is enabled.
  */
 "auto";
 
-var config = require("../lib/config.js");
-var guard = require("../lib/guard.js");
-var watchdog = require("../lib/watchdog.js");
+import config = require("../lib/config.js");
+import guard = require("../lib/guard.js");
+import watchdog = require("../lib/watchdog.js");
 
 guard.enforce();
-auto.waitFor();
+// The "auto" directive above guarantees AutoJs6 has populated this global.
+auto!.waitFor();
 
-var profile = config.detectDeviceProfile();
+const profile = config.detectDeviceProfile();
 watchdog.runCycle("manual-test", profile);
 toast("stayturgid watchdog test cycle done — check /sdcard/stayturgid/logs/watchdog.log");

--- a/device/autojs6/tsconfig.json
+++ b/device/autojs6/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "CommonJS",
+    "lib": ["ES2015"],
+    "types": [],
+    "strict": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["**/*.ts"]
+}

--- a/device/autojs6/types/globals.d.ts
+++ b/device/autojs6/types/globals.d.ts
@@ -1,0 +1,166 @@
+// Ambient globals provided by the AutoJs6 Rhino runtime.
+//
+// This is deliberately NOT a general-purpose AutoJs6 API surface — it covers
+// only what device/autojs6/**/*.ts and docs/research/autojs6-hd8-project/*.ts
+// actually call, typed from observed usage. AutoJs6 has no first-party .d.ts
+// package with real content (@sm003/autojs6-dts on npm ships empty stub
+// files; the real declarations are a separate multi-MB GitHub archive
+// covering the full Android SDK surface, far beyond what this fleet-watchdog
+// codebase touches).
+//
+// Globals that may not exist on every AutoJs6 build/version are typed
+// `| undefined` rather than assumed-present, matching the `typeof x !==
+// "undefined"` guards already used at every call site — the type checker now
+// enforces the same guard the original JS did defensively.
+
+declare function sleep(ms: number): void;
+declare function toast(message: string): void;
+declare function setInterval(handler: () => void, timeoutMs: number): number;
+declare function setTimeout(handler: () => void, timeoutMs: number): number;
+
+interface Console {
+  log(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+}
+declare const console: Console;
+
+interface FilesApi {
+  exists(path: string): boolean;
+  read(path: string): string;
+  write(path: string, content: string): void;
+  append(path: string, content: string): void;
+  ensureDir(path: string): void;
+}
+declare const files: FilesApi;
+
+/** Result of a shell() invocation: process exit code + captured stdout/stderr. */
+interface ShellResult {
+  code: number;
+  result: string;
+  /** stderr output — e.g. "Permission denied" when root was needed but not granted. */
+  error?: string;
+}
+declare function shell(command: string, sync: boolean): ShellResult;
+
+interface AppStartActivityOptions {
+  packageName: string;
+  className: string;
+  flags?: string[];
+}
+interface AppStartServiceOptions {
+  action: string;
+  packageName: string;
+  className: string;
+  extras?: Record<string, string>;
+}
+interface AppApi {
+  startActivity(options: AppStartActivityOptions): void;
+  startService(options: AppStartServiceOptions): void;
+}
+declare const app: AppApi;
+
+declare const device: {
+  sdkInt: number;
+};
+
+/** A running AutoJs6 script engine (as returned by engines.all() / myEngine()). */
+interface Engine {
+  id: unknown;
+  getSource(): string | null;
+  forceStop(): void;
+}
+interface EngineApi {
+  all(): Engine[];
+  myEngine(): Engine | null;
+  execScriptFile(path: string, config: org.autojs.autojs.execution.ExecutionConfig): void;
+}
+declare const engines: EngineApi;
+declare const runtime: {
+  engines: EngineApi;
+};
+
+declare const context: {
+  getSystemService(serviceName: string): unknown;
+  NOTIFICATION_SERVICE: string;
+};
+
+interface ThreadHandle {
+  join(timeoutMs: number): void;
+}
+declare const threads: {
+  start(fn: () => void): ThreadHandle;
+};
+
+declare const timers:
+  | {
+      keepAlive?: () => void;
+    }
+  | undefined;
+
+/** AutoJs6's accessibility-service handle; present only under the `"auto";` mode directive. */
+declare const auto:
+  | {
+      service: unknown;
+      waitFor(): void;
+    }
+  | undefined;
+
+/**
+ * Shizuku privileged-shell bridge. Callable directly (runs a command) and
+ * carries optional status properties/methods depending on AutoJs6 version —
+ * every call site checks for both function-ness and member presence before use.
+ */
+interface ShizukuApi {
+  (command: string): ShellResult;
+  isOperational?(): boolean;
+  hasPermission?(): boolean;
+  isRunning?(): boolean;
+  state?: unknown;
+}
+declare const shizuku: ShizukuApi | undefined;
+
+// --- Java interop (Rhino LiveConnect) -----------------------------------
+//
+// Referenced via fully-qualified path rather than AutoJs6's importClass()
+// shortcut, which binds a short alias into scope in a way TypeScript's
+// module system cannot model. The fully-qualified form resolves to the
+// identical Java class object, so this is a typing-only difference.
+
+declare namespace org.autojs.autojs.execution {
+  class ExecutionConfig {
+    setWorkingDirectory(dir: string): void;
+  }
+}
+
+declare namespace android.app {
+  class NotificationChannel {
+    constructor(id: string, name: string, importance: number);
+    setDescription(description: string): void;
+  }
+
+  namespace NotificationManager {
+    const IMPORTANCE_HIGH: number;
+  }
+  interface NotificationManager {
+    createNotificationChannel(channel: NotificationChannel): void;
+    notify(id: number, notification: unknown): void;
+    cancel(id: number): void;
+  }
+
+  namespace Notification {
+    class Builder {
+      constructor(context: unknown, channelId?: string);
+      setContentTitle(title: string): Builder;
+      setContentText(text: string): Builder;
+      setSmallIcon(iconResourceId: number): Builder;
+      setOnlyAlertOnce(value: boolean): Builder;
+      setAutoCancel(value: boolean): Builder;
+      build(): unknown;
+    }
+  }
+}
+
+declare namespace android.R.drawable {
+  const ic_dialog_alert: number;
+}

--- a/docs/research/autojs6-hd8-project/main.js
+++ b/docs/research/autojs6-hd8-project/main.js
@@ -1,27 +1,29 @@
 // @generated
 "use strict";
-// @ts-nocheck
 /**
  * stayturgid AutoJs6 watchdog — entry point.
  *
  * Enable AutoJs6 accessibility, then run this script (or use boot-launcher.js from Termux:Boot).
  * Optional: AutoJs6 timed task every 20 min + run on boot for main.js.
+ *
+ * Kept as a reference copy (see README.md) — this directory has no sibling
+ * ./lib/*, so its requires below are typed against the canonical
+ * device/autojs6/lib/*.ts sources via a type-only import (erased at compile
+ * time; the require() calls below are unaffected and still resolve exactly
+ * as originally written, or not at all, matching this file's documented
+ * "reference, not the source of truth" status).
  */
 "auto";
-var config = require("./lib/config.js");
-var guard = require("./lib/guard.js");
-var watchdog = require("./lib/watchdog.js");
-var log = require("./lib/log.js");
-var engineGuard = require("./lib/engine_guard.js");
-var profile;
-try {
-  profile = config.detectDeviceProfile();
-} catch (e) {
-  profile = {};
-}
+Object.defineProperty(exports, "__esModule", { value: true });
+const config = require("./lib/config.js");
+const guard = require("./lib/guard.js");
+const watchdog = require("./lib/watchdog.js");
+const log = require("./lib/log.js");
+const engineGuard = require("./lib/engine_guard.js");
+const profile = config.detectDeviceProfile();
 try {
   config.ensureDirs(profile); // create shared dirs (self-heal)
-} catch (e) {
+} catch (_a) {
   /* best effort — cycles mkdir on demand too */
 }
 if (profile.usingGenericDefaults) {
@@ -45,17 +47,17 @@ function safeCycle(trigger) {
   }
 }
 log.append("[watchdog] stayturgid AutoJs6 started device=" + (profile.id || "?"));
-var stopped = engineGuard.dedupeMainEngines();
+const stopped = engineGuard.dedupeMainEngines();
 if (stopped > 0) {
   log.append("[watchdog] stopped " + stopped + " duplicate main.js engine(s)");
 }
 safeCycle("boot"); // covers manual launch + boot auto-start
 // Every 20 minutes — the loop is ALWAYS established, even if the boot cycle
 // above hit trouble, so the watchdog self-recovers on the next tick.
-setInterval(function () {
+setInterval(() => {
   safeCycle("interval");
 }, config.INTERVAL_MS);
-setTimeout(function () {
+setTimeout(() => {
   try {
     toast("stayturgid main.js still running after 1 minute");
     log.append("[watchdog] delayed startup toast emitted");
@@ -64,4 +66,4 @@ setTimeout(function () {
   }
 }, 60000);
 // Keep the script process alive (AutoJs6 stops when the main thread exits)
-setInterval(function () {}, 60000);
+setInterval(() => {}, 60000);

--- a/docs/research/autojs6-hd8-project/main.ts
+++ b/docs/research/autojs6-hd8-project/main.ts
@@ -1,28 +1,41 @@
-// @ts-nocheck
 /**
  * stayturgid AutoJs6 watchdog — entry point.
  *
  * Enable AutoJs6 accessibility, then run this script (or use boot-launcher.js from Termux:Boot).
  * Optional: AutoJs6 timed task every 20 min + run on boot for main.js.
+ *
+ * Kept as a reference copy (see README.md) — this directory has no sibling
+ * ./lib/*, so its requires below are typed against the canonical
+ * device/autojs6/lib/*.ts sources via a type-only import (erased at compile
+ * time; the require() calls below are unaffected and still resolve exactly
+ * as originally written, or not at all, matching this file's documented
+ * "reference, not the source of truth" status).
  */
 "auto";
 
-var config = require("./lib/config.js");
-var guard = require("./lib/guard.js");
-var watchdog = require("./lib/watchdog.js");
-var log = require("./lib/log.js");
-var engineGuard = require("./lib/engine_guard.js");
+import type { DeviceProfile } from "../../../device/autojs6/lib/config.js";
 
-var profile;
-try {
-  profile = config.detectDeviceProfile();
-} catch (e) {
-  profile = {};
-}
+declare function require(id: "./lib/config.js"): {
+  detectDeviceProfile(): DeviceProfile;
+  ensureDirs(profile: DeviceProfile): void;
+  INTERVAL_MS: number;
+};
+declare function require(id: "./lib/guard.js"): { enforce(profile: DeviceProfile): void };
+declare function require(id: "./lib/watchdog.js"): { runCycle(trigger: string, profile: DeviceProfile): void };
+declare function require(id: "./lib/log.js"): { append(line: string): string };
+declare function require(id: "./lib/engine_guard.js"): { dedupeMainEngines(): number };
+
+const config = require("./lib/config.js");
+const guard = require("./lib/guard.js");
+const watchdog = require("./lib/watchdog.js");
+const log = require("./lib/log.js");
+const engineGuard = require("./lib/engine_guard.js");
+
+const profile = config.detectDeviceProfile();
 
 try {
   config.ensureDirs(profile); // create shared dirs (self-heal)
-} catch (e) {
+} catch {
   /* best effort — cycles mkdir on demand too */
 }
 
@@ -40,7 +53,7 @@ try {
 }
 
 // Run one guarded cycle.
-function safeCycle(trigger) {
+function safeCycle(trigger: string): void {
   try {
     guard.enforce(profile);
     watchdog.runCycle(trigger, profile);
@@ -50,7 +63,7 @@ function safeCycle(trigger) {
 }
 
 log.append("[watchdog] stayturgid AutoJs6 started device=" + (profile.id || "?"));
-var stopped = engineGuard.dedupeMainEngines();
+const stopped = engineGuard.dedupeMainEngines();
 if (stopped > 0) {
   log.append("[watchdog] stopped " + stopped + " duplicate main.js engine(s)");
 }
@@ -58,11 +71,11 @@ safeCycle("boot"); // covers manual launch + boot auto-start
 
 // Every 20 minutes — the loop is ALWAYS established, even if the boot cycle
 // above hit trouble, so the watchdog self-recovers on the next tick.
-setInterval(function () {
+setInterval(() => {
   safeCycle("interval");
 }, config.INTERVAL_MS);
 
-setTimeout(function () {
+setTimeout(() => {
   try {
     toast("stayturgid main.js still running after 1 minute");
     log.append("[watchdog] delayed startup toast emitted");
@@ -72,4 +85,4 @@ setTimeout(function () {
 }, 60000);
 
 // Keep the script process alive (AutoJs6 stops when the main thread exits)
-setInterval(function () {}, 60000);
+setInterval(() => {}, 60000);

--- a/docs/research/autojs6-hd8-project/tsconfig.json
+++ b/docs/research/autojs6-hd8-project/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2015",
+    "module": "CommonJS",
+    "lib": ["ES2015"],
+    "types": [],
+    "strict": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["*.ts", "../../../device/autojs6/types/globals.d.ts"]
+}

--- a/just/tools/rendered_dom_check.js
+++ b/just/tools/rendered_dom_check.js
@@ -1,146 +1,130 @@
 #!/usr/bin/env node
 // @generated
 "use strict";
-// @ts-nocheck
+Object.defineProperty(exports, "__esModule", { value: true });
 // Check rendered dashboard pages for visible HTML-as-text, missing JS elements,
 // and common template escaping failures.
 //
 // Usage: node just/tools/rendered_dom_check.js [url...]
 // Default: http://127.0.0.1:4097/
-var __awaiter =
-  (this && this.__awaiter) ||
-  function (thisArg, _arguments, P, generator) {
-    function adopt(value) {
-      return value instanceof P
-        ? value
-        : new P(function (resolve) {
-            resolve(value);
-          });
-    }
-    return new (P || (P = Promise))(function (resolve, reject) {
-      function fulfilled(value) {
-        try {
-          step(generator.next(value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function rejected(value) {
-        try {
-          step(generator["throw"](value));
-        } catch (e) {
-          reject(e);
-        }
-      }
-      function step(result) {
-        result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected);
-      }
-      step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-  };
-const urls = process.argv.slice(2).length ? process.argv.slice(2) : ["http://127.0.0.1:4097/"];
-function checkPage(page, url) {
-  return __awaiter(this, void 0, void 0, function* () {
-    const issues = [];
-    try {
-      yield page.goto(url, { waitUntil: "domcontentloaded", timeout: 15000 });
-    } catch (err) {
-      issues.push({ type: "error", msg: `Page load failed: ${err.message}` });
-      return issues;
-    }
-    // Wait a beat for HTMX to render dynamic content
-    yield page.evaluate(() => new Promise((r) => setTimeout(r, 2000)));
-    // 1. Visible HTML-in-text: walk text nodes for literal < or HTML-like patterns
-    const htmlInText = yield page.evaluate(() => {
-      const results = [];
-      const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false);
-      let node;
-      while ((node = walker.nextNode())) {
-        const text = node.textContent.trim();
-        if (!text) continue;
-        if (text.includes("<") || /&lt;|&gt;|&amp;lt;/.test(text)) {
-          const el = node.parentElement;
-          const tag = el
-            ? `<${el.tagName.toLowerCase()}${el.id ? "#" + el.id : ""}${el.className ? "." + el.className.split(" ").join(".") : ""}>`
-            : "?";
-          results.push({
-            text: text.substring(0, 120),
-            context: `${tag}: "${text.substring(0, 60)}..."`,
-          });
-        }
-      }
-      return results;
-    });
-    for (const r of htmlInText) {
-      issues.push({ type: "html-in-text", msg: r.context });
-    }
-    // 2. Check HTMX-loaded sections populated
-    const htmxEmpty = yield page.evaluate(() => {
-      const empty = [];
-      document.querySelectorAll("[hx-get]").forEach((el) => {
-        const text = el.textContent.trim().toLowerCase();
-        if (text === "" || text === "loading…" || text === "loading..." || text.includes("htmx-indicator")) {
-          empty.push(`HTMX target <${el.tagName.toLowerCase()}${el.id ? "#" + el.id : ""}> still empty`);
-        }
-      });
-      return empty;
-    });
-    for (const m of htmxEmpty) {
-      issues.push({ type: "htmx-empty", msg: m });
-    }
-    // 3. Visible JS template markers ({{ }}, {% %})
-    const templateMarkers = yield page.evaluate(() => {
-      const results = [];
-      const re = /\{\{|%\}|\{\%|%}/;
-      const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false);
-      let node;
-      while ((node = walker.nextNode())) {
-        if (re.test(node.textContent)) {
-          const el = node.parentElement;
-          const tag = el ? el.tagName.toLowerCase() : "?";
-          results.push(`Unrendered template marker in <${tag}>: "${node.textContent.substring(0, 80)}"`);
-        }
-      }
-      return results;
-    });
-    for (const m of templateMarkers) {
-      issues.push({ type: "template-marker", msg: m });
-    }
-    return issues;
-  });
+const puppeteer = require("puppeteer");
+function parseHttpUrl(raw) {
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    console.error(`FAIL: not a valid URL: ${raw}`);
+    process.exit(1);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    console.error(`FAIL: unsupported URL scheme (expected http/https): ${raw}`);
+    process.exit(1);
+  }
+  return parsed.href;
 }
-(() =>
-  __awaiter(void 0, void 0, void 0, function* () {
-    const puppeteer = require("puppeteer");
-    let browser;
-    try {
-      browser = yield puppeteer.launch({
-        headless: true,
-        args: ["--no-sandbox", "--disable-setuid-sandbox"],
-      });
-    } catch (err) {
-      console.error(`FAIL: Could not launch browser: ${err.message}`);
-      process.exit(1);
-    }
-    let totalIssues = 0;
-    for (const url of urls) {
-      const page = yield browser.newPage();
-      console.log(`\n${url}`);
-      const issues = yield checkPage(page, url);
-      yield page.close();
-      if (issues.length === 0) {
-        console.log("  OK");
-      } else {
-        for (const issue of issues) {
-          totalIssues++;
-          const icon = issue.type === "error" ? "✖" : issue.type === "htmx-empty" ? "⚠" : "!";
-          console.log(`  ${icon} [${issue.type}] ${issue.msg}`);
-        }
+const urls = (process.argv.slice(2).length ? process.argv.slice(2) : ["http://127.0.0.1:4097/"]).map(parseHttpUrl);
+async function checkPage(page, url) {
+  const issues = [];
+  try {
+    // `url` is parseHttpUrl()-validated to http(s) only (see call site) before
+    // reaching this function, and originates from this CLI tool's own argv —
+    // local operator input, not remote/network-controlled.
+    // nosemgrep: javascript.puppeteer.security.audit.puppeteer-goto-injection.puppeteer-goto-injection
+    await page.goto(url, { waitUntil: "domcontentloaded", timeout: 15000 });
+  } catch (err) {
+    issues.push({ type: "error", msg: `Page load failed: ${err instanceof Error ? err.message : String(err)}` });
+    return issues;
+  }
+  // Wait a beat for HTMX to render dynamic content
+  await page.evaluate(() => new Promise((r) => setTimeout(r, 2000)));
+  // 1. Visible HTML-in-text: walk text nodes for literal < or HTML-like patterns
+  const htmlInText = await page.evaluate(() => {
+    const results = [];
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
+    let node;
+    while ((node = walker.nextNode())) {
+      const text = (node.textContent || "").trim();
+      if (!text) continue;
+      if (text.includes("<") || /&lt;|&gt;|&amp;lt;/.test(text)) {
+        const el = node.parentElement;
+        const tag = el
+          ? `<${el.tagName.toLowerCase()}${el.id ? "#" + el.id : ""}${el.className ? "." + el.className.split(" ").join(".") : ""}>`
+          : "?";
+        results.push({
+          text: text.substring(0, 120),
+          context: `${tag}: "${text.substring(0, 60)}..."`,
+        });
       }
     }
-    yield browser.close();
-    if (totalIssues > 0) {
-      console.log(`\n${totalIssues} issue(s) found`);
-      process.exit(1);
+    return results;
+  });
+  for (const r of htmlInText) {
+    issues.push({ type: "html-in-text", msg: r.context });
+  }
+  // 2. Check HTMX-loaded sections populated
+  const htmxEmpty = await page.evaluate(() => {
+    const empty = [];
+    document.querySelectorAll("[hx-get]").forEach((el) => {
+      const text = (el.textContent || "").trim().toLowerCase();
+      if (text === "" || text === "loading…" || text === "loading..." || text.includes("htmx-indicator")) {
+        empty.push(`HTMX target <${el.tagName.toLowerCase()}${el.id ? "#" + el.id : ""}> still empty`);
+      }
+    });
+    return empty;
+  });
+  for (const m of htmxEmpty) {
+    issues.push({ type: "htmx-empty", msg: m });
+  }
+  // 3. Visible JS template markers ({{ }}, {% %})
+  const templateMarkers = await page.evaluate(() => {
+    const results = [];
+    const re = /\{\{|%\}|\{\%|%}/;
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
+    let node;
+    while ((node = walker.nextNode())) {
+      if (re.test(node.textContent || "")) {
+        const el = node.parentElement;
+        const tag = el ? el.tagName.toLowerCase() : "?";
+        results.push(`Unrendered template marker in <${tag}>: "${(node.textContent || "").substring(0, 80)}"`);
+      }
     }
-  }))();
+    return results;
+  });
+  for (const m of templateMarkers) {
+    issues.push({ type: "template-marker", msg: m });
+  }
+  return issues;
+}
+(async () => {
+  let browser;
+  try {
+    browser = await puppeteer.launch({
+      headless: true,
+      args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    });
+  } catch (err) {
+    console.error(`FAIL: Could not launch browser: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+  let totalIssues = 0;
+  for (const url of urls) {
+    const page = await browser.newPage();
+    console.log(`\n${url}`);
+    const issues = await checkPage(page, url);
+    await page.close();
+    if (issues.length === 0) {
+      console.log("  OK");
+    } else {
+      for (const issue of issues) {
+        totalIssues++;
+        const icon = issue.type === "error" ? "✖" : issue.type === "htmx-empty" ? "⚠" : "!";
+        console.log(`  ${icon} [${issue.type}] ${issue.msg}`);
+      }
+    }
+  }
+  await browser.close();
+  if (totalIssues > 0) {
+    console.log(`\n${totalIssues} issue(s) found`);
+    process.exit(1);
+  }
+})();

--- a/just/tools/rendered_dom_check.ts
+++ b/just/tools/rendered_dom_check.ts
@@ -1,19 +1,47 @@
 #!/usr/bin/env node
-// @ts-nocheck
 // Check rendered dashboard pages for visible HTML-as-text, missing JS elements,
 // and common template escaping failures.
 //
 // Usage: node just/tools/rendered_dom_check.js [url...]
 // Default: http://127.0.0.1:4097/
+import puppeteer = require("puppeteer");
 
-const urls = process.argv.slice(2).length ? process.argv.slice(2) : ["http://127.0.0.1:4097/"];
+import type { Page } from "puppeteer";
 
-async function checkPage(page, url) {
-  const issues = [];
+function parseHttpUrl(raw: string): string {
+  let parsed: URL;
   try {
+    parsed = new URL(raw);
+  } catch {
+    console.error(`FAIL: not a valid URL: ${raw}`);
+    process.exit(1);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    console.error(`FAIL: unsupported URL scheme (expected http/https): ${raw}`);
+    process.exit(1);
+  }
+  return parsed.href;
+}
+
+const urls = (process.argv.slice(2).length ? process.argv.slice(2) : ["http://127.0.0.1:4097/"]).map(parseHttpUrl);
+
+type IssueType = "error" | "html-in-text" | "htmx-empty" | "template-marker";
+
+interface Issue {
+  type: IssueType;
+  msg: string;
+}
+
+async function checkPage(page: Page, url: string): Promise<Issue[]> {
+  const issues: Issue[] = [];
+  try {
+    // `url` is parseHttpUrl()-validated to http(s) only (see call site) before
+    // reaching this function, and originates from this CLI tool's own argv —
+    // local operator input, not remote/network-controlled.
+    // nosemgrep: javascript.puppeteer.security.audit.puppeteer-goto-injection.puppeteer-goto-injection
     await page.goto(url, { waitUntil: "domcontentloaded", timeout: 15000 });
   } catch (err) {
-    issues.push({ type: "error", msg: `Page load failed: ${err.message}` });
+    issues.push({ type: "error", msg: `Page load failed: ${err instanceof Error ? err.message : String(err)}` });
     return issues;
   }
 
@@ -22,11 +50,11 @@ async function checkPage(page, url) {
 
   // 1. Visible HTML-in-text: walk text nodes for literal < or HTML-like patterns
   const htmlInText = await page.evaluate(() => {
-    const results = [];
-    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false);
-    let node;
+    const results: { text: string; context: string }[] = [];
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
+    let node: Node | null;
     while ((node = walker.nextNode())) {
-      const text = node.textContent.trim();
+      const text = (node.textContent || "").trim();
       if (!text) continue;
       if (text.includes("<") || /&lt;|&gt;|&amp;lt;/.test(text)) {
         const el = node.parentElement;
@@ -47,9 +75,9 @@ async function checkPage(page, url) {
 
   // 2. Check HTMX-loaded sections populated
   const htmxEmpty = await page.evaluate(() => {
-    const empty = [];
+    const empty: string[] = [];
     document.querySelectorAll("[hx-get]").forEach((el) => {
-      const text = el.textContent.trim().toLowerCase();
+      const text = (el.textContent || "").trim().toLowerCase();
       if (text === "" || text === "loading…" || text === "loading..." || text.includes("htmx-indicator")) {
         empty.push(`HTMX target <${el.tagName.toLowerCase()}${el.id ? "#" + el.id : ""}> still empty`);
       }
@@ -62,15 +90,15 @@ async function checkPage(page, url) {
 
   // 3. Visible JS template markers ({{ }}, {% %})
   const templateMarkers = await page.evaluate(() => {
-    const results = [];
+    const results: string[] = [];
     const re = /\{\{|%\}|\{\%|%}/;
-    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null, false);
-    let node;
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
+    let node: Node | null;
     while ((node = walker.nextNode())) {
-      if (re.test(node.textContent)) {
+      if (re.test(node.textContent || "")) {
         const el = node.parentElement;
         const tag = el ? el.tagName.toLowerCase() : "?";
-        results.push(`Unrendered template marker in <${tag}>: "${node.textContent.substring(0, 80)}"`);
+        results.push(`Unrendered template marker in <${tag}>: "${(node.textContent || "").substring(0, 80)}"`);
       }
     }
     return results;
@@ -83,15 +111,14 @@ async function checkPage(page, url) {
 }
 
 (async () => {
-  const puppeteer = require("puppeteer");
-  let browser;
+  let browser: Awaited<ReturnType<typeof puppeteer.launch>>;
   try {
     browser = await puppeteer.launch({
       headless: true,
       args: ["--no-sandbox", "--disable-setuid-sandbox"],
     });
   } catch (err) {
-    console.error(`FAIL: Could not launch browser: ${err.message}`);
+    console.error(`FAIL: Could not launch browser: ${err instanceof Error ? err.message : String(err)}`);
     process.exit(1);
   }
 

--- a/just/tools/tsconfig.json
+++ b/just/tools/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "lib": ["ES2020", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["*.ts"]
+}

--- a/justfile
+++ b/justfile
@@ -60,14 +60,17 @@ agent-review:
 
 # Build TypeScript files into JavaScript and add generated header
 build-ts:
-    bunx tsc
+    bunx tsc -p device/autojs6/tsconfig.json
+    bunx tsc -p docs/research/autojs6-hd8-project/tsconfig.json
+    bunx tsc -p tests/js/tsconfig.json
+    bunx tsc -p just/tools/tsconfig.json
     bunx biome format --write device/autojs6 tests/js just/tools docs/research
     python3 just/tools/add_generated_header.py
 
 # Verify TS/JS migration and mappings
 check-ts:
     @echo "Verifying 1-to-1 mapping..."
-    @for f in $(find device/autojs6 tests/js just/tools docs/research -name "*.ts" -not -path "*/node_modules/*" 2>/dev/null); do \
+    @for f in $(find device/autojs6 tests/js just/tools docs/research -name "*.ts" -not -name "*.d.ts" -not -path "*/node_modules/*" 2>/dev/null); do \
       js_file="${f%.ts}.js"; \
       if [ ! -f "$js_file" ]; then \
         echo "Error: Missing corresponding JS file for $f (run 'just build-ts')"; exit 1; \

--- a/tests/js/boot-launcher.test.js
+++ b/tests/js/boot-launcher.test.js
@@ -1,34 +1,32 @@
 // @generated
-// @ts-nocheck
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 /**
  * Regression test for boot-launcher.js child working-directory handling.
  * AutoJs6 otherwise inherits scripts/ and main.js cannot load ./lib/*.
  */
-"use strict";
-var fs = require("fs");
-var path = require("path");
-var vm = require("vm");
-var repo = path.resolve(__dirname, "..", "..");
-var source = fs.readFileSync(path.join(repo, "device", "autojs6", "scripts", "boot-launcher.js"), "utf8");
-var main = "/sdcard/stayturgid/autojs6/main.js";
-var execution = null;
-function ExecutionConfig() {
-  this.workingDirectory = null;
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+const repo = path.resolve(__dirname, "..", "..");
+const source = fs.readFileSync(path.join(repo, "device", "autojs6", "scripts", "boot-launcher.js"), "utf8");
+const main = "/sdcard/stayturgid/autojs6/main.js";
+class ExecutionConfig {
+  constructor() {
+    this.workingDirectory = null;
+  }
+  setWorkingDirectory(value) {
+    this.workingDirectory = value;
+  }
 }
-ExecutionConfig.prototype.setWorkingDirectory = function (value) {
-  this.workingDirectory = String(value);
-};
-var sandbox = {
-  require: function (name) {
+let execution = null;
+const sandbox = {
+  require(name) {
     if (name === "../lib/engine_guard.js") {
       return {
         MAIN: main,
-        findMainEngines: function () {
-          return [];
-        },
-        dedupeMainEngines: function () {
-          return 0;
-        },
+        findMainEngines: () => [],
+        dedupeMainEngines: () => 0,
       };
     }
     if (name === "../lib/config.js") {
@@ -37,25 +35,38 @@ var sandbox = {
     throw new Error("unexpected require: " + name);
   },
   files: {},
+  // Rhino's CommonJS module loader always wraps a loaded script with its own
+  // `module`/`exports` (confirmed: org.mozilla.javascript.commonjs.module,
+  // the real implementation behind AutoJs6's require()). tsc's compiled
+  // output now references `exports` unconditionally (the __esModule stamp
+  // every ES-module-syntax .ts file gets under CommonJS output, regardless
+  // of whether it has real exports) — this sandbox has to provide one too,
+  // matching what the real loader always does.
+  exports: {},
   engines: {
-    execScriptFile: function (script, config) {
-      execution = { script: script, config: config };
+    execScriptFile: (script, config) => {
+      execution = { script, config };
     },
   },
   org: {
     autojs: {
       autojs: {
-        execution: { ExecutionConfig: ExecutionConfig },
+        execution: { ExecutionConfig },
       },
     },
   },
 };
 vm.runInNewContext(source, sandbox, { filename: "boot-launcher.js" });
-var passed =
-  execution !== null &&
-  execution.script === main &&
-  execution.config instanceof ExecutionConfig &&
-  execution.config.workingDirectory === "/sdcard/stayturgid/autojs6";
+// `execution` is only ever assigned inside the `engines.execScriptFile` closure
+// above, which TS's control-flow analysis doesn't follow — it computes
+// `execution`'s flow type here as bare `null` even after the closure has run.
+// The assertion restores its actual declared type.
+const result = execution;
+const passed =
+  result !== null &&
+  result.script === main &&
+  result.config instanceof ExecutionConfig &&
+  result.config.workingDirectory === "/sdcard/stayturgid/autojs6";
 console.log((passed ? "ok" : "not ok") + " 1 - child runs from AutoJs6 project directory");
 console.log("1..1");
 process.exit(passed ? 0 : 1);

--- a/tests/js/boot-launcher.test.ts
+++ b/tests/js/boot-launcher.test.ts
@@ -1,37 +1,42 @@
-// @ts-nocheck
 /**
  * Regression test for boot-launcher.js child working-directory handling.
  * AutoJs6 otherwise inherits scripts/ and main.js cannot load ./lib/*.
  */
-"use strict";
+import fs = require("fs");
+import path = require("path");
+import vm = require("vm");
 
-var fs = require("fs");
-var path = require("path");
-var vm = require("vm");
+const repo = path.resolve(__dirname, "..", "..");
+const source = fs.readFileSync(path.join(repo, "device", "autojs6", "scripts", "boot-launcher.js"), "utf8");
+const main = "/sdcard/stayturgid/autojs6/main.js";
 
-var repo = path.resolve(__dirname, "..", "..");
-var source = fs.readFileSync(path.join(repo, "device", "autojs6", "scripts", "boot-launcher.js"), "utf8");
-var main = "/sdcard/stayturgid/autojs6/main.js";
-var execution = null;
-
-function ExecutionConfig() {
-  this.workingDirectory = null;
+class ExecutionConfig {
+  workingDirectory: string | null = null;
+  setWorkingDirectory(value: string): void {
+    this.workingDirectory = value;
+  }
 }
-ExecutionConfig.prototype.setWorkingDirectory = function (value) {
-  this.workingDirectory = String(value);
-};
 
-var sandbox = {
-  require: function (name) {
+interface Execution {
+  script: string;
+  config: ExecutionConfig;
+}
+
+let execution: Execution | null = null;
+
+interface EngineGuardStub {
+  MAIN: string;
+  findMainEngines(): unknown[];
+  dedupeMainEngines(): number;
+}
+
+const sandbox = {
+  require(name: string): EngineGuardStub | { WATCHDOG_LOG: string } {
     if (name === "../lib/engine_guard.js") {
       return {
         MAIN: main,
-        findMainEngines: function () {
-          return [];
-        },
-        dedupeMainEngines: function () {
-          return 0;
-        },
+        findMainEngines: () => [],
+        dedupeMainEngines: () => 0,
       };
     }
     if (name === "../lib/config.js") {
@@ -40,15 +45,23 @@ var sandbox = {
     throw new Error("unexpected require: " + name);
   },
   files: {},
+  // Rhino's CommonJS module loader always wraps a loaded script with its own
+  // `module`/`exports` (confirmed: org.mozilla.javascript.commonjs.module,
+  // the real implementation behind AutoJs6's require()). tsc's compiled
+  // output now references `exports` unconditionally (the __esModule stamp
+  // every ES-module-syntax .ts file gets under CommonJS output, regardless
+  // of whether it has real exports) — this sandbox has to provide one too,
+  // matching what the real loader always does.
+  exports: {},
   engines: {
-    execScriptFile: function (script, config) {
-      execution = { script: script, config: config };
+    execScriptFile: (script: string, config: ExecutionConfig): void => {
+      execution = { script, config };
     },
   },
   org: {
     autojs: {
       autojs: {
-        execution: { ExecutionConfig: ExecutionConfig },
+        execution: { ExecutionConfig },
       },
     },
   },
@@ -56,11 +69,16 @@ var sandbox = {
 
 vm.runInNewContext(source, sandbox, { filename: "boot-launcher.js" });
 
-var passed =
-  execution !== null &&
-  execution.script === main &&
-  execution.config instanceof ExecutionConfig &&
-  execution.config.workingDirectory === "/sdcard/stayturgid/autojs6";
+// `execution` is only ever assigned inside the `engines.execScriptFile` closure
+// above, which TS's control-flow analysis doesn't follow — it computes
+// `execution`'s flow type here as bare `null` even after the closure has run.
+// The assertion restores its actual declared type.
+const result = execution as Execution | null;
+const passed =
+  result !== null &&
+  result.script === main &&
+  result.config instanceof ExecutionConfig &&
+  result.config.workingDirectory === "/sdcard/stayturgid/autojs6";
 console.log((passed ? "ok" : "not ok") + " 1 - child runs from AutoJs6 project directory");
 console.log("1..1");
 process.exit(passed ? 0 : 1);

--- a/tests/js/comonitor.test.js
+++ b/tests/js/comonitor.test.js
@@ -1,61 +1,57 @@
 // @generated
-// @ts-nocheck
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 /**
  * Unit tests for device/autojs6/lib/comonitor.js under node (files{} + shizuku shims).
  * Emits TAP. Exit 0 = pass.
  */
-"use strict";
-var fs = require("fs"),
-  os = require("os"),
-  path = require("path");
-var repo = path.resolve(__dirname, "..", "..");
-var tmp = fs.mkdtempSync(path.join(os.tmpdir(), "stcom-"));
-var mapped = function (p) {
-  return path.join(tmp, String(p).replace(/\//g, "_"));
-};
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const Module = require("module");
+const repo = path.resolve(__dirname, "..", "..");
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "stcom-"));
+const mapped = (p) => path.join(tmp, p.replace(/\//g, "_"));
 global.files = {
-  exists: function (p) {
-    if (String(p) === "/sdcard/stayturgid/state/device.json") return true;
+  exists(p) {
+    if (p === "/sdcard/stayturgid/state/device.json") return true;
     return fs.existsSync(mapped(p));
   },
-  read: function (p) {
-    if (String(p) === "/sdcard/stayturgid/state/device.json") {
+  read(p) {
+    if (p === "/sdcard/stayturgid/state/device.json") {
       return JSON.stringify({ id: "oneui-device", sdRoot: "/sdcard/stayturgid" });
     }
     return fs.readFileSync(mapped(p), "utf8");
   },
-  append: function (p, s) {
+  append(p, s) {
     fs.appendFileSync(mapped(p), s);
   },
-  write: function (p, s) {
+  write(p, s) {
     fs.writeFileSync(mapped(p), s);
   },
-  ensureDir: function () {},
+  ensureDir() {},
 };
-global.console = console;
-global.sleep = function () {};
-global.shell = function () {
-  return { code: 1, result: "" };
-};
+global.sleep = () => {};
+global.shell = () => ({ code: 1, result: "" });
 global.auto = { service: null };
-var n = 0,
-  failed = 0;
+let n = 0;
+let failed = 0;
 function ok(cond, desc) {
   n++;
   console.log((cond ? "ok " : "not ok ") + n + " - " + desc);
   if (!cond) failed++;
 }
 // Stub shizuku_shell before requiring comonitor (watchdog deps pull it in).
-var shizukuState = { operational: true, cmds: [] };
-var Module = require("module");
-var origLoad = Module._load;
-Module._load = function (request, parent) {
+// Module._load is a private Node API with no public typings — the double
+// assertion through `unknown` is the narrowest way to reach it.
+const shizukuState = { operational: true, cmds: [] };
+const ModuleInternals = Module;
+const origLoad = ModuleInternals._load;
+ModuleInternals._load = (request, parent) => {
   if (request === "./shizuku_shell.js" || request.endsWith("/shizuku_shell.js")) {
     return {
-      isOperational: function () {
-        return shizukuState.operational;
-      },
-      exec: function (cmd) {
+      isOperational: () => shizukuState.operational,
+      exec: (cmd) => {
         shizukuState.cmds.push(cmd);
         if (cmd.indexOf("pgrep -x sshd") >= 0 || cmd.indexOf("[s]shd") >= 0) {
           return { code: 0, result: "" };
@@ -80,79 +76,65 @@ Module._load = function (request, parent) {
     };
   }
   if (request === "./notify.js" || request.endsWith("/notify.js")) {
-    return { show: function () {}, clear: function () {} };
+    return { show: () => {}, clear: () => {} };
   }
   if (request === "./repair.js" || request.endsWith("/repair.js")) {
-    return {
-      repairCatastrophic: function () {
-        return true;
-      },
-    };
+    return { repairCatastrophic: () => true };
   }
-  return origLoad.apply(this, arguments);
+  return origLoad.call(Module, request, parent);
 };
-var comonitor = require(path.join(repo, "device", "autojs6", "lib", "comonitor.js"));
-var log = require(path.join(repo, "device", "autojs6", "lib", "log.js"));
+const comonitor = require(path.join(repo, "device", "autojs6", "lib", "comonitor.js"));
+const log = require(path.join(repo, "device", "autojs6", "lib", "log.js"));
 ok(typeof comonitor.probeA11y === "function", "probeA11y exported");
-var profile = { id: "oneui-device", sdRoot: "/sdcard/stayturgid", notifyTag: "" };
+const profile = { id: "oneui-device", sdRoot: "/sdcard/stayturgid", notifyTag: "" };
 // Sticky candidate: auto present, service null, settings lists AutoJs6 → degraded (not hard FAILED)
 global.auto = { service: null };
-var sticky = comonitor.run(profile, { force: true, reason: "sticky" });
+const sticky = comonitor.run(profile, { force: true, reason: "sticky" });
 ok(
   sticky !== null && sticky.a11y === "degraded",
   "comonitor reports a11y degraded when settings list ON but auto.service null (sticky candidate)",
 );
 // Bound: auto.service truthy → up
 global.auto = { service: {} };
-var result = comonitor.run(profile, { force: true, reason: "test" });
+const result = comonitor.run(profile, { force: true, reason: "test" });
 ok(result !== null, "comonitor.run returns a status object when forced");
-ok(result.sshd === "up" || result.sshd === "restarted", "comonitor probes sshd");
-ok(result.shizuku === "up", "comonitor probes shizuku");
-ok(result.a11y === "up", "comonitor probes a11y when auto.service bound");
-ok(result.port === "open", "comonitor probes shell 5555 on non-split");
+ok(result !== null && (result.sshd === "up" || result.sshd === "restarted"), "comonitor probes sshd");
+ok(result !== null && result.shizuku === "up", "comonitor probes shizuku");
+ok(result !== null && result.a11y === "up", "comonitor probes a11y when auto.service bound");
+ok(result !== null && result.port === "open", "comonitor probes shell 5555 on non-split");
 // comonitor.run() should persist status to state.json via writeState
-var comonitorConfig = require(path.join(repo, "device", "autojs6", "lib", "config.js"));
-var statePath = comonitorConfig.pathsFor(profile).watchdogState;
-var stateContent = "";
+const comonitorConfig = require(path.join(repo, "device", "autojs6", "lib", "config.js"));
+const statePath = comonitorConfig.pathsFor(profile).watchdogState;
+let stateContent = "";
 try {
   stateContent = fs.readFileSync(mapped(statePath), "utf8");
-} catch (e) {}
-var stateObj = null;
+} catch {
+  /* ignore */
+}
+let stateObj = null;
 try {
   stateObj = JSON.parse(stateContent);
-} catch (e) {}
+} catch {
+  /* ignore */
+}
 ok(
-  stateObj !== null && stateObj.comonitor && typeof stateObj.comonitor.port === "string",
+  stateObj !== null && !!stateObj.comonitor && typeof stateObj.comonitor.port === "string",
   "comonitor.run() writes comonitor.port to state.json via writeState",
 );
 ok(
-  stateObj !== null && stateObj.comonitor && typeof stateObj.comonitor.timestamp === "string",
+  stateObj !== null && !!stateObj.comonitor && typeof stateObj.comonitor.timestamp === "string",
   "comonitor.run() includes timestamp in state.json comonitor namespace",
 );
 // Fire / split-storage: skip localhost:5555
-var fire = { id: "fireos-device", sdRoot: "/data/data/com.termux/files/home/.stayturgid/shared" };
-var fireResult = comonitor.run(fire, { force: true, reason: "split-storage" });
-ok(fireResult.port === "skip", "split-storage skips localhost:5555");
-ok(fireResult.wifi === "skip", "split-storage skips wifi flag");
+const fire = { id: "fireos-device", sdRoot: "/data/data/com.termux/files/home/.stayturgid/shared" };
+const fireResult = comonitor.run(fire, { force: true, reason: "split-storage" });
+ok(fireResult !== null && fireResult.port === "skip", "split-storage skips localhost:5555");
+ok(fireResult !== null && fireResult.wifi === "skip", "split-storage skips wifi flag");
 // Without force and with fresh Termux repair, defer
-var config = require(path.join(repo, "device", "autojs6", "lib", "config.js"));
+const config = require(path.join(repo, "device", "autojs6", "lib", "config.js"));
 function stamp(d) {
-  function p(x) {
-    return (x < 10 ? "0" : "") + x;
-  }
-  return (
-    d.getFullYear() +
-    "-" +
-    p(d.getMonth() + 1) +
-    "-" +
-    p(d.getDate()) +
-    " " +
-    p(d.getHours()) +
-    ":" +
-    p(d.getMinutes()) +
-    ":" +
-    p(d.getSeconds())
-  );
+  const p = (x) => (x < 10 ? "0" : "") + x;
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
 }
 files.write(
   config.WATCHDOG_LOG,
@@ -161,14 +143,14 @@ files.write(
 ok(log.isRepairLoopStale() === false, "fresh repair for defer test");
 ok(comonitor.run(profile, { force: false }) === null, "comonitor defers when Termux repair is fresh and force=false");
 // Periodic path (force=true) always runs — fleet parity
-var periodic = comonitor.run(profile, { force: true, reason: "periodic" });
+const periodic = comonitor.run(profile, { force: true, reason: "periodic" });
 ok(periodic !== null && periodic.port === "open", "comonitor force=true runs even when Termux repair is fresh");
 // log.js accepts [comonitor] STATUS
 files.write(
   config.WATCHDOG_LOG,
   stamp(new Date()) + " [comonitor] STATUS port=skip shizuku=up sshd=up a11y=up shell=no wifi=skip\n",
 );
-var st = log.latestRepairStatus();
+const st = log.latestRepairStatus();
 ok(st !== null && st.port === "skip" && st.a11y === "up", "latestRepairStatus accepts [comonitor] STATUS with a11y");
 ok(log.isRepairLoopStale() === true, "[comonitor] alone does not count as Termux repair freshness");
 console.log("1.." + n);

--- a/tests/js/comonitor.test.ts
+++ b/tests/js/comonitor.test.ts
@@ -1,64 +1,110 @@
-// @ts-nocheck
 /**
  * Unit tests for device/autojs6/lib/comonitor.js under node (files{} + shizuku shims).
  * Emits TAP. Exit 0 = pass.
  */
-"use strict";
-var fs = require("fs"),
-  os = require("os"),
-  path = require("path");
+import fs = require("fs");
+import os = require("os");
+import path = require("path");
+import Module = require("module");
 
-var repo = path.resolve(__dirname, "..", "..");
-var tmp = fs.mkdtempSync(path.join(os.tmpdir(), "stcom-"));
-var mapped = function (p) {
-  return path.join(tmp, String(p).replace(/\//g, "_"));
-};
+declare global {
+  // `var` is required here — TS global augmentation blocks don't accept let/const.
+  var files: {
+    exists(p: string): boolean;
+    read(p: string): string;
+    append(p: string, s: string): void;
+    write(p: string, s: string): void;
+    ensureDir(p: string): void;
+  };
+  var sleep: (ms: number) => void;
+  var shell: (cmd: string, sync: boolean) => { code: number; result: string };
+  var auto: { service: unknown } | undefined;
+}
+
+interface RepairStatus {
+  port: string;
+  shizuku: string | null;
+  sshd: string | null;
+  a11y?: string;
+  shell?: string;
+  wifi?: string;
+}
+
+interface DevicePaths {
+  watchdogState: string;
+}
+
+interface ConfigModule {
+  WATCHDOG_LOG: string;
+  pathsFor(profile: unknown): DevicePaths;
+}
+
+interface LogModule {
+  isRepairLoopStale(): boolean;
+  latestRepairStatus(): RepairStatus | null;
+}
+
+interface ComonitorStatus {
+  port: string;
+  shizuku: string;
+  sshd: string;
+  a11y: string;
+  shell: string;
+  wifi: string;
+  reason: string;
+}
+
+interface ComonitorModule {
+  probeA11y(split: boolean): string;
+  run(profile: unknown, opts: { force: boolean; reason?: string }): ComonitorStatus | null;
+}
+
+const repo = path.resolve(__dirname, "..", "..");
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "stcom-"));
+const mapped = (p: string): string => path.join(tmp, p.replace(/\//g, "_"));
 
 global.files = {
-  exists: function (p) {
-    if (String(p) === "/sdcard/stayturgid/state/device.json") return true;
+  exists(p) {
+    if (p === "/sdcard/stayturgid/state/device.json") return true;
     return fs.existsSync(mapped(p));
   },
-  read: function (p) {
-    if (String(p) === "/sdcard/stayturgid/state/device.json") {
+  read(p) {
+    if (p === "/sdcard/stayturgid/state/device.json") {
       return JSON.stringify({ id: "oneui-device", sdRoot: "/sdcard/stayturgid" });
     }
     return fs.readFileSync(mapped(p), "utf8");
   },
-  append: function (p, s) {
+  append(p, s) {
     fs.appendFileSync(mapped(p), s);
   },
-  write: function (p, s) {
+  write(p, s) {
     fs.writeFileSync(mapped(p), s);
   },
-  ensureDir: function () {},
+  ensureDir() {},
 };
-global.console = console;
-global.sleep = function () {};
-global.shell = function () {
-  return { code: 1, result: "" };
-};
+global.sleep = () => {};
+global.shell = () => ({ code: 1, result: "" });
 global.auto = { service: null };
 
-var n = 0,
-  failed = 0;
-function ok(cond, desc) {
+let n = 0;
+let failed = 0;
+function ok(cond: boolean, desc: string): void {
   n++;
   console.log((cond ? "ok " : "not ok ") + n + " - " + desc);
   if (!cond) failed++;
 }
 
 // Stub shizuku_shell before requiring comonitor (watchdog deps pull it in).
-var shizukuState = { operational: true, cmds: [] };
-var Module = require("module");
-var origLoad = Module._load;
-Module._load = function (request, parent) {
+// Module._load is a private Node API with no public typings — the double
+// assertion through `unknown` is the narrowest way to reach it.
+const shizukuState = { operational: true, cmds: [] as string[] };
+const ModuleInternals = Module as unknown as { _load: (request: string, parent: unknown) => unknown };
+const origLoad = ModuleInternals._load;
+ModuleInternals._load = (request: string, parent: unknown): unknown => {
   if (request === "./shizuku_shell.js" || request.endsWith("/shizuku_shell.js")) {
     return {
-      isOperational: function () {
-        return shizukuState.operational;
-      },
-      exec: function (cmd) {
+      isOperational: () => shizukuState.operational,
+      exec: (cmd: string) => {
         shizukuState.cmds.push(cmd);
         if (cmd.indexOf("pgrep -x sshd") >= 0 || cmd.indexOf("[s]shd") >= 0) {
           return { code: 0, result: "" };
@@ -83,86 +129,72 @@ Module._load = function (request, parent) {
     };
   }
   if (request === "./notify.js" || request.endsWith("/notify.js")) {
-    return { show: function () {}, clear: function () {} };
+    return { show: () => {}, clear: () => {} };
   }
   if (request === "./repair.js" || request.endsWith("/repair.js")) {
-    return {
-      repairCatastrophic: function () {
-        return true;
-      },
-    };
+    return { repairCatastrophic: () => true };
   }
-  return origLoad.apply(this, arguments);
+  return origLoad.call(Module, request, parent);
 };
 
-var comonitor = require(path.join(repo, "device", "autojs6", "lib", "comonitor.js"));
-var log = require(path.join(repo, "device", "autojs6", "lib", "log.js"));
+const comonitor = require(path.join(repo, "device", "autojs6", "lib", "comonitor.js")) as ComonitorModule;
+const log = require(path.join(repo, "device", "autojs6", "lib", "log.js")) as LogModule;
 
 ok(typeof comonitor.probeA11y === "function", "probeA11y exported");
 
-var profile = { id: "oneui-device", sdRoot: "/sdcard/stayturgid", notifyTag: "" };
+const profile = { id: "oneui-device", sdRoot: "/sdcard/stayturgid", notifyTag: "" };
 
 // Sticky candidate: auto present, service null, settings lists AutoJs6 → degraded (not hard FAILED)
 global.auto = { service: null };
-var sticky = comonitor.run(profile, { force: true, reason: "sticky" });
+const sticky = comonitor.run(profile, { force: true, reason: "sticky" });
 ok(
   sticky !== null && sticky.a11y === "degraded",
   "comonitor reports a11y degraded when settings list ON but auto.service null (sticky candidate)",
 );
 // Bound: auto.service truthy → up
 global.auto = { service: {} };
-var result = comonitor.run(profile, { force: true, reason: "test" });
+const result = comonitor.run(profile, { force: true, reason: "test" });
 ok(result !== null, "comonitor.run returns a status object when forced");
-ok(result.sshd === "up" || result.sshd === "restarted", "comonitor probes sshd");
-ok(result.shizuku === "up", "comonitor probes shizuku");
-ok(result.a11y === "up", "comonitor probes a11y when auto.service bound");
-ok(result.port === "open", "comonitor probes shell 5555 on non-split");
+ok(result !== null && (result.sshd === "up" || result.sshd === "restarted"), "comonitor probes sshd");
+ok(result !== null && result.shizuku === "up", "comonitor probes shizuku");
+ok(result !== null && result.a11y === "up", "comonitor probes a11y when auto.service bound");
+ok(result !== null && result.port === "open", "comonitor probes shell 5555 on non-split");
 
 // comonitor.run() should persist status to state.json via writeState
-var comonitorConfig = require(path.join(repo, "device", "autojs6", "lib", "config.js"));
-var statePath = comonitorConfig.pathsFor(profile).watchdogState;
-var stateContent = "";
+const comonitorConfig = require(path.join(repo, "device", "autojs6", "lib", "config.js")) as ConfigModule;
+const statePath = comonitorConfig.pathsFor(profile).watchdogState;
+let stateContent = "";
 try {
   stateContent = fs.readFileSync(mapped(statePath), "utf8");
-} catch (e) {}
-var stateObj = null;
+} catch {
+  /* ignore */
+}
+let stateObj: { comonitor?: { port?: unknown; timestamp?: unknown } } | null = null;
 try {
   stateObj = JSON.parse(stateContent);
-} catch (e) {}
+} catch {
+  /* ignore */
+}
 ok(
-  stateObj !== null && stateObj.comonitor && typeof stateObj.comonitor.port === "string",
+  stateObj !== null && !!stateObj.comonitor && typeof stateObj.comonitor.port === "string",
   "comonitor.run() writes comonitor.port to state.json via writeState",
 );
 ok(
-  stateObj !== null && stateObj.comonitor && typeof stateObj.comonitor.timestamp === "string",
+  stateObj !== null && !!stateObj.comonitor && typeof stateObj.comonitor.timestamp === "string",
   "comonitor.run() includes timestamp in state.json comonitor namespace",
 );
 
 // Fire / split-storage: skip localhost:5555
-var fire = { id: "fireos-device", sdRoot: "/data/data/com.termux/files/home/.stayturgid/shared" };
-var fireResult = comonitor.run(fire, { force: true, reason: "split-storage" });
-ok(fireResult.port === "skip", "split-storage skips localhost:5555");
-ok(fireResult.wifi === "skip", "split-storage skips wifi flag");
+const fire = { id: "fireos-device", sdRoot: "/data/data/com.termux/files/home/.stayturgid/shared" };
+const fireResult = comonitor.run(fire, { force: true, reason: "split-storage" });
+ok(fireResult !== null && fireResult.port === "skip", "split-storage skips localhost:5555");
+ok(fireResult !== null && fireResult.wifi === "skip", "split-storage skips wifi flag");
 
 // Without force and with fresh Termux repair, defer
-var config = require(path.join(repo, "device", "autojs6", "lib", "config.js"));
-function stamp(d) {
-  function p(x) {
-    return (x < 10 ? "0" : "") + x;
-  }
-  return (
-    d.getFullYear() +
-    "-" +
-    p(d.getMonth() + 1) +
-    "-" +
-    p(d.getDate()) +
-    " " +
-    p(d.getHours()) +
-    ":" +
-    p(d.getMinutes()) +
-    ":" +
-    p(d.getSeconds())
-  );
+const config = require(path.join(repo, "device", "autojs6", "lib", "config.js")) as ConfigModule;
+function stamp(d: Date): string {
+  const p = (x: number) => (x < 10 ? "0" : "") + x;
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
 }
 files.write(
   config.WATCHDOG_LOG,
@@ -172,7 +204,7 @@ ok(log.isRepairLoopStale() === false, "fresh repair for defer test");
 ok(comonitor.run(profile, { force: false }) === null, "comonitor defers when Termux repair is fresh and force=false");
 
 // Periodic path (force=true) always runs — fleet parity
-var periodic = comonitor.run(profile, { force: true, reason: "periodic" });
+const periodic = comonitor.run(profile, { force: true, reason: "periodic" });
 ok(periodic !== null && periodic.port === "open", "comonitor force=true runs even when Termux repair is fresh");
 
 // log.js accepts [comonitor] STATUS
@@ -180,7 +212,7 @@ files.write(
   config.WATCHDOG_LOG,
   stamp(new Date()) + " [comonitor] STATUS port=skip shizuku=up sshd=up a11y=up shell=no wifi=skip\n",
 );
-var st = log.latestRepairStatus();
+const st = log.latestRepairStatus();
 ok(st !== null && st.port === "skip" && st.a11y === "up", "latestRepairStatus accepts [comonitor] STATUS with a11y");
 ok(log.isRepairLoopStale() === true, "[comonitor] alone does not count as Termux repair freshness");
 

--- a/tests/js/log.test.js
+++ b/tests/js/log.test.js
@@ -1,5 +1,6 @@
 // @generated
-// @ts-nocheck
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 /**
  * Unit tests for device/autojs6/lib/log.js under node, with a files{} shim standing
  * in for the AutoJs6 global. Emits TAP. Exit 0 = pass.
@@ -7,76 +8,59 @@
  * Covers CODE-REVIEW.md L12: timestamps must parse as local time via
  * component construction, not Date.parse (local-vs-UTC ambiguous).
  */
-"use strict";
-var fs = require("fs"),
-  os = require("os"),
-  path = require("path");
-var repo = path.resolve(__dirname, "..", "..");
-var tmp = fs.mkdtempSync(path.join(os.tmpdir(), "stlog-"));
-var mapped = function (p) {
-  return path.join(tmp, String(p).replace(/\//g, "_"));
-};
-var ensureDirCalls = [];
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const repo = path.resolve(__dirname, "..", "..");
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "stlog-"));
+const mapped = (p) => path.join(tmp, p.replace(/\//g, "_"));
+const ensureDirCalls = [];
 global.files = {
-  exists: function (p) {
-    if (String(p) === "/sdcard/stayturgid/state/device.json") return true;
+  exists(p) {
+    if (p === "/sdcard/stayturgid/state/device.json") return true;
     return fs.existsSync(mapped(p));
   },
-  read: function (p) {
-    if (String(p) === "/sdcard/stayturgid/state/device.json") {
+  read(p) {
+    if (p === "/sdcard/stayturgid/state/device.json") {
       return JSON.stringify({ id: "oneui-device", sdRoot: "/sdcard/stayturgid" });
     }
     return fs.readFileSync(mapped(p), "utf8");
   },
-  append: function (p, s) {
+  append(p, s) {
     fs.appendFileSync(mapped(p), s);
   },
-  write: function (p, s) {
+  write(p, s) {
     fs.writeFileSync(mapped(p), s);
   },
   // AutoJs6 files.ensureDir(path) expects a directory (trailing slash). The
   // shim records the raw argument so tests can assert log.append() passes the
   // log's *directory*, not the file path (CODE-REVIEW ensureDir regression).
-  ensureDir: function (p) {
-    ensureDirCalls.push(String(p));
+  ensureDir(p) {
+    ensureDirCalls.push(p);
   },
 };
-var n = 0,
-  failed = 0;
+let n = 0;
+let failed = 0;
 function ok(cond, desc) {
   n++;
   console.log((cond ? "ok " : "not ok ") + n + " - " + desc);
   if (!cond) failed++;
 }
 function stamp(d) {
-  function p(x) {
-    return (x < 10 ? "0" : "") + x;
-  }
-  return (
-    d.getFullYear() +
-    "-" +
-    p(d.getMonth() + 1) +
-    "-" +
-    p(d.getDate()) +
-    " " +
-    p(d.getHours()) +
-    ":" +
-    p(d.getMinutes()) +
-    ":" +
-    p(d.getSeconds())
-  );
+  const p = (x) => (x < 10 ? "0" : "") + x;
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
 }
-var config = require(path.join(repo, "device", "autojs6", "lib", "config.js"));
-var log = require(path.join(repo, "device", "autojs6", "lib", "log.js"));
+const config = require(path.join(repo, "device", "autojs6", "lib", "config.js"));
+const log = require(path.join(repo, "device", "autojs6", "lib", "log.js"));
 // parseStatusLine
-var s = log.parseStatusLine("2026-07-06 01:02:03 [repair] STATUS port=open shizuku=up sshd=restarted shell=yes rc=0");
+const s = log.parseStatusLine("2026-07-06 01:02:03 [repair] STATUS port=open shizuku=up sshd=restarted shell=yes rc=0");
 ok(
   s !== null && s.port === "open" && s.shizuku === "up" && s.sshd === "restarted",
   "parseStatusLine extracts port/shizuku/sshd",
 );
-ok(s.shell === "yes", "parseStatusLine extracts shell when present");
+ok(s !== null && s.shell === "yes", "parseStatusLine extracts shell when present");
 ok(log.parseStatusLine("garbage line") === null, "parseStatusLine rejects non-STATUS lines");
-var full = log.parseStatusLine(
+const full = log.parseStatusLine(
   "2026-07-09 19:00:00 [comonitor] STATUS port=skip shizuku=up sshd=up a11y=repaired shell=no wifi=skip",
 );
 ok(
@@ -84,8 +68,8 @@ ok(
   "parseStatusLine extracts a11y/wifi from comonitor STATUS",
 );
 // latestRepairStatus picks the most recent [repair] STATUS
-var now = new Date();
-var old = new Date(Date.now() - 20 * 60 * 1000);
+const now = new Date();
+const old = new Date(Date.now() - 20 * 60 * 1000);
 files.write(
   config.WATCHDOG_LOG,
   stamp(old) +
@@ -93,7 +77,7 @@ files.write(
     stamp(now) +
     " [repair] STATUS port=open shizuku=up sshd=up shell=yes rc=0\n",
 );
-var latest = log.latestRepairStatus();
+const latest = log.latestRepairStatus();
 ok(latest !== null && latest.port === "open", "latestRepairStatus returns most recent STATUS");
 // Prefer [repair] over newer [comonitor]
 files.write(
@@ -103,10 +87,10 @@ files.write(
     stamp(now) +
     " [comonitor] STATUS port=CLOSED_NO_SHELL shizuku=up sshd=up a11y=up shell=no wifi=up\n",
 );
-var prefer = log.latestRepairStatus();
+const prefer = log.latestRepairStatus();
 ok(prefer !== null && prefer.port === "open", "latestRepairStatus prefers [repair] over newer [comonitor]");
 // L12 regression: local-time parse, no UTC skew
-var ts = log.latestRepairTimestampMs();
+const ts = log.latestRepairTimestampMs();
 ok(
   ts !== null && Math.abs(ts - now.getTime()) < 2000,
   "latestRepairTimestampMs matches local wall clock (no UTC skew)",
@@ -121,56 +105,62 @@ ok(log.latestRepairStatus() === null, "log without STATUS lines => null status")
 // path. Passing the file path to files.ensureDir would create a directory that
 // shadows the log file (files.append then fails / self-heal never works).
 ensureDirCalls.length = 0;
-var written = log.append("[repair] STATUS port=open shizuku=up sshd=up shell=yes rc=0");
+const written = log.append("[repair] STATUS port=open shizuku=up sshd=up shell=yes rc=0");
 ok(ensureDirCalls.length >= 1, "append() calls files.ensureDir before writing");
-var dirArg = ensureDirCalls[ensureDirCalls.length - 1];
+const dirArg = ensureDirCalls[ensureDirCalls.length - 1];
 ok(
   /\/logs\/?$/.test(dirArg) && dirArg.indexOf("watchdog.log") < 0,
   "append() ensures the log directory, not the log file path",
 );
 ok(log.readWatchdogLog().indexOf(written) >= 0, "append() writes the timestamped line to the watchdog log");
 // JSONL dual-write: append() should also write a valid JSON line to watchdog.jsonl
-var watchdogJsonlPath = config.pathsFor(config.detectDeviceProfile()).watchdogJsonl;
-var jsonlContent = "";
+const watchdogJsonlPath = config.pathsFor(config.detectDeviceProfile()).watchdogJsonl;
+let jsonlContent = "";
 try {
   jsonlContent = fs.readFileSync(mapped(watchdogJsonlPath), "utf8");
-} catch (e) {}
-var jsonlLines = jsonlContent.split("\n").filter(function (l) {
-  return l.trim();
-});
+} catch {
+  /* ignore */
+}
+const jsonlLines = jsonlContent.split("\n").filter((l) => l.trim());
 ok(jsonlLines.length > 0, "append() dual-writes at least one JSONL line to watchdog.jsonl");
 if (jsonlLines.length > 0) {
-  var parsed = null;
+  let parsed = null;
   try {
     parsed = JSON.parse(jsonlLines[jsonlLines.length - 1]);
-  } catch (e) {}
+  } catch {
+    /* ignore */
+  }
   ok(parsed !== null && typeof parsed.timestamp === "string", "JSONL line has a timestamp field");
   ok(parsed !== null && typeof parsed.message === "string", "JSONL line has a message field");
   ok(parsed !== null && parsed.hostname === "oneui-device", "JSONL line contains hostname from device profile");
 }
 // writeState: writes state.json with source namespace and timestamp
 log.writeState("repair", { port: "open", shizuku: "up", sshd: "up", shell: "yes" });
-var statePath = config.pathsFor(config.detectDeviceProfile()).watchdogState;
-var stateContent = "";
+const statePath = config.pathsFor(config.detectDeviceProfile()).watchdogState;
+let stateContent = "";
 try {
   stateContent = fs.readFileSync(mapped(statePath), "utf8");
-} catch (e) {}
-var stateObj = null;
+} catch {
+  /* ignore */
+}
+let stateObj = null;
 try {
   stateObj = JSON.parse(stateContent);
-} catch (e) {}
+} catch {
+  /* ignore */
+}
 ok(
-  stateObj !== null && stateObj.repair && stateObj.repair.port === "open",
+  stateObj !== null && !!stateObj.repair && stateObj.repair.port === "open",
   "writeState() persists repair.port to state.json",
 );
 ok(
-  stateObj !== null && stateObj.repair && typeof stateObj.repair.timestamp === "string",
+  stateObj !== null && !!stateObj.repair && typeof stateObj.repair.timestamp === "string",
   "writeState() adds a timestamp to the state entry",
 );
 // latestRepairStatus() prefers state.json over log scanning
 // Clear the watchdog log so any result must come from state.json
 files.write(config.WATCHDOG_LOG, "no status lines here\n");
-var fromState = log.latestRepairStatus();
+const fromState = log.latestRepairStatus();
 ok(fromState !== null && fromState.port === "open", "latestRepairStatus() reads from state.json when available");
 // H10 regression: AutoJs6 does not provide files.getParent(). The shared helper
 // must derive the directory using plain string operations and ensure the parent

--- a/tests/js/log.test.ts
+++ b/tests/js/log.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Unit tests for device/autojs6/lib/log.js under node, with a files{} shim standing
  * in for the AutoJs6 global. Emits TAP. Exit 0 = pass.
@@ -6,82 +5,108 @@
  * Covers CODE-REVIEW.md L12: timestamps must parse as local time via
  * component construction, not Date.parse (local-vs-UTC ambiguous).
  */
-"use strict";
-var fs = require("fs"),
-  os = require("os"),
-  path = require("path");
+import fs = require("fs");
+import os = require("os");
+import path = require("path");
 
-var repo = path.resolve(__dirname, "..", "..");
-var tmp = fs.mkdtempSync(path.join(os.tmpdir(), "stlog-"));
-var mapped = function (p) {
-  return path.join(tmp, String(p).replace(/\//g, "_"));
-};
+declare global {
+  // `var` is required here — TS global augmentation blocks don't accept let/const.
+  var files: {
+    exists(p: string): boolean;
+    read(p: string): string;
+    append(p: string, s: string): void;
+    write(p: string, s: string): void;
+    ensureDir(p: string): void;
+  };
+}
 
-var ensureDirCalls = [];
+interface RepairStatus {
+  port: string;
+  shizuku: string | null;
+  sshd: string | null;
+  a11y?: string;
+  shell?: string;
+  wifi?: string;
+}
+
+interface DevicePaths {
+  watchdogJsonl: string;
+  watchdogState: string;
+}
+
+interface ConfigModule {
+  WATCHDOG_LOG: string;
+  pathsFor(profile: unknown): DevicePaths;
+  detectDeviceProfile(): unknown;
+  parentDir(filePath: string): string;
+  ensureParentDir(filePath: string): string;
+}
+
+interface LogModule {
+  parseStatusLine(line: string): RepairStatus | null;
+  latestRepairStatus(): RepairStatus | null;
+  latestRepairTimestampMs(): number | null;
+  isRepairLoopStale(): boolean;
+  append(line: string): string;
+  readWatchdogLog(): string;
+  writeState(source: string, statusObj: Record<string, unknown>): void;
+}
+
+const repo = path.resolve(__dirname, "..", "..");
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "stlog-"));
+const mapped = (p: string): string => path.join(tmp, p.replace(/\//g, "_"));
+
+const ensureDirCalls: string[] = [];
 global.files = {
-  exists: function (p) {
-    if (String(p) === "/sdcard/stayturgid/state/device.json") return true;
+  exists(p) {
+    if (p === "/sdcard/stayturgid/state/device.json") return true;
     return fs.existsSync(mapped(p));
   },
-  read: function (p) {
-    if (String(p) === "/sdcard/stayturgid/state/device.json") {
+  read(p) {
+    if (p === "/sdcard/stayturgid/state/device.json") {
       return JSON.stringify({ id: "oneui-device", sdRoot: "/sdcard/stayturgid" });
     }
     return fs.readFileSync(mapped(p), "utf8");
   },
-  append: function (p, s) {
+  append(p, s) {
     fs.appendFileSync(mapped(p), s);
   },
-  write: function (p, s) {
+  write(p, s) {
     fs.writeFileSync(mapped(p), s);
   },
   // AutoJs6 files.ensureDir(path) expects a directory (trailing slash). The
   // shim records the raw argument so tests can assert log.append() passes the
   // log's *directory*, not the file path (CODE-REVIEW ensureDir regression).
-  ensureDir: function (p) {
-    ensureDirCalls.push(String(p));
+  ensureDir(p) {
+    ensureDirCalls.push(p);
   },
 };
 
-var n = 0,
-  failed = 0;
-function ok(cond, desc) {
+let n = 0;
+let failed = 0;
+function ok(cond: boolean, desc: string): void {
   n++;
   console.log((cond ? "ok " : "not ok ") + n + " - " + desc);
   if (!cond) failed++;
 }
-function stamp(d) {
-  function p(x) {
-    return (x < 10 ? "0" : "") + x;
-  }
-  return (
-    d.getFullYear() +
-    "-" +
-    p(d.getMonth() + 1) +
-    "-" +
-    p(d.getDate()) +
-    " " +
-    p(d.getHours()) +
-    ":" +
-    p(d.getMinutes()) +
-    ":" +
-    p(d.getSeconds())
-  );
+function stamp(d: Date): string {
+  const p = (x: number) => (x < 10 ? "0" : "") + x;
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
 }
 
-var config = require(path.join(repo, "device", "autojs6", "lib", "config.js"));
-var log = require(path.join(repo, "device", "autojs6", "lib", "log.js"));
+const config = require(path.join(repo, "device", "autojs6", "lib", "config.js")) as ConfigModule;
+const log = require(path.join(repo, "device", "autojs6", "lib", "log.js")) as LogModule;
 
 // parseStatusLine
-var s = log.parseStatusLine("2026-07-06 01:02:03 [repair] STATUS port=open shizuku=up sshd=restarted shell=yes rc=0");
+const s = log.parseStatusLine("2026-07-06 01:02:03 [repair] STATUS port=open shizuku=up sshd=restarted shell=yes rc=0");
 ok(
   s !== null && s.port === "open" && s.shizuku === "up" && s.sshd === "restarted",
   "parseStatusLine extracts port/shizuku/sshd",
 );
-ok(s.shell === "yes", "parseStatusLine extracts shell when present");
+ok(s !== null && s.shell === "yes", "parseStatusLine extracts shell when present");
 ok(log.parseStatusLine("garbage line") === null, "parseStatusLine rejects non-STATUS lines");
 
-var full = log.parseStatusLine(
+const full = log.parseStatusLine(
   "2026-07-09 19:00:00 [comonitor] STATUS port=skip shizuku=up sshd=up a11y=repaired shell=no wifi=skip",
 );
 ok(
@@ -90,8 +115,8 @@ ok(
 );
 
 // latestRepairStatus picks the most recent [repair] STATUS
-var now = new Date();
-var old = new Date(Date.now() - 20 * 60 * 1000);
+const now = new Date();
+const old = new Date(Date.now() - 20 * 60 * 1000);
 files.write(
   config.WATCHDOG_LOG,
   stamp(old) +
@@ -99,7 +124,7 @@ files.write(
     stamp(now) +
     " [repair] STATUS port=open shizuku=up sshd=up shell=yes rc=0\n",
 );
-var latest = log.latestRepairStatus();
+const latest = log.latestRepairStatus();
 ok(latest !== null && latest.port === "open", "latestRepairStatus returns most recent STATUS");
 
 // Prefer [repair] over newer [comonitor]
@@ -110,11 +135,11 @@ files.write(
     stamp(now) +
     " [comonitor] STATUS port=CLOSED_NO_SHELL shizuku=up sshd=up a11y=up shell=no wifi=up\n",
 );
-var prefer = log.latestRepairStatus();
+const prefer = log.latestRepairStatus();
 ok(prefer !== null && prefer.port === "open", "latestRepairStatus prefers [repair] over newer [comonitor]");
 
 // L12 regression: local-time parse, no UTC skew
-var ts = log.latestRepairTimestampMs();
+const ts = log.latestRepairTimestampMs();
 ok(
   ts !== null && Math.abs(ts - now.getTime()) < 2000,
   "latestRepairTimestampMs matches local wall clock (no UTC skew)",
@@ -132,9 +157,9 @@ ok(log.latestRepairStatus() === null, "log without STATUS lines => null status")
 // path. Passing the file path to files.ensureDir would create a directory that
 // shadows the log file (files.append then fails / self-heal never works).
 ensureDirCalls.length = 0;
-var written = log.append("[repair] STATUS port=open shizuku=up sshd=up shell=yes rc=0");
+const written = log.append("[repair] STATUS port=open shizuku=up sshd=up shell=yes rc=0");
 ok(ensureDirCalls.length >= 1, "append() calls files.ensureDir before writing");
-var dirArg = ensureDirCalls[ensureDirCalls.length - 1];
+const dirArg = ensureDirCalls[ensureDirCalls.length - 1];
 ok(
   /\/logs\/?$/.test(dirArg) && dirArg.indexOf("watchdog.log") < 0,
   "append() ensures the log directory, not the log file path",
@@ -142,20 +167,22 @@ ok(
 ok(log.readWatchdogLog().indexOf(written) >= 0, "append() writes the timestamped line to the watchdog log");
 
 // JSONL dual-write: append() should also write a valid JSON line to watchdog.jsonl
-var watchdogJsonlPath = config.pathsFor(config.detectDeviceProfile()).watchdogJsonl;
-var jsonlContent = "";
+const watchdogJsonlPath = config.pathsFor(config.detectDeviceProfile()).watchdogJsonl;
+let jsonlContent = "";
 try {
   jsonlContent = fs.readFileSync(mapped(watchdogJsonlPath), "utf8");
-} catch (e) {}
-var jsonlLines = jsonlContent.split("\n").filter(function (l) {
-  return l.trim();
-});
+} catch {
+  /* ignore */
+}
+const jsonlLines = jsonlContent.split("\n").filter((l) => l.trim());
 ok(jsonlLines.length > 0, "append() dual-writes at least one JSONL line to watchdog.jsonl");
 if (jsonlLines.length > 0) {
-  var parsed = null;
+  let parsed: { timestamp?: unknown; message?: unknown; hostname?: unknown } | null = null;
   try {
     parsed = JSON.parse(jsonlLines[jsonlLines.length - 1]);
-  } catch (e) {}
+  } catch {
+    /* ignore */
+  }
   ok(parsed !== null && typeof parsed.timestamp === "string", "JSONL line has a timestamp field");
   ok(parsed !== null && typeof parsed.message === "string", "JSONL line has a message field");
   ok(parsed !== null && parsed.hostname === "oneui-device", "JSONL line contains hostname from device profile");
@@ -163,28 +190,32 @@ if (jsonlLines.length > 0) {
 
 // writeState: writes state.json with source namespace and timestamp
 log.writeState("repair", { port: "open", shizuku: "up", sshd: "up", shell: "yes" });
-var statePath = config.pathsFor(config.detectDeviceProfile()).watchdogState;
-var stateContent = "";
+const statePath = config.pathsFor(config.detectDeviceProfile()).watchdogState;
+let stateContent = "";
 try {
   stateContent = fs.readFileSync(mapped(statePath), "utf8");
-} catch (e) {}
-var stateObj = null;
+} catch {
+  /* ignore */
+}
+let stateObj: { repair?: { port?: unknown; timestamp?: unknown } } | null = null;
 try {
   stateObj = JSON.parse(stateContent);
-} catch (e) {}
+} catch {
+  /* ignore */
+}
 ok(
-  stateObj !== null && stateObj.repair && stateObj.repair.port === "open",
+  stateObj !== null && !!stateObj.repair && stateObj.repair.port === "open",
   "writeState() persists repair.port to state.json",
 );
 ok(
-  stateObj !== null && stateObj.repair && typeof stateObj.repair.timestamp === "string",
+  stateObj !== null && !!stateObj.repair && typeof stateObj.repair.timestamp === "string",
   "writeState() adds a timestamp to the state entry",
 );
 
 // latestRepairStatus() prefers state.json over log scanning
 // Clear the watchdog log so any result must come from state.json
 files.write(config.WATCHDOG_LOG, "no status lines here\n");
-var fromState = log.latestRepairStatus();
+const fromState = log.latestRepairStatus();
 ok(fromState !== null && fromState.port === "open", "latestRepairStatus() reads from state.json when available");
 
 // H10 regression: AutoJs6 does not provide files.getParent(). The shared helper

--- a/tests/js/tsconfig.json
+++ b/tests/js/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "types": ["node"],
+    "strict": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "compilerOptions": {
-    "target": "ES2015",
-    "module": "CommonJS",
-    "allowJs": false,
-    "strict": false
-  }
-}


### PR DESCRIPTION
## Summary
Follow-up to #39. Removes `@ts-nocheck` from all 27 `.ts` files and rewrites the auto-translated JS-with-a-`.ts`-extension source into real, strictly-typed TypeScript (no `any`, discriminated unions, string-literal status types, named interfaces, explicit nullability).

- New `device/autojs6/types/globals.d.ts`: ambient declarations for exactly the Rhino/AutoJs6 API surface the code touches, derived from actual call sites and cross-checked against AutoJs6's bundled docs and Rhino's own module-loader source.
- Split the single loose `tsconfig.json` into 4 per-runtime configs (`strict: true`): `device/autojs6` + `docs/research/autojs6-hd8-project` (Rhino), `tests/js` (Node), `just/tools` (Node + DOM lib for Puppeteer). Mixing these would let device code type-check against globals that don't exist on-device.
- `import x = require("./y.js")` throughout — TypeScript's CJS-interop syntax compiles to a plain `require()` call with zero interop overhead, verified to keep emitted output structurally identical to the original hand-written requires.
- Status values (sshd/a11y/shizuku/port/shell/wifi) are now string-literal union types; `termux.ts`'s `invokeRepair()` result is a discriminated union on `ok`.

## Runtime-behavior preservation
This compiles to code running on a live physical Android fleet via Rhino, not Node/browser, so:
- Every ambient API signature was checked against real usage across all 27 files; `shell()`/`shizuku()`'s never-null contract was confirmed against AutoJs6's own docs before relying on it to drop redundant defensive null-checks.
- Two comparisons (`sshd === "FAILED"`, `a11y === "FAILED"`/`"repaired"`) were dead code — traced every assignment site in `comonitor.ts` and confirmed those probes can never produce those values, so honest typing required simplifying them to what's reachable.
- Left two pre-existing, CodeRabbit-flagged logic quirks untouched (`shizuku.ts`'s redundant retry call, `test-stale-loop-once.ts` wiping prior `[repair]` history) — both byte-identical on `master`, out of scope for a typing-focused rewrite of hardware-facing code.
- `boot-launcher.test.ts`'s hand-rolled `vm` sandbox needed an `exports: {}` stub — tsc's CommonJS output always stamps the `__esModule` marker regardless of whether a file has real exports, and Rhino's actual loader always provides one; only the test's synthetic sandbox didn't.
- `rendered_dom_check.ts`: the correct ES2020 target for this Node-only tool emits native `async`/`await` instead of the old ES2015 downlevel polyfill, which had been incidentally hiding a real semgrep `puppeteer-goto-injection` match. Added explicit http(s)-only URL validation before `page.goto()` rather than just suppressing the finding.

## Test plan
- [x] `just check` clean
- [x] `just lint` clean
- [x] `just test` clean (all 3 AutoJs6 node test suites pass in full: 24/24, 16/16, 1/1)
- [x] `pre-commit run --all-files` — all 24 hooks pass
- [x] Zero `any` and zero `@ts-nocheck` remaining across all 27 `.ts` files
- [x] Compiled `.js` output spot-checked for correct `require()` paths and Java interop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved health probing and recovery for accessibility, Shizuku, Wi‑Fi, SSH, and Tailscale; uses fresher repair state and better fallbacks.
  - More reliable status persistence and smarter notification clearing to reduce duplicates and stale alerts.
  - Watchdog/monitor updates prevent duplicate accessibility and only trigger SSH notifications when truly down.
  - Prevented multiple main engines from running at the same time.

- **New Features**
  - Improved status reporting for degraded accessibility and repair outcomes.
  - Rendered DOM checker now validates HTTP/HTTPS URLs with clearer errors.

- **Chores**
  - Expanded TypeScript conversion/typing and automated test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->