### PR TITLE
Handle FIRERPA runtime policy and Fire OS recovery

### DIFF
--- a/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/install_apk.yml
+++ b/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/install_apk.yml
@@ -96,8 +96,8 @@
 - name: Whitelist package from device idle (battery optimization) — {{ _apk.id }}
   ansible.builtin.shell: |
     adb -s "{{ _bootstrap_adb }}" shell dumpsys deviceidle whitelist +{{ _apk.id }}
-    adb -s "{{ _bootstrap_adb }}" shell cmd appops set {{ _apk.id }} RUN_ANY_IN_BACKGROUND ignore || true
-    adb -s "{{ _bootstrap_adb }}" shell cmd appops set {{ _apk.id }} RUN_IN_BACKGROUND ignore || true
+    adb -s "{{ _bootstrap_adb }}" shell cmd appops set {{ _apk.id }} RUN_ANY_IN_BACKGROUND allow || true
+    adb -s "{{ _bootstrap_adb }}" shell cmd appops set {{ _apk.id }} RUN_IN_BACKGROUND allow || true
   changed_when: false
   failed_when: false
   delegate_to: localhost

--- a/ansible_collections/stayturgid/fleet/roles/shizuku_config/tasks/main.yml
+++ b/ansible_collections/stayturgid/fleet/roles/shizuku_config/tasks/main.yml
@@ -118,6 +118,8 @@
     device: "{{ lookup('stayturgid.android_common.adb_device', inventory_hostname) }}"
     connect: true
     action: moe.shizuku.privileged.api.HEADLESS_START
+    component: >-
+      moe.shizuku.privileged.api/moe.shizuku.manager.receiver.HeadlessStartStopReceiver
   changed_when: false
   failed_when: false
   delegate_to: localhost

--- a/ansible_collections/stayturgid/fleet/roles/shizuku_config/tasks/main.yml
+++ b/ansible_collections/stayturgid/fleet/roles/shizuku_config/tasks/main.yml
@@ -11,6 +11,15 @@
   delegate_to: localhost
   when: not (stayturgid_no_local_adb | default(false) | bool)
 
+- name: Reconcile Shizuku background execution policy
+  stayturgid.android_common.android_app_privileges:
+    device: "{{ lookup('stayturgid.android_common.adb_device', inventory_hostname) }}"
+    profiles:
+      - package: moe.shizuku.privileged.api
+        battery_unrestricted: true
+        disable_unused_restrictions: true
+  delegate_to: localhost
+
 - name: Create temporary file for Shizuku fleet profile staging
   ansible.builtin.tempfile:
     state: file

--- a/control/bin/firerpa_health_monitor.py
+++ b/control/bin/firerpa_health_monitor.py
@@ -15,7 +15,9 @@ Usage:
 from __future__ import annotations
 
 import os
+import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -31,16 +33,49 @@ ROOT = os.path.join(os.path.expanduser("~"), ".config", "stayturgid")
 try:
     from lamda.client import Device
 except ImportError:
-    print("lamda-client not installed -- skipping FIRERPA health check", file=sys.stderr)
-    sys.exit(0)
+    Device = None
 
 import json
-import subprocess
 
 from control.lib.ansible_context import resolve_ansible_context, resolved_env
 
 
-def get_fleet() -> dict[str, str]:
+@dataclass(frozen=True)
+class FirerpaTarget:
+    """Inventory-derived FIRERPA policy for one Android host."""
+
+    alias: str
+    ip: str
+    usb_serial: str = ""
+    enabled: bool = True
+    runtime_status: str = "supported"
+    recovery_mode: str = "none"
+    port: int = 65000
+    certificate_device_path: str = "/data/local/tmp/firerpa/server/lamda.pem"
+
+
+LIFECYCLE = (
+    REPO_ROOT
+    / "ansible_collections"
+    / "stayturgid"
+    / "firerpa"
+    / "roles"
+    / "firerpa"
+    / "files"
+    / "firerpa_lifecycle.py"
+)
+RECOVERY_MODE_CONTROL_NODE_ADB = "control-node-adb"
+
+
+def _as_bool(value: object, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def get_fleet() -> list[FirerpaTarget]:
     context = resolve_ansible_context(REPO_ROOT)
     env = resolved_env(REPO_ROOT)
 
@@ -53,7 +88,7 @@ def get_fleet() -> dict[str, str]:
     )
     if result.returncode != 0:
         print("Failed to resolve inventory: " + result.stderr, file=sys.stderr)
-        return {}
+        return []
 
     inv = json.loads(result.stdout)
     hosts = inv.get("stayturgid", {}).get("hosts", [])
@@ -64,18 +99,37 @@ def get_fleet() -> dict[str, str]:
 
     hostvars = inv.get("_meta", {}).get("hostvars", {})
 
-    fleet = {}
+    fleet = []
     for host in hosts:
-        ip = hostvars.get(host, {}).get("ansible_host")
+        variables = hostvars.get(host, {})
+        ip = variables.get("ansible_host")
         if ip:
-            fleet[host] = ip
+            fleet.append(
+                FirerpaTarget(
+                    alias=host,
+                    ip=str(ip),
+                    usb_serial=str(variables.get("device_usb_serial", "")),
+                    enabled=_as_bool(variables.get("firerpa_enabled"), True),
+                    runtime_status=str(variables.get("firerpa_runtime_status", "supported")),
+                    recovery_mode=str(variables.get("firerpa_recovery_mode", "none")),
+                    port=int(variables.get("firerpa_port", 65000)),
+                    certificate_device_path=str(
+                        variables.get(
+                            "firerpa_certificate_device_path",
+                            "/data/local/tmp/firerpa/server/lamda.pem",
+                        )
+                    ),
+                )
+            )
 
     return fleet
 
 
-def check_device(alias: str, ip: str) -> dict:
+def check_device(alias: str, ip: str, port: int = 65000) -> dict:
+    if Device is None:
+        return {"firerpa": "unreachable", "error": "lamda-client not installed"}
     try:
-        d = Device(ip, port=65000, certificate=certificate_path())
+        d = Device(ip, port=port, certificate=certificate_path())
         info = d.server_info()
     except Exception as e:
         return {"firerpa": "unreachable", "error": str(e)[:120]}
@@ -114,7 +168,77 @@ def check_device(alias: str, ip: str) -> dict:
     return result
 
 
+def _adb_reachable(target: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["adb", "-s", target, "shell", "echo", "ok"],
+            capture_output=True,
+            text=True,
+            timeout=12,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0 and "ok" in result.stdout
+
+
+def _recovery_adb_target(target: FirerpaTarget) -> str:
+    network_target = f"{target.ip}:5555"
+    try:
+        subprocess.run(
+            ["adb", "connect", network_target],
+            capture_output=True,
+            text=True,
+            timeout=12,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    if _adb_reachable(network_target):
+        return network_target
+    if target.usb_serial and _adb_reachable(target.usb_serial):
+        return target.usb_serial
+    return ""
+
+
+def recover_device(target: FirerpaTarget) -> tuple[bool, str]:
+    """Start FIRERPA through the inventory-selected control-node transport."""
+
+    if target.recovery_mode != RECOVERY_MODE_CONTROL_NODE_ADB:
+        return False, "not-configured"
+    adb_target = _recovery_adb_target(target)
+    if not adb_target:
+        return False, "adb-unreachable"
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(LIFECYCLE),
+                "start",
+                "--adb-target",
+                adb_target,
+                f"--port={target.port}",
+                f"--certificate={target.certificate_device_path}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "lifecycle-timeout"
+    except OSError as exc:
+        return False, f"lifecycle-error-{type(exc).__name__}"
+    if result.returncode == 0:
+        return True, "recovered"
+    detail = (result.stderr or result.stdout).strip().splitlines()
+    return False, (detail[-1][:120] if detail else f"lifecycle-exit-{result.returncode}")
+
+
 def main() -> int:
+    if Device is None:
+        print("lamda-client not installed -- skipping FIRERPA health check", file=sys.stderr)
+        return 0
     rc = 0
     trim_log(os.path.join(ROOT, "logs", LOG_NAME), max_age_days=30, max_lines=2000)
     fleet = get_fleet()
@@ -122,8 +246,32 @@ def main() -> int:
         print("No active devices found in inventory.", file=sys.stderr)
         return 1
 
-    for alias, ip in fleet.items():
-        result = check_device(alias, ip)
+    for target in fleet:
+        if target.runtime_status != "supported":
+            status = f"firerpa={target.runtime_status} sshd=skip shizuku=skip"
+            status += f" issues={target.runtime_status}"
+            log(
+                LOG_NAME,
+                WARNING,
+                f"{target.alias} via firerpa:{target.ip}:{target.port}: {status}",
+                also_print=False,
+            )
+            continue
+        if not target.enabled:
+            log(
+                LOG_NAME,
+                INFO,
+                f"{target.alias} via firerpa:{target.ip}:{target.port}: firerpa=disabled sshd=skip shizuku=skip",
+                also_print=False,
+            )
+            continue
+
+        result = check_device(target.alias, target.ip, target.port)
+        recovery = ""
+        if result.get("firerpa") == "unreachable" and target.recovery_mode == RECOVERY_MODE_CONTROL_NODE_ADB:
+            recovered, recovery = recover_device(target)
+            if recovered:
+                result = check_device(target.alias, target.ip, target.port)
         firerpa = result.get("firerpa", "unreachable")
         sshd = result.get("sshd", "unknown")
         shizuku = result.get("shizuku", "unknown")
@@ -140,12 +288,22 @@ def main() -> int:
         if shizuku == "down":
             issues.append("shizuku_down")
             level = WARNING
+        if recovery and recovery != "recovered":
+            issues.append("recovery_failed")
+            level = WARNING
 
         status = f"firerpa={firerpa} sshd={sshd} shizuku={shizuku}"
+        if recovery:
+            status += f" recovery={recovery}"
         if issues:
             status += f" issues={','.join(issues)}"
 
-        log(LOG_NAME, level, "%s via firerpa:%s:65000: %s" % (alias, ip, status), also_print=False)
+        log(
+            LOG_NAME,
+            level,
+            f"{target.alias} via firerpa:{target.ip}:{target.port}: {status}",
+            also_print=False,
+        )
 
     return rc
 

--- a/control/bin/firerpa_health_monitor.py
+++ b/control/bin/firerpa_health_monitor.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -65,6 +66,8 @@ LIFECYCLE = (
     / "firerpa_lifecycle.py"
 )
 RECOVERY_MODE_CONTROL_NODE_ADB = "control-node-adb"
+RECOVERY_READY_ATTEMPTS = 6
+RECOVERY_READY_INTERVAL_SECONDS = 2
 
 
 def _as_bool(value: object, default: bool) -> bool:
@@ -271,7 +274,12 @@ def main() -> int:
         if result.get("firerpa") == "unreachable" and target.recovery_mode == RECOVERY_MODE_CONTROL_NODE_ADB:
             recovered, recovery = recover_device(target)
             if recovered:
-                result = check_device(target.alias, target.ip, target.port)
+                for attempt in range(RECOVERY_READY_ATTEMPTS):
+                    result = check_device(target.alias, target.ip, target.port)
+                    if result.get("firerpa") != "unreachable":
+                        break
+                    if attempt + 1 < RECOVERY_READY_ATTEMPTS:
+                        time.sleep(RECOVERY_READY_INTERVAL_SECONDS)
         firerpa = result.get("firerpa", "unreachable")
         sshd = result.get("sshd", "unknown")
         shizuku = result.get("shizuku", "unknown")

--- a/just/fleet.just
+++ b/just/fleet.just
@@ -263,19 +263,19 @@ _firerpa_deploy_impl:
     {{ ansible_playbook }} ansible/playbooks/fleet/firerpa.yml {{ limit_flag }} -e firerpa_enabled=true
 
 firerpa-deploy-legacy:
-    @just _firerpa_deploy_impl
+    @hosts="{{ hosts }}" just _firerpa_deploy_impl
 
 firerpa-deploy:
-    @just _firerpa_deploy_impl
+    @hosts="{{ hosts }}" just _firerpa_deploy_impl
 
 _firerpa_remove_impl:
     {{ ansible_playbook }} ansible/playbooks/fleet/firerpa.yml {{ limit_flag }} -e firerpa_enabled=false
 
 firerpa-remove-legacy:
-    @just _firerpa_remove_impl
+    @hosts="{{ hosts }}" just _firerpa_remove_impl
 
 firerpa-remove:
-    @just _firerpa_remove_impl
+    @hosts="{{ hosts }}" just _firerpa_remove_impl
 
 _firerpa_heal_impl:
     #!/usr/bin/env bash
@@ -283,10 +283,10 @@ _firerpa_heal_impl:
     python3 control/bin/firerpa_heal.py {{ if hosts == "" { "--all" } else { "--host " + hosts } }}
 
 firerpa-heal-legacy:
-    @just _firerpa_heal_impl
+    @hosts="{{ hosts }}" just _firerpa_heal_impl
 
 firerpa-heal host="":
-    @just _firerpa_heal_impl {{ if host == "" { "--all" } else { "--host " + host } }}
+    @hosts="{{ host }}" just _firerpa_heal_impl
 
 _firerpa_health_impl:
     #!/usr/bin/env bash

--- a/tests/python/test_firerpa_health_monitor.py
+++ b/tests/python/test_firerpa_health_monitor.py
@@ -72,6 +72,7 @@ def test_main_reports_known_incompatibility_and_recovers_opted_in_host(monkeypat
     monkeypatch.setattr(monitor, "Device", object())
     monkeypatch.setattr(monitor, "check_device", fake_check)
     monkeypatch.setattr(monitor, "recover_device", lambda _target: (True, "recovered"))
+    monkeypatch.setattr(monitor.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(monitor, "trim_log", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         monitor,

--- a/tests/python/test_firerpa_health_monitor.py
+++ b/tests/python/test_firerpa_health_monitor.py
@@ -1,0 +1,108 @@
+"""Policy and recovery tests for the Mac-side FIRERPA monitor."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import firerpa_health_monitor as monitor
+
+
+def test_as_bool_handles_inventory_strings() -> None:
+    assert monitor._as_bool(True, False)
+    assert monitor._as_bool("yes", False)
+    assert not monitor._as_bool("false", True)
+    assert monitor._as_bool(None, True)
+
+
+def test_recover_device_uses_canonical_lifecycle(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **_kwargs):
+        calls.append(argv)
+        return SimpleNamespace(returncode=0, stdout="ok", stderr="")
+
+    target = monitor.FirerpaTarget(
+        alias="fire-tablet",
+        ip="100.64.0.8",
+        recovery_mode=monitor.RECOVERY_MODE_CONTROL_NODE_ADB,
+    )
+    monkeypatch.setattr(monitor, "_recovery_adb_target", lambda _target: "100.64.0.8:5555")
+    monkeypatch.setattr(monitor.subprocess, "run", fake_run)
+
+    assert monitor.recover_device(target) == (True, "recovered")
+    assert calls == [
+        [
+            monitor.sys.executable,
+            str(monitor.LIFECYCLE),
+            "start",
+            "--adb-target",
+            "100.64.0.8:5555",
+            "--port=65000",
+            "--certificate=/data/local/tmp/firerpa/server/lamda.pem",
+        ]
+    ]
+
+
+def test_main_reports_known_incompatibility_and_recovers_opted_in_host(monkeypatch) -> None:
+    logs: list[tuple[int, str]] = []
+    checks = {"fire-tablet": 0}
+    targets = [
+        monitor.FirerpaTarget(alias="phone", ip="100.64.0.1"),
+        monitor.FirerpaTarget(
+            alias="preview-phone",
+            ip="100.64.0.2",
+            enabled=False,
+            runtime_status="pending-incompatible-runtime",
+        ),
+        monitor.FirerpaTarget(
+            alias="fire-tablet",
+            ip="100.64.0.8",
+            recovery_mode=monitor.RECOVERY_MODE_CONTROL_NODE_ADB,
+        ),
+    ]
+
+    def fake_check(alias: str, _ip: str, _port: int):
+        if alias == "fire-tablet":
+            checks[alias] += 1
+            if checks[alias] == 1:
+                return {"firerpa": "unreachable"}
+        return {"firerpa": "10.0", "sshd": "up", "shizuku": "up"}
+
+    monkeypatch.setattr(monitor, "get_fleet", lambda: targets)
+    monkeypatch.setattr(monitor, "Device", object())
+    monkeypatch.setattr(monitor, "check_device", fake_check)
+    monkeypatch.setattr(monitor, "recover_device", lambda _target: (True, "recovered"))
+    monkeypatch.setattr(monitor, "trim_log", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        monitor,
+        "log",
+        lambda _name, level, message, **_kwargs: logs.append((level, message)),
+    )
+
+    assert monitor.main() == 0
+    assert checks["fire-tablet"] == 2
+    assert any("firerpa=pending-incompatible-runtime" in message for _, message in logs)
+    assert any("fire-tablet" in message and "recovery=recovered" in message for _, message in logs)
+
+
+def test_main_fails_when_control_node_recovery_fails(monkeypatch) -> None:
+    target = monitor.FirerpaTarget(
+        alias="fire-tablet",
+        ip="100.64.0.8",
+        recovery_mode=monitor.RECOVERY_MODE_CONTROL_NODE_ADB,
+    )
+    logs: list[str] = []
+    monkeypatch.setattr(monitor, "get_fleet", lambda: [target])
+    monkeypatch.setattr(monitor, "Device", object())
+    monkeypatch.setattr(monitor, "check_device", lambda *_args: {"firerpa": "unreachable"})
+    monkeypatch.setattr(monitor, "recover_device", lambda _target: (False, "adb-unreachable"))
+    monkeypatch.setattr(monitor, "trim_log", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        monitor,
+        "log",
+        lambda _name, _level, message, **_kwargs: logs.append(message),
+    )
+
+    assert monitor.main() == 1
+    assert "recovery=adb-unreachable" in logs[-1]
+    assert "issues=firerpa_down,recovery_failed" in logs[-1]

--- a/tests/python/test_fleet_app_privileges.py
+++ b/tests/python/test_fleet_app_privileges.py
@@ -188,3 +188,4 @@ def test_shizuku_role_reconciles_background_execution_policy():
     assert "android_app_privileges:" in task_file
     assert "package: moe.shizuku.privileged.api" in task_file
     assert "battery_unrestricted: true" in task_file
+    assert "moe.shizuku.manager.receiver.HeadlessStartStopReceiver" in task_file

--- a/tests/python/test_fleet_app_privileges.py
+++ b/tests/python/test_fleet_app_privileges.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -166,3 +167,24 @@ def test_battery_optimized_removes_whitelist_and_denies_background():
     assert any("appops set com.aurora.store RUN_ANY_IN_BACKGROUND ignore" in c for c in calls)
     items = results[0]["items"]
     assert any(i.get("status") == "unwhitelisted" for i in items)
+
+
+def test_legacy_bootstrap_battery_unrestricted_allows_background_execution():
+    repo_root = Path(__file__).resolve().parents[2]
+    task_file = (
+        repo_root / "ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/install_apk.yml"
+    ).read_text()
+
+    assert "RUN_ANY_IN_BACKGROUND allow" in task_file
+    assert "RUN_IN_BACKGROUND allow" in task_file
+    assert "RUN_ANY_IN_BACKGROUND ignore" not in task_file
+    assert "RUN_IN_BACKGROUND ignore" not in task_file
+
+
+def test_shizuku_role_reconciles_background_execution_policy():
+    repo_root = Path(__file__).resolve().parents[2]
+    task_file = (repo_root / "ansible_collections/stayturgid/fleet/roles/shizuku_config/tasks/main.yml").read_text()
+
+    assert "android_app_privileges:" in task_file
+    assert "package: moe.shizuku.privileged.api" in task_file
+    assert "battery_unrestricted: true" in task_file


### PR DESCRIPTION
## Summary

- derive FIRERPA targets and compatibility policy from the active site inventory
- recover opted-in Fire OS targets through control-node ADB
- keep known incompatible runtimes visible without restart loops
- correct background AppOps for unrestricted packages and Shizuku
- explicitly target Shizuku's headless receiver on Fire OS
- preserve `hosts` through recursive FIRERPA just recipes

## Verification

- `24 passed` across FIRERPA monitor, lifecycle, and app-privilege tests
- Ruff check and format passed
- Mypy passed across 240 Python files
- Ansible syntax check passed using the discovered `site-djbclark` context
- Full pre-commit suite passed on both commits
- `hosts=hd8 just --dry-run _firerpa_deploy_impl` includes `-l hd8`
- hd8: FIRERPA v10 works via control-node ADB on API 30
- p7a: FIRERPA v10 exits as unsupported on API 37; upstream rebuild request is firerpa/lamda#147

Closes #51.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health monitoring now supports device-specific FIRERPA settings and automatic ADB-based recovery.
  * Recovery status and failure details are reported more clearly.
  * Shizuku background execution is configured for improved reliability.
  * APKs marked as battery-unrestricted can continue running in the background.

* **Bug Fixes**
  * Fleet deploy, removal, and healing commands now consistently apply selected host targeting.
  * Shizuku startup now targets the correct receiver explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->