### PR TITLE
release: advance ops suite to 1.0.2

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.0.1"
+  "version": "1.0.2"
 }


### PR DESCRIPTION
## Summary
- Bump `ops-release.json` to **1.0.2**.
- Includes post-1.0.1 master: agent boot-stability / 0.6.0-boot-stability.
- Coordinated with site-djbclark + site-private.