### PR TITLE
Publish comprehensive public session handoff

### DIFF
--- a/ansible_collections/stayturgid/android_common/plugins/modules/shizuku_start.py
+++ b/ansible_collections/stayturgid/android_common/plugins/modules/shizuku_start.py
@@ -13,11 +13,12 @@ description:
   - Starts the Shizuku daemon on an Android device over ADB.
   - First tries C(HEADLESS_START) broadcast (works when Shizuku has been paired).
   - Falls back to direct C(libshizuku.so) native launch (first-time, no pairing).
-  - "Applies the fleet profile (TCP mode, start-on-boot, watchdog) after start,
+  - >-
+    Applies the fleet profile (TCP mode, start-on-boot, watchdog) after start,
     and reconciles it on every run (even when Shizuku is already up) so
     preferences like C(watchdog) — which the app itself defaults to off,
     and which can only be turned on via this profile — cannot silently drift
-    back to a non-self-healing configuration between cold starts."
+    back to a non-self-healing configuration between cold starts.
   - Verifies the daemon is running and port 5555 is reachable.
   - Idempotent with respect to the Shizuku daemon itself: does not
     restart/relaunch it when already running with port 5555 open.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -5,8 +5,8 @@
 > [../README.md](../README.md). See AGENTS.md's "Where documentation goes"
 > table for what belongs in this file versus elsewhere.
 
-**Last verified:** 2026-07-24 (site-discovery hardening completed; s24/hd8
-native-agent and Tailscale state verified). Read this first; it links
+**Last verified:** 2026-07-24 (FIRERPA/Fire OS recovery work and ownership
+audit merged; s24/hd8/p7a ADB state directly checked). Read this first; it links
 everywhere else. If a
 claim here looks stale, trust `git log`, `just health`, and the
 [GitHub issues](https://github.com/djbclark/stayturgid/issues) over this file,
@@ -28,22 +28,29 @@ and update this file in the same commit.
 
 ## Fleet workstreams (current)
 
+<!-- markdownlint-disable MD060 -->
+
 | Workstream                                                                                                                                       | State                                                        | Detail                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | ------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Site discovery hardening** ([#48](https://github.com/djbclark/stayturgid/issues/48))                                                           | **Completed 2026-07-24**                                     | Shared resolver excludes `site-private`, honors `OPS_ROOT/.mysite`, announces the selected path/source, and safely creates the configurable private-companion directory when absent.                                                                                                                                                                                                                                                                                                                                  |
 | **K1 — native agent** (AutoJs6 -> Kotlin/Shizuku UserService)                                                                                    | Cutover landed (195c5c7, 2026-07-22), **not fully verified** | hd8, p7a, and s24 are confirmed on v0.3.6 debug with one host and one Shizuku UserService each; the UI exposes copyable build/runtime diagnostics. [#43](https://github.com/djbclark/stayturgid/issues/43) still tracks AutoJs6 removal and the forced `CLOSED_NO_SHELL` soak; [#45](https://github.com/djbclark/stayturgid/issues/45) tracks release APK and official Shizuku packaging. See [operations/sessions/handoff-2026-07-23-native-agent-k1.md](operations/sessions/handoff-2026-07-23-native-agent-k1.md). |
 | **OpenObserve <-> Vector auth**                                                                                                                  | **Broken, live**                                             | 401 Unauthorized on both OO sinks (latest seen 2026-07-23T12:21Z). Blocks K1 soak evidence and both T5 follow-ons. Tracked in [#44](https://github.com/djbclark/stayturgid/issues/44). `soft_health.jsonl` on the Mac is the source of truth until this is fixed.                                                                                                                                                                                                                                                     |
 | **F1 — FIRERPA MCP bridge**                                                                                                                      | Planned, not implemented                                     | Decisions D1-D3 finalized ([operations/plans/firerpa-mcp-bridge-plan-2026-07-22.md](operations/plans/firerpa-mcp-bridge-plan-2026-07-22.md)). Tracked in [#46](https://github.com/djbclark/stayturgid/issues/46), including the open consent-surface question. `mcp` 1.28.1 installed in `~/.venv-stayturgid-firerpa` (that venv has **no pip binary** — verify with `python -c "import importlib.metadata; ..."`, not `pip show`).                                                                                   |
+| **FIRERPA / Fire OS recovery**                                                                                                                   | **Merged; transport limitation confirmed**                   | hd8 FIRERPA 10.0 works through control-node ADB; Fire OS clears classic TCP ADB and wireless-debugging state across reboot. The health monitor now allows a bounded five-minute hd8 settle window. p7a remains explicitly `pending-incompatible-runtime`; upstream rebuild request is [firerpa/lamda#147](https://github.com/firerpa/lamda/issues/147).                                                                                                                                                               |
+| **Ownership audit** ([#50](https://github.com/djbclark/stayturgid/issues/50))                                                                    | **Inventory complete; operator decisions open**              | The public issue records the inventory and seven ownership questions. Prompt the operator before opening migration issues.                                                                                                                                                                                                                                                                                                                                                                                            |
 | **T5 — observability/portal unification**                                                                                                        | Evaluated, not started                                       | Reject Homer/Glance ([research/evaluations/observability-portal-unification-evaluation-2026-07-23.md](research/evaluations/observability-portal-unification-evaluation-2026-07-23.md)). Follow-ons tracked in [#47](https://github.com/djbclark/stayturgid/issues/47), blocked on #44.                                                                                                                                                                                                                                |
 | **Settings-state corruption** ([#41](https://github.com/djbclark/stayturgid/issues/41), [#42](https://github.com/djbclark/stayturgid/issues/42)) | Investigation open                                           | Battery-percentage reset + portrait-lock flip on Android; hypothesis is settings-DB corruption around sleep/wake. [#16](https://github.com/djbclark/stayturgid/issues/16) describes an overlapping symptom and is now cross-linked.                                                                                                                                                                                                                                                                                   |
 
+<!-- markdownlint-enable MD060 -->
+
 ## Fleet health (as of last check)
 
-- **s24** — online, healthy, direct Tailscale connection.
-- **p7a** — offline (Tailscale unreachable). Check physically before assuming
-  a software fault.
-- **hd8** — offline (Tailscale unreachable). Also has a history of Shizuku
-  service failures independent of the offline state.
+- **s24** — online; FIRERPA and Shizuku directly verified healthy.
+- **p7a** — ADB and Shizuku reachable; FIRERPA intentionally down because the
+  current closed runtime rejects API 37 with `unsupported sdk`.
+- **hd8** — ADB, FIRERPA 10.0, FIRERPA SSH, and Shizuku directly verified
+  healthy. Startup may span pre-login and post-login and take about five
+  minutes to settle.
 
 Run `just health` for current state — do not trust the table above once it's
 more than a day or two old.
@@ -61,16 +68,24 @@ more than a day or two old.
   committing, or the commit will fail on style, not content.
 - `device/native-agent/agent-release.jks` (the release signing keystore) must
   never be tracked in git. Check `git status` before any broad `git add`.
+- `/Users/djbclark/src/Shizuku` has an intentionally dirty nested `api`
+  submodule from pre-existing user work. Preserve it; inspect `git diff -- api`
+  before any cleanup. Its fork `master` is ahead of upstream `origin/master`
+  by design.
 - The sibling private repo `~/ops/site-djbclark` may have its own uncommitted
   operator-authored files (e.g. `human/F2-BREW-SERVICES-DECISIONS.md`) — leave
   those alone unless the operator asks you to touch them.
 
 ## Operator-action queue (things only a human can do)
 
-1. Set OpenObserve credentials for the Vector LaunchAgent and restart it ([#44](https://github.com/djbclark/stayturgid/issues/44)).
-2. Physically check p7a and hd8 (Tailscale unreachable).
+1. Answer the seven ownership questions in the private #50 audit before any
+   repository moves.
+2. Set OpenObserve credentials for the Vector LaunchAgent and restart it
+   ([#44](https://github.com/djbclark/stayturgid/issues/44)).
 3. Decide the F1 consent-surface phasing question ([#46](https://github.com/djbclark/stayturgid/issues/46)).
-4. Remove (or authorize removal of) the stray `~/stayturgid` file.
+4. Decide whether to publish Shizuku release20 through the normal APK path.
+5. Retest p7a only after firerpa/lamda#147 publishes a compatible runtime.
+6. Remove (or authorize removal of) the stray `~/stayturgid` file.
 
 ## Where things are documented
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -3,6 +3,11 @@
 Start at **[docs/STATUS.md](STATUS.md)** — current fleet/workstream state,
 known gotchas, and the operator-action queue.
 
+The latest complete baton is
+[handoff-2026-07-24-firerpa-ownership.md](operations/sessions/handoff-2026-07-24-firerpa-ownership.md).
+It is public and self-contained; the next AI must prompt the operator with its
+loose ends before starting new implementation.
+
 Session-by-session history lives in
 [docs/operations/sessions/](operations/sessions/); completed or superseded
 plans and old sessions are archived in [docs/archive/](archive/).

--- a/docs/operations/sessions/handoff-2026-07-24-firerpa-ownership.md
+++ b/docs/operations/sessions/handoff-2026-07-24-firerpa-ownership.md
@@ -1,0 +1,105 @@
+# Handoff — FIRERPA, Fire OS, and ownership audit
+
+Date: 2026-07-24
+
+This is the public handoff for the next AI session. It is intentionally
+self-contained: the next AI must not need `site-private` or this session's
+conversation to recover the state.
+
+## First action in the next session
+
+Prompt the operator with the unresolved items in **Loose ends and operator
+prompts** before implementing anything. Do not silently choose an ownership
+boundary, start the MCP bridge, publish a Shizuku release, or retest p7a with an
+unannounced FIRERPA binary.
+
+Also report this worktree warning immediately:
+
+- The local Shizuku checkout has a pre-existing dirty nested `api` submodule.
+  Preserve it. Inspect `git diff -- api` before any cleanup; never reset or
+  clean that submodule without explicit operator direction.
+- The fork's `master` is intentionally ahead of upstream `origin/master`.
+  Compare the fork remote with the upstream remote before calling this drift.
+
+## Completed and merged
+
+- stayturgid PR [#52](https://github.com/djbclark/stayturgid/pull/52):
+  inventory-derived FIRERPA policy, control-node ADB recovery, Fire OS AppOps
+  reconciliation, explicit Shizuku receiver targeting, and just-recipe host
+  propagation.
+- stayturgid PR [#53](https://github.com/djbclark/stayturgid/pull/53): bounded
+  five-minute FIRERPA readiness window for slow Fire HD 8 startup.
+- site-djbclark PR [#2](https://github.com/djbclark/site-djbclark/pull/2):
+  p7a incompatible-runtime policy and hd8 recovery mode.
+- Shizuku PR [#1](https://github.com/djbclark/Shizuku/pull/1): Fire OS
+  notification-resource and native-library packaging fixes.
+- The ownership inventory is summarized publicly in issue
+  [#50](https://github.com/djbclark/stayturgid/issues/50); its seven operator
+  decisions are repeated below so this handoff does not depend on a private
+  repository.
+
+All required CI/security checks and post-merge targeted checks passed. There
+are no open PRs in stayturgid, site-djbclark, or the Shizuku fork.
+
+## Verified device state
+
+- s24: FIRERPA and Shizuku healthy.
+- hd8: FIRERPA 10.0, FIRERPA SSH, and Shizuku healthy.
+- p7a: Shizuku healthy; FIRERPA intentionally down because the current closed
+  runtime exits with `unsupported sdk` on API 37.
+
+Fire HD 8 startup is split across pre-login and post-login phases and can take
+about five minutes to settle. The monitor now waits up to that bounded period.
+
+A no-touch reboot test established that Fire OS clears classic TCP ADB and
+wireless-debugging state across reboot. No reliable non-root self-bootstrap path
+was found. USB/ADB or another already-running control channel is still required
+for recovery.
+
+The `adb_enabled=0` then `=1` experiment is unsafe: the first write killed the
+only shell before the second command could run. Do not repeat it without an
+explicit recovery plan.
+
+## FIRERPA conclusions
+
+- hd8 is binary-compatible with the current official v10 arm64 server. Its
+  failure mode was lifecycle/transport, not a need for a rebuilt closed server.
+- p7a is genuinely incompatible with the current server. The only rebuild
+  request opened is [firerpa/lamda#147](https://github.com/firerpa/lamda/issues/147).
+  Upstream said a future version will support Android 17/16KB page size; retest
+  only after a concrete release exists.
+- The release20 Shizuku APK was built and installed on hd8, but was not tagged
+  or published through the normal distribution path.
+
+## Loose ends and operator prompts
+
+Prompt these in this order:
+
+1. **Issue #50 ownership decisions:** dashboard ownership; Eternal Terminal/SSH
+   CA; CFEngine retention; VLM site-versus-private ownership; generic app
+   defaults versus site catalog; public research provenance; and generic
+   peer-help protocol versus site-only feature.
+2. **Shizuku release distribution:** decide whether release20 should receive a
+   tag/GitHub release and be added to the normal APK/Obtainium path.
+3. **p7a FIRERPA:** wait for a compatible upstream release, then retest and
+   update the inventory classification.
+4. **F1 FIRERPA MCP bridge (#46):** implementation awaits operator approval and
+   the consent-surface choice (local dialog/notifications first versus MCP
+   elicitation).
+5. **Observability:** [#44](https://github.com/djbclark/stayturgid/issues/44)
+   (OpenObserve↔Vector 401) blocks [#47](https://github.com/djbclark/stayturgid/issues/47)
+   (Grafana/portal follow-ons).
+6. **K1 residuals:** [#43](https://github.com/djbclark/stayturgid/issues/43)
+   and [#45](https://github.com/djbclark/stayturgid/issues/45) still need
+   native-agent cutover verification, soak evidence, and signed-release
+   decisions.
+7. **Stale backlog:** triage H1/H3, B63/B64, T2/T4, and settings issues
+   #41/#42/#16; several may be latent or superseded by K1.
+
+## Next-session hygiene
+
+At start, inspect all four worktrees with `git status --short --branch`, verify
+the active remotes, and read this handoff plus `docs/STATUS.md`. Preserve the
+dirty Shizuku `api` submodule. Do not merge or publish anything until the
+operator has answered the applicable prompt above and the relevant checks are
+green.


### PR DESCRIPTION
## Summary

- publish a public, self-contained session handoff for the next AI/operator
- record current FIRERPA, Fire OS, Shizuku, device, and ownership-audit state
- make the unresolved operator decisions explicit instead of hiding them in a private overlay
- repair malformed Ansible module documentation exposed by the handoff validation hook

## Verification

- `markdownlint` on the changed documentation
- `git diff --check`
- full pre-commit suite, including ruff, mypy, ansible-lint, bandit, semgrep, and secret detection

The handoff is intentionally public so a future AI can resume from the repository without access to private files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified fleet-profile behavior in the Shizuku startup module documentation.
  * Updated operational status, fleet health, workstreams, and operator action items.
  * Added a complete operational handoff covering device verification, compatibility findings, ownership decisions, and next-session checks.
  * Updated handoff guidance to direct operators to the latest complete baton document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->