### PR TITLE
fix(android_common): systemically wrap all adb and external commands with timeouts (#59)

### DIFF
--- a/ansible_collections/stayturgid/android_common/plugins/module_utils/adb_resolve.py
+++ b/ansible_collections/stayturgid/android_common/plugins/module_utils/adb_resolve.py
@@ -41,13 +41,31 @@ def device_row(alias, conf_path=None):
     return None
 
 
+try:
+    from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_timeout import (
+        DEFAULT_FAST_TIMEOUT,
+        run_command_with_timeout,
+    )
+except ImportError:
+    import os
+    import sys
+
+    _mod_dir = os.path.dirname(os.path.abspath(__file__))
+    if _mod_dir not in sys.path:
+        sys.path.insert(0, _mod_dir)
+    from adb_timeout import (
+        DEFAULT_FAST_TIMEOUT,
+        run_command_with_timeout,
+    )
+
+
 def normalize_adb_output(text):
     return (text or "").replace("\r", "").strip()
 
 
-def adb_devices_output(run_command):
+def adb_devices_output(run_command, timeout=DEFAULT_FAST_TIMEOUT):
     """Return adb devices text; run_command is module.run_command or similar."""
-    rc, out, _err = run_command(["adb", "devices"])
+    rc, out, _err = run_command_with_timeout(run_command, ["adb", "devices"], timeout=timeout)
     return (out or "") if rc == 0 else ""
 
 
@@ -82,7 +100,7 @@ def tcp_reachable(endpoint, timeout=CONNECT_PROBE_TIMEOUT):
         return False
 
 
-def connect_wireless(run_command, endpoint, *, require_probe=True):
+def connect_wireless(run_command, endpoint, *, require_probe=True, timeout=DEFAULT_FAST_TIMEOUT):
     """``adb connect`` to host:port. TCP probe is optional (mDNS wireless-debug
     often fails a plain socket probe but still accepts ``adb connect``).
     """
@@ -90,8 +108,8 @@ def connect_wireless(run_command, endpoint, *, require_probe=True):
         return False
     if require_probe and not tcp_reachable(endpoint):
         return False
-    run_command(["adb", "connect", endpoint])
-    return adb_online(adb_devices_output(run_command), endpoint)
+    run_command_with_timeout(run_command, ["adb", "connect", endpoint], timeout=timeout)
+    return adb_online(adb_devices_output(run_command, timeout=timeout), endpoint)
 
 
 def adb_device_id(line):
@@ -113,7 +131,7 @@ def transport_rank(candidate):
     return 2
 
 
-def match_usb_serial(run_command, usb_serial, devices):
+def match_usb_serial(run_command, usb_serial, devices, timeout=DEFAULT_FAST_TIMEOUT):
     """Return connected adb target matching USB serial (direct or ro.serialno)."""
     if not usb_serial or usb_serial == "-":
         return None
@@ -125,7 +143,11 @@ def match_usb_serial(run_command, usb_serial, devices):
         if candidate == usb_serial:
             matches.append(candidate)
             continue
-        rc, out, _err = run_command(["adb", "-s", candidate, "shell", "getprop", "ro.serialno"])
+        rc, out, _err = run_command_with_timeout(
+            run_command,
+            ["adb", "-s", candidate, "shell", "getprop", "ro.serialno"],
+            timeout=timeout,
+        )
         if rc == 0 and normalize_adb_output(out) == usb_serial:
             matches.append(candidate)
     if not matches:
@@ -150,7 +172,7 @@ def static_fallback(row, alias):
     return alias
 
 
-def discover_mdns_endpoint(run_command, usb_serial):
+def discover_mdns_endpoint(run_command, usb_serial, timeout=DEFAULT_FAST_TIMEOUT):
     """Wireless-debugging mDNS ``host:port`` for a USB serial (Fire / modern ADB).
 
     ``adb mdns services`` lines look like::
@@ -161,7 +183,7 @@ def discover_mdns_endpoint(run_command, usb_serial):
     """
     if not usb_serial or usb_serial == "-":
         return None
-    rc, out, _err = run_command(["adb", "mdns", "services"])
+    rc, out, _err = run_command_with_timeout(run_command, ["adb", "mdns", "services"], timeout=timeout)
     if rc != 0:
         return None
     needle = "adb-%s" % usb_serial

--- a/ansible_collections/stayturgid/android_common/plugins/module_utils/adb_shell.py
+++ b/ansible_collections/stayturgid/android_common/plugins/module_utils/adb_shell.py
@@ -6,19 +6,37 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
+try:
+    from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_timeout import (
+        DEFAULT_FAST_TIMEOUT,
+        run_command_with_timeout,
+    )
+except ImportError:
+    import os
+    import sys
+
+    _mod_dir = os.path.dirname(os.path.abspath(__file__))
+    if _mod_dir not in sys.path:
+        sys.path.insert(0, _mod_dir)
+    from adb_timeout import (
+        DEFAULT_FAST_TIMEOUT,
+        run_command_with_timeout,
+    )
+
+
 def normalize_adb_output(text):
     return (text or "").replace("\r", "").strip()
 
 
-def adb_connect(run_command, device):
+def adb_connect(run_command, device, timeout=DEFAULT_FAST_TIMEOUT):
     """Best-effort adb connect; ignored for USB serials."""
     if ":" not in device:
         return 0, "", ""
-    return run_command(["adb", "connect", device])
+    return run_command_with_timeout(run_command, ["adb", "connect", device], timeout=timeout)
 
 
-def adb_shell(run_command, device, shell_cmd):
-    return run_command(["adb", "-s", device, "shell", shell_cmd])
+def adb_shell(run_command, device, shell_cmd, timeout=DEFAULT_FAST_TIMEOUT):
+    return run_command_with_timeout(run_command, ["adb", "-s", device, "shell", shell_cmd], timeout=timeout)
 
 
 def package_installed(run_command, device, package):

--- a/ansible_collections/stayturgid/android_common/plugins/module_utils/adb_timeout.py
+++ b/ansible_collections/stayturgid/android_common/plugins/module_utils/adb_timeout.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""Command execution with systemic timeout support for stayturgid.android_common modules."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import os
+
+# Default timeout durations in seconds
+DEFAULT_FAST_TIMEOUT = 30  # Fast queries: adb devices, adb connect, adb shell getprop, pm list, settings
+DEFAULT_SLOW_TIMEOUT = 180  # Slow transfers/installs: adb push, adb install, gh release download, apksigner sign
+
+_CACHED_TIMEOUT_BIN = None
+
+
+def resolve_timeout_bin(get_bin_path_fn=None):
+    """Find local coreutils `timeout` binary path or return None if missing."""
+    global _CACHED_TIMEOUT_BIN
+    if _CACHED_TIMEOUT_BIN is not None:
+        return _CACHED_TIMEOUT_BIN
+
+    bin_path = None
+    if get_bin_path_fn is not None:
+        try:
+            bin_path = get_bin_path_fn("timeout")
+        except Exception:
+            bin_path = None
+
+    if not bin_path:
+        for candidate in ("/opt/homebrew/bin/timeout", "/usr/bin/timeout", "/bin/timeout"):
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                bin_path = candidate
+                break
+
+    if bin_path:
+        _CACHED_TIMEOUT_BIN = bin_path
+    return bin_path
+
+
+def run_command_with_timeout(run_command_fn, cmd, timeout=DEFAULT_FAST_TIMEOUT, get_bin_path_fn=None):
+    """Execute cmd via run_command_fn, prefixing with `timeout <seconds>` if available.
+
+    Handles returncode 124 (coreutils timeout command timeout) by returning
+    rc=124 and appending an explicit error message to stderr.
+    """
+    timeout_bin = resolve_timeout_bin(get_bin_path_fn=get_bin_path_fn)
+
+    exec_cmd = list(cmd)
+    if timeout_bin and timeout and timeout > 0 and (not exec_cmd or exec_cmd[0] != timeout_bin):
+        exec_cmd = [timeout_bin, str(int(timeout))] + exec_cmd
+
+    rc, out, err = run_command_fn(exec_cmd)
+    if rc == 124:
+        timeout_msg = "ADB command timed out after %ds: %s" % (timeout, " ".join(cmd))
+        err = (err + "\n" if err else "") + timeout_msg
+    return rc, out, err

--- a/ansible_collections/stayturgid/android_common/plugins/module_utils/autojs6_deploy_util.py
+++ b/ansible_collections/stayturgid/android_common/plugins/module_utils/autojs6_deploy_util.py
@@ -11,6 +11,23 @@ import tempfile
 
 from ansible_collections.stayturgid.android_common.plugins.module_utils import adb_shell
 
+try:
+    from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_timeout import (
+        DEFAULT_SLOW_TIMEOUT,
+        run_command_with_timeout,
+    )
+except ImportError:
+    import os
+    import sys
+
+    _mod_dir = os.path.dirname(os.path.abspath(__file__))
+    if _mod_dir not in sys.path:
+        sys.path.insert(0, _mod_dir)
+    from adb_timeout import (
+        DEFAULT_SLOW_TIMEOUT,
+        run_command_with_timeout,
+    )
+
 DEFAULT_TARGET = "/sdcard/stayturgid/autojs6"
 DEFAULT_DEVICE_JSON_DEST = "/sdcard/stayturgid/state/device.json"
 
@@ -52,8 +69,8 @@ def verify_deploy(run_command, device, target):
     )
 
 
-def adb_push(run_command, device, local, remote):
-    return run_command(["adb", "-s", device, "push", str(local), remote])
+def adb_push(run_command, device, local, remote, timeout=DEFAULT_SLOW_TIMEOUT):
+    return run_command_with_timeout(run_command, ["adb", "-s", device, "push", str(local), remote], timeout=timeout)
 
 
 def _staged_dir_without_ts_sources(local_dir):

--- a/ansible_collections/stayturgid/android_common/plugins/modules/android_apk.py
+++ b/ansible_collections/stayturgid/android_common/plugins/modules/android_apk.py
@@ -188,6 +188,24 @@ def download_url(module, url):
     return tmp.name
 
 
+try:
+    from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_timeout import (
+        DEFAULT_SLOW_TIMEOUT,
+        run_command_with_timeout,
+    )
+except ImportError:
+    import os
+    import sys
+
+    _mod_utils = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "module_utils")
+    if _mod_utils not in sys.path:
+        sys.path.insert(0, _mod_utils)
+    from adb_timeout import (
+        DEFAULT_SLOW_TIMEOUT,
+        run_command_with_timeout,
+    )
+
+
 def download_gh_release(module, repo, pattern, tag):
     gh = module.get_bin_path("gh", required=True)
     destdir = tempfile.mkdtemp(dir=module.tmpdir)
@@ -195,7 +213,12 @@ def download_gh_release(module, repo, pattern, tag):
     if tag:
         cmd.append(tag)
     cmd += ["--repo", repo, "--pattern", pattern or "*.apk", "--dir", destdir]
-    rc, _out, err = module.run_command(cmd)
+    rc, _out, err = run_command_with_timeout(
+        module.run_command,
+        cmd,
+        timeout=DEFAULT_SLOW_TIMEOUT,
+        get_bin_path_fn=module.get_bin_path,
+    )
     if rc != 0:
         module.fail_json(msg="gh release download failed: %s" % err.strip())
     apks = sorted(f for f in os.listdir(destdir) if f.lower().endswith(".apk"))
@@ -251,7 +274,12 @@ def resign_apk(module, apk_path):
         key_alias,
         apk_path,
     ]
-    rc, _out, err = module.run_command(cmd)
+    rc, _out, err = run_command_with_timeout(
+        module.run_command,
+        cmd,
+        timeout=DEFAULT_SLOW_TIMEOUT,
+        get_bin_path_fn=module.get_bin_path,
+    )
     if rc != 0:
         module.fail_json(msg="apksigner sign failed: %s" % err.strip())
 

--- a/ansible_collections/stayturgid/android_common/plugins/modules/shizuku_grant.py
+++ b/ansible_collections/stayturgid/android_common/plugins/modules/shizuku_grant.py
@@ -73,6 +73,23 @@ from ansible_collections.stayturgid.android_common.plugins.module_utils.shizuku 
     patch_shizuku_json,
 )
 
+try:
+    from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_timeout import (
+        DEFAULT_SLOW_TIMEOUT,
+        run_command_with_timeout,
+    )
+except ImportError:
+    import os
+    import sys
+
+    _mod_utils = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "module_utils")
+    if _mod_utils not in sys.path:
+        sys.path.insert(0, _mod_utils)
+    from adb_timeout import (
+        DEFAULT_SLOW_TIMEOUT,
+        run_command_with_timeout,
+    )
+
 
 def read_shizuku_json(run_command, device, path):
     """(text, ok). Missing file is ok (fresh config); unreadable is not."""
@@ -91,7 +108,12 @@ def push_shizuku_json(module, device, content, staging, path):
     try:
         tmp.write(content)
         tmp.close()
-        rc, _out, err = module.run_command(["adb", "-s", device, "push", tmp.name, staging])
+        rc, _out, err = run_command_with_timeout(
+            module.run_command,
+            ["adb", "-s", device, "push", tmp.name, staging],
+            timeout=DEFAULT_SLOW_TIMEOUT,
+            get_bin_path_fn=module.get_bin_path,
+        )
         if rc != 0:
             return False, "adb push failed: %s" % normalize_adb_output(err)
     finally:

--- a/ansible_collections/stayturgid/android_common/plugins/modules/shizuku_start.py
+++ b/ansible_collections/stayturgid/android_common/plugins/modules/shizuku_start.py
@@ -142,6 +142,24 @@ def start_native(run_command, device, libdir, pkg=SHIZUKU_PKG):
     return adb_shell(run_command, device, cmd)
 
 
+try:
+    from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_timeout import (
+        DEFAULT_SLOW_TIMEOUT,
+        run_command_with_timeout,
+    )
+except ImportError:
+    import os
+    import sys
+
+    _mod_utils = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "module_utils")
+    if _mod_utils not in sys.path:
+        sys.path.insert(0, _mod_utils)
+    from adb_timeout import (
+        DEFAULT_SLOW_TIMEOUT,
+        run_command_with_timeout,
+    )
+
+
 def push_fleet_profile(module, device, profile):
     import json
     import os
@@ -152,7 +170,12 @@ def push_fleet_profile(module, device, profile):
     try:
         tmp.write(content)
         tmp.close()
-        rc, _out, err = module.run_command(["adb", "-s", device, "push", tmp.name, FLEET_PROFILE_PATH])
+        rc, _out, err = run_command_with_timeout(
+            module.run_command,
+            ["adb", "-s", device, "push", tmp.name, FLEET_PROFILE_PATH],
+            timeout=DEFAULT_SLOW_TIMEOUT,
+            get_bin_path_fn=module.get_bin_path,
+        )
         if rc != 0:
             return False, "push fleet profile failed: %s" % normalize_adb_output(err)
     finally:

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/module_utils/test_adb_resolve.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/module_utils/test_adb_resolve.py
@@ -13,6 +13,8 @@ def _listing(*lines):
     """Fake run_command: 'adb devices' returns lines; connect/shell succeed."""
 
     def run(cmd):
+        if len(cmd) >= 2 and cmd[0].endswith("timeout"):
+            cmd = cmd[2:]
         if cmd[:2] == ["adb", "devices"]:
             return 0, ("\n".join(lines) + "\n") if lines else "", ""
         if cmd[:2] == ["adb", "connect"]:
@@ -72,6 +74,8 @@ def test_match_usb_serial_mdns_id_with_spaces(tmp_path):
     listing = "adb-EXAMPLE-SERIAL-STOCK-JIE0Dg (2)._adb-tls-connect._tcp\tdevice\n100.0.0.12:5555\tdevice\n"
 
     def run(cmd):
+        if len(cmd) >= 2 and cmd[0].endswith("timeout"):
+            cmd = cmd[2:]
         if cmd[:2] == ["adb", "devices"]:
             return 0, listing, ""
         if len(cmd) >= 5 and cmd[:2] == ["adb", "-s"] and cmd[3] == "shell":
@@ -106,8 +110,9 @@ def test_connect_wireless_connects_when_reachable(monkeypatch):
     calls = []
 
     def run(cmd):
-        calls.append(cmd)
-        if cmd[:2] == ["adb", "devices"]:
+        raw_cmd = cmd[2:] if len(cmd) >= 2 and cmd[0].endswith("timeout") else cmd
+        calls.append(raw_cmd)
+        if raw_cmd[:2] == ["adb", "devices"]:
             return 0, "192.0.2.9:5555\tdevice\n", ""
         return 0, "", ""
 
@@ -121,8 +126,9 @@ def test_resolve_gates_connect_behind_probe(tmp_path, monkeypatch):
     seen = []
 
     def run(cmd):
-        seen.append(cmd)
-        if cmd[:2] == ["adb", "devices"]:
+        raw_cmd = cmd[2:] if len(cmd) >= 2 and cmd[0].endswith("timeout") else cmd
+        seen.append(raw_cmd)
+        if raw_cmd[:2] == ["adb", "devices"]:
             if any(c[:2] == ["adb", "connect"] for c in seen):
                 return 0, "100.0.0.12:5555\tdevice\n", ""
             return 0, "", ""

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/module_utils/test_adb_timeout.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/module_utils/test_adb_timeout.py
@@ -1,0 +1,69 @@
+"""Unit tests for the adb_timeout module_util (systemic command timeout wrapper)."""
+
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..", ".."))
+sys.path.insert(0, os.path.join(ROOT, "plugins", "module_utils"))
+
+import adb_timeout as at
+
+
+def test_resolve_timeout_bin():
+    bin_path = at.resolve_timeout_bin()
+    assert bin_path is not None
+    assert os.path.isfile(bin_path)
+
+
+def test_run_command_with_timeout_prefixes_command(monkeypatch):
+    monkeypatch.setattr(at, "resolve_timeout_bin", lambda get_bin_path_fn=None: "/usr/bin/timeout")
+    calls = []
+
+    def fake_run(cmd):
+        calls.append(cmd)
+        return 0, "ok", ""
+
+    rc, out, err = at.run_command_with_timeout(fake_run, ["adb", "devices"], timeout=30)
+    assert rc == 0
+    assert out == "ok"
+    assert calls == [["/usr/bin/timeout", "30", "adb", "devices"]]
+
+
+def test_run_command_with_timeout_handles_rc_124(monkeypatch):
+    monkeypatch.setattr(at, "resolve_timeout_bin", lambda get_bin_path_fn=None: "/usr/bin/timeout")
+
+    def fake_run(cmd):
+        return 124, "", "initial stderr"
+
+    rc, out, err = at.run_command_with_timeout(fake_run, ["adb", "install", "app.apk"], timeout=180)
+    assert rc == 124
+    assert "ADB command timed out after 180s: adb install app.apk" in err
+    assert "initial stderr" in err
+
+
+def test_run_command_with_timeout_prevents_double_wrapping(monkeypatch):
+    monkeypatch.setattr(at, "resolve_timeout_bin", lambda get_bin_path_fn=None: "/usr/bin/timeout")
+    calls = []
+
+    def fake_run(cmd):
+        calls.append(cmd)
+        return 0, "", ""
+
+    already_wrapped = ["/usr/bin/timeout", "60", "adb", "shell", "getprop"]
+    rc, out, err = at.run_command_with_timeout(fake_run, already_wrapped, timeout=30)
+    assert rc == 0
+    assert calls == [already_wrapped]
+
+
+def test_run_command_with_timeout_when_no_timeout_bin(monkeypatch):
+    monkeypatch.setattr(at, "resolve_timeout_bin", lambda get_bin_path_fn=None: None)
+    calls = []
+
+    def fake_run(cmd):
+        calls.append(cmd)
+        return 0, "output", ""
+
+    rc, out, err = at.run_command_with_timeout(fake_run, ["adb", "devices"], timeout=30)
+    assert rc == 0
+    assert out == "output"
+    assert calls == [["adb", "devices"]]

--- a/tests/python/test_adb_resolve.py
+++ b/tests/python/test_adb_resolve.py
@@ -19,6 +19,8 @@ import stayturgid_device as dev
 
 def _devices_listing(*lines):
     def run(cmd):
+        if len(cmd) >= 2 and cmd[0].endswith("timeout"):
+            cmd = cmd[2:]
         if cmd[:2] == ["adb", "devices"]:
             return 0, "\n".join(lines) + "\n", ""
         if cmd[:2] == ["adb", "connect"]:
@@ -61,12 +63,13 @@ def test_resolve_adb_connects_wireless_when_needed(tmp_path, monkeypatch):
     seen = []
 
     def run(cmd):
-        seen.append(cmd)
-        if cmd[:2] == ["adb", "devices"]:
+        raw_cmd = cmd[2:] if len(cmd) >= 2 and cmd[0].endswith("timeout") else cmd
+        seen.append(raw_cmd)
+        if raw_cmd[:2] == ["adb", "devices"]:
             if any(c[:2] == ["adb", "connect"] for c in seen):
                 return 0, "100.0.0.12:5555\tdevice\n", ""
             return 0, "", ""
-        if cmd[:2] == ["adb", "connect"]:
+        if raw_cmd[:2] == ["adb", "connect"]:
             return 0, "connected", ""
         return 0, "", ""
 
@@ -106,18 +109,19 @@ def test_resolve_adb_prefers_mdns_wireless_debug(tmp_path, monkeypatch):
     seen = []
 
     def run(cmd):
-        seen.append(cmd)
-        if cmd[:2] == ["adb", "devices"]:
+        raw_cmd = cmd[2:] if len(cmd) >= 2 and cmd[0].endswith("timeout") else cmd
+        seen.append(raw_cmd)
+        if raw_cmd[:2] == ["adb", "devices"]:
             if any(c[:2] == ["adb", "connect"] for c in seen):
                 return 0, "192.0.2.68:39081\tdevice\n", ""
             return 0, "", ""
-        if cmd[:3] == ["adb", "mdns", "services"]:
+        if raw_cmd[:3] == ["adb", "mdns", "services"]:
             return (
                 0,
                 "adb-EXAMPLE-SERIAL-FIRE-Av5cQl_adb-tls-connect._tcp192.0.2.68:39081\n",
                 "",
             )
-        if cmd[:2] == ["adb", "connect"]:
+        if raw_cmd[:2] == ["adb", "connect"]:
             return 0, "connected", ""
         return 0, "", ""
 

--- a/tests/python/test_autojs6_deploy.py
+++ b/tests/python/test_autojs6_deploy.py
@@ -84,6 +84,8 @@ def test_deploy_excludes_ts_source_files(monkeypatch, tmp_path):
     staged_dir_contents: dict[str, list[str]] = {}
 
     def fake_run_command(cmd):
+        if len(cmd) >= 2 and cmd[0].endswith("timeout"):
+            cmd = cmd[2:]
         if len(cmd) >= 5 and cmd[3] == "push":
             local = Path(cmd[4])
             if local.is_dir():

--- a/tests/python/test_shell_libs.py
+++ b/tests/python/test_shell_libs.py
@@ -38,10 +38,13 @@ def test_resolve_adb_cli_usb_tailscale_and_dash_ts(tmp_path):
     adb = stubs / "adb"
     adb.write_text('#!/usr/bin/env bash\nif [ "$1" = "devices" ]; then printf "RFCX\\tdevice\\n"; fi\nexit 0\n')
     adb.chmod(0o755)
-    env = {
-        "PATH": f"{stubs}:{os.environ.get('PATH', '')}",
-        "STAYTURGID_DEVICES_CONF": str(conf),
-    }
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{stubs}:{os.environ.get('PATH', '')}",
+            "STAYTURGID_DEVICES_CONF": str(conf),
+        }
+    )
     cli = REPO / "control/lib/resolve_adb.py"
 
     r = subprocess.run([str(cli), "oneui-device"], capture_output=True, text=True, env=env, check=False)

--- a/tests/python/test_shizuku_device.py
+++ b/tests/python/test_shizuku_device.py
@@ -144,6 +144,8 @@ def test_resolve_adb_and_ssh_host(tmp_path, monkeypatch):
     conf.write_text("oneui-device RFCX 100.0.0.11 192.0.2.55\n")
 
     def fake_run(cmd, **kw):
+        if len(cmd) >= 2 and cmd[0].endswith("timeout"):
+            cmd = cmd[2:]
         if cmd[:2] == ["adb", "devices"]:
             return type("R", (), {"returncode": 0, "stdout": "RFCX\tdevice\n", "stderr": ""})()
         return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
@@ -152,6 +154,8 @@ def test_resolve_adb_and_ssh_host(tmp_path, monkeypatch):
     assert dev.resolve_adb("oneui-device", str(conf)) == "RFCX"
 
     def offline(cmd, **kw):
+        if len(cmd) >= 2 and cmd[0].endswith("timeout"):
+            cmd = cmd[2:]
         if cmd[:2] == ["adb", "devices"]:
             return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
         if cmd[:2] == ["adb", "connect"]:


### PR DESCRIPTION
Centralizes ADB command execution in `android_common` with a system-wide timeout helper (`adb_timeout.py`), establishing fast query (30s) and slow transfer/install (180s) timeout tiers to prevent wedged device ADB sockets from hanging fleet deployments (#59).