### PR TITLE
release: advance ops suite to 1.0.3

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.0.2"
+  "version": "1.0.3"
 }


### PR DESCRIPTION
Advance the coordinated ops suite version to **1.0.3** for the stayturgid repository.

This is the version-bump PR of a coordinated three-repo release (stayturgid, site-djbclark, site-private), all tagged `ops-v1.0.3`.

## What ships in 1.0.3 (stayturgid)
Merged in #72 — normal fleet deploy now converges desired state:
- Immutable bootstrap APK locks (release tag, asset filename, versionName, SHA-256); native agent locked to agent-v0.6.0 / 0.6.0-boot-stability.
- APK ensure-before-verify ordering for factory-reset convergence (documented + regression-tested).
- Stale/incompatible APK reinstall with data-preserving upgrade then visible clean fallback.
- Native-agent peer reconciliation, headless trigger, HostService verification with async retry.
- Headless Obtainium catalog import during the main fleet pass; ops-locked apps exempt from background updates.
- Single fleet-role pass; legacy UI-driven Obtainium import removed.
- Healing coverage: 33 desired states, 7 mechanisms.

## This PR's diff
- `ops-release.json`: `1.0.2` → `1.0.3` (one line).

Merge is gated on operator confirmation per the coordinated-release contract (docs/OPS-RELEASES.md). Tag + GitHub Release follow only after all three version-bump PRs merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application release version from 1.0.2 to 1.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->