### PR TITLE
fix(agent): suppress Tailscale GUI launch, reap stale UserServices, unify Fire OS target reminder (#64, #65, #66)

### DIFF
--- a/control/tools/native-agent/provision_peer.py
+++ b/control/tools/native-agent/provision_peer.py
@@ -117,24 +117,26 @@ def set_target_reminder(target: str) -> None:
     """Best-effort: drop the 'approve the Allow dialog' marker on a target device
     so its own agent nags the operator standing at it. The peer clears the marker
     automatically over the authorized connection once peer-start succeeds.
-
-    Needs the Mac to be able to adb-reach the target (same host:port the peer
-    uses); silently skips if not reachable.
     """
+    resolved_target = adb.resolve_target(target) if target else target
     try:
-        adb.run([adb.adb_bin(), "connect", target], timeout=15)
+        adb.run([adb.adb_bin(), "connect", resolved_target], timeout=15)
     except Exception:  # noqa: BLE001
         pass
     ok = False
     for pkg in AGENT_PKGS:
-        d = f"/sdcard/Android/data/{pkg}/files"
-        r = adb.adb(target, "shell", f"mkdir -p {d} && : > {d}/{REMINDER_FILE} && echo OK")
+        r = adb.adb(
+            resolved_target,
+            "shell",
+            f"run-as {pkg} touch files/{REMINDER_FILE} 2>/dev/null || "
+            f"(d=/sdcard/Android/data/{pkg}/files && mkdir -p $d && : > $d/{REMINDER_FILE}) && echo OK",
+        )
         if "OK" in (r.stdout or ""):
             ok = True
     if ok:
-        print(f"  target reminder set on {target} (agent there will prompt to approve)")
+        print(f"  target reminder set on {resolved_target} (agent there will prompt to approve)")
     else:
-        print(f"  note: could not set target reminder on {target} (adb-unreachable?) — skipping")
+        print(f"  note: could not set target reminder on {resolved_target} (adb-unreachable?) — skipping")
 
 
 def trigger_start(serial: str) -> int:

--- a/control/tools/native-agent/start_agent.py
+++ b/control/tools/native-agent/start_agent.py
@@ -44,6 +44,12 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Starting native-agent on {serial} ({component})...")
     # Force-stop first so FGS + UserService restart cleanly after freezes.
     adb.adb(serial, "shell", f"am force-stop {pkg}")
+    # Stop any stale UserService processes (which run as UID 2000 under Shizuku and survive force-stop)
+    for p in (PKG_DEBUG, PKG_RELEASE):
+        stale = adb.adb(serial, "shell", f"pidof {p}:userservice").stdout or ""
+        pids = [pid for pid in stale.strip().split() if pid.isdigit()]
+        if pids:
+            adb.adb(serial, "shell", f"kill {' '.join(pids)}")
     time.sleep(1)
     r = adb.adb(serial, "shell", f"am start -n {component}")
     if r.returncode != 0:

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/AuthorizeReminder.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/AuthorizeReminder.kt
@@ -21,20 +21,24 @@ object AuthorizeReminder {
 
     /** True if this device has been asked to prompt for peer-start approval. */
     fun isPresent(context: Context): Boolean {
-        val dir = context.getExternalFilesDir(null) ?: return false
-        return File(dir, FILE_NAME).exists()
+        if (File(context.filesDir, FILE_NAME).exists()) return true
+        val extDir = context.getExternalFilesDir(null) ?: return false
+        return File(extDir, FILE_NAME).exists()
     }
 
     fun clear(context: Context) {
-        val dir = context.getExternalFilesDir(null) ?: return
-        runCatching { File(dir, FILE_NAME).delete() }
+        runCatching { File(context.filesDir, FILE_NAME).delete() }
+        val extDir = context.getExternalFilesDir(null) ?: return
+        runCatching { File(extDir, FILE_NAME).delete() }
     }
 
     /**
      * A shell command a peer runs on the target (over ADB, uid 2000) to remove the marker for
-     * whichever agent build is installed. Package-independent and idempotent.
+     * whichever agent build is installed. Uses run-as for internal storage (Fire OS compatible)
+     * with external storage fallback. Package-independent and idempotent.
      */
     fun clearCommand(): String =
-        AGENT_PACKAGES.joinToString(" ") { "/sdcard/Android/data/$it/files/$FILE_NAME" }
-            .let { "rm -f $it" }
+        AGENT_PACKAGES.joinToString("; ") { pkg ->
+            "run-as $pkg rm -f files/$FILE_NAME 2>/dev/null; rm -f /sdcard/Android/data/$pkg/files/$FILE_NAME 2>/dev/null"
+        }
 }

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/CatastrophicRepair.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/CatastrophicRepair.kt
@@ -183,9 +183,15 @@ object CatastrophicRepair {
             return Result(policyOk, detail)
         }
 
-        // Activity launch is a best-effort prompt/fallback. It may need an
-        // unlocked screen and operator input, so success is still determined
-        // only by a fresh tunnel + Tailscale control-plane probe.
+        // Activity launch is a best-effort prompt/fallback. It requires an
+        // unlocked screen and operator input. Never foreground the GUI if the
+        // VPN tunnel interface is actually up (e.g. transient control-plane ping failure).
+        if (ComonitorProbes.isTailscaleTunnelUp()) {
+            val detail = "tailscale tunnel up; control-plane probe flaky (GUI launch suppressed)"
+            appendLog("[agent] $detail")
+            return Result(policyOk, detail)
+        }
+
         shellOut(arrayOf("am", "start", "-n", TAILSCALE_COMPONENT), 8)
         val restored = waitForTailscaleUp(attempts = 3)
         val detail =

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/ComonitorProbes.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/ComonitorProbes.kt
@@ -73,15 +73,18 @@ object ComonitorProbes {
         )
     }
 
+    fun isTailscaleTunnelUp(): Boolean {
+        val netDev = readText("/proc/net/dev").orEmpty()
+        return netDev.lineSequence().any { line ->
+            val iface = line.substringBefore(':').trim()
+            iface == "tun0" || iface == "tailscale0"
+        }
+    }
+
     private fun probeTailscale(): String {
         val installed = shellOut(arrayOf("pm", "path", TAILSCALE_PACKAGE), 4)
         if (installed.isNullOrBlank() || !installed.contains("package:")) return "skip"
-        val netDev = readText("/proc/net/dev").orEmpty()
-        val tunnelUp =
-            netDev.lineSequence().any { line ->
-                val iface = line.substringBefore(':').trim()
-                iface == "tun0" || iface == "tailscale0"
-            }
+        val tunnelUp = isTailscaleTunnelUp()
         val controlPlaneUp =
             commandOk(arrayOf("ping", "-c", "1", "-W", "2", TAILSCALE_CONTROL_HOST), 4)
         return if (tunnelUp && controlPlaneUp) "up" else "down"

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/HostService.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/HostService.kt
@@ -51,7 +51,8 @@ class HostService : Service() {
             .daemon(true)
             .processNameSuffix("userservice")
             .debuggable(BuildConfig.DEBUG)
-            .version(BuildConfig.VERSION_CODE)
+            // Pin version to 1 so Shizuku dedupes the daemon service across app upgrades (#65)
+            .version(1)
             .tag("stayturgid-agent")
     }
 

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/ShizukuUserService.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/ShizukuUserService.kt
@@ -2,6 +2,7 @@ package org.stayturgid.agent
 
 import android.content.Context
 import android.hardware.input.InputManager
+import android.os.Process
 import android.os.SystemClock
 import android.util.Log
 import android.view.InputDevice
@@ -10,6 +11,7 @@ import android.view.KeyCharacterMap
 import android.view.KeyEvent
 import androidx.annotation.Keep
 import java.lang.reflect.Method
+import java.util.concurrent.TimeUnit
 
 /**
  * Runs as UID 2000 (shell) under Shizuku. No non-SDK restrictions.
@@ -22,6 +24,7 @@ class ShizukuUserService : IStayTurgidService.Stub {
 
     constructor() {
         Log.i(TAG, "constructor")
+        reapStaleUserServices()
     }
 
     /**
@@ -32,6 +35,7 @@ class ShizukuUserService : IStayTurgidService.Stub {
     constructor(context: Context) {
         appContext = context.applicationContext ?: context
         Log.i(TAG, "constructor with Context: $context")
+        reapStaleUserServices()
     }
 
     override fun destroy() {
@@ -194,6 +198,26 @@ class ShizukuUserService : IStayTurgidService.Stub {
                 )
         match.isAccessible = true
         return match
+    }
+
+    private fun reapStaleUserServices() {
+        val myPid = Process.myPid()
+        val pkgs = arrayOf("org.stayturgid.agent", "org.stayturgid.agent.debug")
+        for (pkg in pkgs) {
+            try {
+                val p = ProcessBuilder("pidof", "$pkg:userservice").redirectErrorStream(true).start()
+                if (p.waitFor(2, TimeUnit.SECONDS)) {
+                    val out = p.inputStream.bufferedReader().readText().trim()
+                    val pids = out.split(Regex("\\s+")).mapNotNull { it.toIntOrNull() }.filter { it != myPid }
+                    if (pids.isNotEmpty()) {
+                        Log.i(TAG, "Reaping ${pids.size} stale UserService pid(s): $pids (my pid: $myPid)")
+                        ProcessBuilder("kill", *pids.map { it.toString() }.toTypedArray()).start()
+                    }
+                }
+            } catch (t: Throwable) {
+                Log.w(TAG, "reapStaleUserServices failed for $pkg: ${t.message}")
+            }
+        }
     }
 
     companion object {

--- a/device/native-agent/app/src/test/kotlin/org/stayturgid/agent/AuthorizeReminderTest.kt
+++ b/device/native-agent/app/src/test/kotlin/org/stayturgid/agent/AuthorizeReminderTest.kt
@@ -9,7 +9,8 @@ class AuthorizeReminderTest {
     @Test
     fun clearCommandRemovesBothAgentBuildsMarkers() {
         val cmd = AuthorizeReminder.clearCommand()
-        assertTrue(cmd.startsWith("rm -f "))
+        assertTrue(cmd.contains("run-as org.stayturgid.agent rm -f files/authorize_reminder"))
+        assertTrue(cmd.contains("run-as org.stayturgid.agent.debug rm -f files/authorize_reminder"))
         assertTrue(
             cmd.contains("/sdcard/Android/data/org.stayturgid.agent/files/authorize_reminder")
         )

--- a/tests/python/test_native_agent_start.py
+++ b/tests/python/test_native_agent_start.py
@@ -1,0 +1,41 @@
+"""Unit tests for native-agent start script."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "control" / "tools" / "native-agent" / "start_agent.py"
+SPEC = importlib.util.spec_from_file_location("start_agent", MODULE_PATH)
+assert SPEC and SPEC.loader
+start_agent = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(start_agent)
+
+
+def test_start_agent_kills_stale_user_services(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_adb(serial, *args):
+        cmd = ["adb", "-s", serial, *args]
+        calls.append(cmd)
+        if "pm path" in " ".join(args):
+            return SimpleNamespace(returncode=0, stdout="package:org.stayturgid.agent.debug\n", stderr="")
+        if "pidof org.stayturgid.agent.debug:userservice" in " ".join(args):
+            return SimpleNamespace(returncode=0, stdout="301 302\n", stderr="")
+        if "pidof org.stayturgid.agent:userservice" in " ".join(args):
+            return SimpleNamespace(returncode=0, stdout="\n", stderr="")
+        if "pidof org.stayturgid.agent.debug" in " ".join(args):
+            return SimpleNamespace(returncode=0, stdout="101\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="OK\n", stderr="")
+
+    monkeypatch.setattr(start_agent.adb, "resolve_target", lambda t: t)
+    monkeypatch.setattr(start_agent.adb, "adb", fake_adb)
+    monkeypatch.setattr(start_agent.time, "sleep", lambda _s: None)
+
+    exit_code = start_agent.main(["s24"])
+    assert exit_code == 0
+    kill_calls = [call for call in calls if any("kill" in part for part in call)]
+    assert len(kill_calls) == 1
+    assert kill_calls[0] == ["adb", "-s", "s24", "shell", "kill 301 302"]


### PR DESCRIPTION
## Summary
- **Tailscale GUI Foregrounding Fix (#64)**: Expose `isTailscaleTunnelUp()` in `ComonitorProbes.kt` and gate `CatastrophicRepair.kt`'s `am start` activity launch so it never foregrounds the Tailscale GUI when the VPN tunnel (`tun0`/`tailscale0`) is up and control-plane pings are transiently failing.
- **Shizuku UserService Leak (#65)**: Pin `userServiceArgs.version(1)` in `HostService.kt` so Shizuku daemon registration keys remain stable across version bumps. Add self-reaping of stale `:userservice` PIDs in `ShizukuUserService.kt` upon startup, and stop stale `:userservice` PIDs in `start_agent.py`. Added test `test_native_agent_start.py`.
- **Fire OS Target Reminder Marker (#66)**: Standardize `AuthorizeReminder.kt` on internal `filesDir` (app-private) with `run-as` execution across Fire OS and stock Android, keeping external storage fallback. Update `provision_peer.py` target resolution and marker setup.

## Verification
- `just check`: PASS (21/21 ok)
- `just test`: PASS (585 passed, 1 skipped, 137 collection unit tests passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization reminder marker detection and clearing across internal and external app storage.
  * Agent startup now removes leftover user-service processes before launching the agent.
  * VPN recovery now avoids redundant UI fallback when the tunnel is already active.
  * Enhanced device target resolution and connectivity during provisioning.
* **Reliability**
  * Improved Tailscale tunnel status detection and reduced recovery flakiness.
  * Added cleanup of stale Shizuku user-service processes during initialization.
* **Tests**
  * Added a unit test covering stale user-service shutdown during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->