### PR TITLE
Allow slow Fire HD 8 startup to settle

### DIFF
--- a/control/bin/firerpa_health_monitor.py
+++ b/control/bin/firerpa_health_monitor.py
@@ -66,8 +66,10 @@ LIFECYCLE = (
     / "firerpa_lifecycle.py"
 )
 RECOVERY_MODE_CONTROL_NODE_ADB = "control-node-adb"
-RECOVERY_READY_ATTEMPTS = 6
-RECOVERY_READY_INTERVAL_SECONDS = 2
+# Fire HD 8 startup can span a pre-login and post-login phase and occasionally
+# takes about five minutes before FIRERPA's gRPC endpoint is usable.
+RECOVERY_READY_ATTEMPTS = 30
+RECOVERY_READY_INTERVAL_SECONDS = 10
 
 
 def _as_bool(value: object, default: bool) -> bool:


### PR DESCRIPTION
## Summary

Fire HD 8 startup can span pre-login and post-login phases and sometimes takes about five minutes before FIRERPA is usable. Extend the recovery readiness poll from 10 seconds to a bounded ~5 minutes.

This does not change p7a incompatibility handling or introduce an unbounded retry loop.

## Verification

- full pre-commit suite passed
- targeted FIRERPA monitor tests passed
- Ruff, mypy, and formatting passed

Related to #51.