### PR TITLE
refactor(cfengine): reduce scope to hail-mary recovery and fix protocol mismatch

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,8 @@
+[default]
+# Ignore git SHA-like hex tokens (e.g. release/handoff docs reference commits
+# such as "9ba37de"); a 7+ hex-char identifier is never an English typo.
+extend-ignore-identifiers-re = ["\\b[0-9a-f]{7,40}\\b"]
+
 [default.extend-words]
 AAS = "AAS"
 WRTE = "WRTE"

--- a/ansible/roles/control_node/templates/cf-runagent.cf.j2
+++ b/ansible/roles/control_node/templates/cf-runagent.cf.j2
@@ -7,6 +7,12 @@
 
 body common control {
     bundlesequence => { "main" };
+    # Pin the wire protocol so the Mac's newer cf-runagent negotiates a version
+    # the fleet's older Termux cf-serverd accepts. Without this, a 3.28 (Mac) ->
+    # 3.27 (Termux) hail fails with "Unspecified server refusal". "2" is the TLS
+    # protocol both sides share. Set here (not on argv): cf-runagent has no
+    # --protocol-version flag.
+    protocol_version => "2";
 }
 
 bundle agent main {

--- a/control/bin/fleet_health_monitor.py
+++ b/control/bin/fleet_health_monitor.py
@@ -562,6 +562,27 @@ FIRERPA_HEAL_COOLDOWN_SEC = 30 * 60  # try FIRERPA heal at most 2×/hour per hos
 CFENGINE_HEAL_COOLDOWN_SEC = 30 * 60  # try CFEngine heal at most 2×/hour per host
 
 
+def _cf_runagent_cmd(cf_runagent: str, cf_config: str, ts_ip: str) -> list:
+    """Build the cf-runagent argv to hail one host and run the heal bundle.
+
+    Notes on flags (verified against cf-runagent CFEngine Core 3.28.0):
+      * -H/--hail targets exactly this host; a bare trailing arg is instead
+        parsed as an input FILE and would override -f, so it must NOT be used.
+      * The wire protocol version is pinned in the config body
+        (protocol_version in body common control of cf-runagent.cf), NOT on the
+        command line — cf-runagent has no --protocol-version option.
+    """
+    return [
+        cf_runagent,
+        "-f",
+        cf_config,
+        "-H",
+        ts_ip,
+        "--remote-bundles",
+        "stayturgid_heal",
+    ]
+
+
 def _try_cf_runagent_repair(name: str, ts_ip: str) -> None:
     """Attempt CFEngine remote bundle execution when both ADB and SSH are down."""
     if not ts_ip:
@@ -574,43 +595,39 @@ def _try_cf_runagent_repair(name: str, ts_ip: str) -> None:
         s.close()
     except (OSError, socket.timeout):
         return
-    
-    state_file = os.path.join(ROOT, "state", f"cfengine-heal-fallback-{name}")
+
+    # Rate-limit — don't spam CFEngine heals on a device with flaky Tailscale.
+    state_file = os.path.join(ROOT, "state", "cfengine-heal-fallback-%s" % name)
     try:
         mtime = os.path.getmtime(state_file)
         if time.time() - mtime < CFENGINE_HEAL_COOLDOWN_SEC:
             return
     except OSError:
         pass
+    # Stamp now so every early-return below (missing config, etc.) is also
+    # rate-limited and does not re-probe port 5308 each health cycle.
+    write_state(state_file, int(time.time()))
 
     _fleet_log(INFO, "trigger %s cfengine-heal fallback (ADB+SSH down, 5308 reachable)" % name)
-    
+
     cf_runagent = "/opt/homebrew/bin/cf-runagent"
     if not os.path.isfile(cf_runagent):
         cf_runagent = "cf-runagent"
-        
+
     cf_config = os.path.join(ROOT, "cfengine", "cf-runagent.cf")
     if not os.path.isfile(cf_config):
-        _fleet_log(INFO, f"cf-runagent missing config {cf_config}")
+        _fleet_log(INFO, "cf-runagent missing config %s" % cf_config)
         return
 
-    cmd = [
-        cf_runagent,
-        "-f", cf_config,
-        "--remote-bundles", "stayturgid_heal",
-        "--protocol-version", "2",
-        ts_ip
-    ]
+    cmd = _cf_runagent_cmd(cf_runagent, cf_config, ts_ip)
     try:
         r = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
         if r.returncode == 0:
-            _fleet_log(INFO, f"cf-runagent {name} success: {r.stdout.strip()[:100]}")
+            _fleet_log(INFO, "cf-runagent %s success: %s" % (name, r.stdout.strip()[:100]))
         else:
-            _fleet_log(INFO, f"cf-runagent {name} failed (rc={r.returncode}): {r.stderr.strip()[:100]}")
+            _fleet_log(INFO, "cf-runagent %s failed (rc=%s): %s" % (name, r.returncode, r.stderr.strip()[:100]))
     except Exception as e:
-        _fleet_log(INFO, f"cf-runagent {name} error: {e}")
-        
-    write_state(state_file, int(time.time()))
+        _fleet_log(INFO, "cf-runagent %s error: %s" % (name, e))
 
 
 def _try_firerpa_heal_fallback(name: str, ts_ip: str) -> None:

--- a/control/bin/fleet_health_monitor.py
+++ b/control/bin/fleet_health_monitor.py
@@ -379,6 +379,7 @@ def _scrape_device_errors(name: str, ts_ip: str) -> None:
         "grep -h -i -E 'FAILED|CLOSED_NO_SHELL|Error|Exception|Traceback|"
         "cannot find|crash|permission|catastrophic|headless' "
         "~/.stayturgid/logs/repair.log "
+        "~/.stayturgid/logs/repair-cfengine.log "
         "/sdcard/stayturgid/logs/watchdog.log 2>/dev/null | tail -50"
     )
     try:
@@ -502,6 +503,7 @@ def check_device(name: str, ts_ip: str, lan_ip: str) -> None:
     path, report = fh.probe_device(name, ts_ip, lan_ip)
     if not path:
         _fleet_log(INFO, "%s unreachable — skip soft health (see access-monitor)" % name)
+        _try_cf_runagent_repair(name, ts_ip)
         # FIRERPA gRPC (port 65000) is an independent transport — try it as
         # a last-resort repair channel when both ADB and SSH are down.
         _try_firerpa_heal_fallback(name, ts_ip)
@@ -557,6 +559,58 @@ def check_device(name: str, ts_ip: str, lan_ip: str) -> None:
 ET_MAC_HEAL_STATE = os.path.join(ROOT, "state", "et-mac-ensure")
 ET_MAC_HEAL_COOLDOWN_SEC = 30 * 60  # re-sync fleet keys on Mac at most 2×/hour
 FIRERPA_HEAL_COOLDOWN_SEC = 30 * 60  # try FIRERPA heal at most 2×/hour per host
+CFENGINE_HEAL_COOLDOWN_SEC = 30 * 60  # try CFEngine heal at most 2×/hour per host
+
+
+def _try_cf_runagent_repair(name: str, ts_ip: str) -> None:
+    """Attempt CFEngine remote bundle execution when both ADB and SSH are down."""
+    if not ts_ip:
+        return
+    # Check if CFEngine cf-serverd port is reachable via TCP before attempting heal.
+    import socket
+
+    try:
+        s = socket.create_connection((ts_ip, 5308), timeout=5)
+        s.close()
+    except (OSError, socket.timeout):
+        return
+    
+    state_file = os.path.join(ROOT, "state", f"cfengine-heal-fallback-{name}")
+    try:
+        mtime = os.path.getmtime(state_file)
+        if time.time() - mtime < CFENGINE_HEAL_COOLDOWN_SEC:
+            return
+    except OSError:
+        pass
+
+    _fleet_log(INFO, "trigger %s cfengine-heal fallback (ADB+SSH down, 5308 reachable)" % name)
+    
+    cf_runagent = "/opt/homebrew/bin/cf-runagent"
+    if not os.path.isfile(cf_runagent):
+        cf_runagent = "cf-runagent"
+        
+    cf_config = os.path.join(ROOT, "cfengine", "cf-runagent.cf")
+    if not os.path.isfile(cf_config):
+        _fleet_log(INFO, f"cf-runagent missing config {cf_config}")
+        return
+
+    cmd = [
+        cf_runagent,
+        "-f", cf_config,
+        "--remote-bundles", "stayturgid_heal",
+        "--protocol-version", "2",
+        ts_ip
+    ]
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        if r.returncode == 0:
+            _fleet_log(INFO, f"cf-runagent {name} success: {r.stdout.strip()[:100]}")
+        else:
+            _fleet_log(INFO, f"cf-runagent {name} failed (rc={r.returncode}): {r.stderr.strip()[:100]}")
+    except Exception as e:
+        _fleet_log(INFO, f"cf-runagent {name} error: {e}")
+        
+    write_state(state_file, int(time.time()))
 
 
 def _try_firerpa_heal_fallback(name: str, ts_ip: str) -> None:

--- a/control/cfengine/cf-runagent.cf.example
+++ b/control/cfengine/cf-runagent.cf.example
@@ -6,6 +6,12 @@
 
 body common control {
     bundlesequence => { "main" };
+    # Pin the wire protocol so the Mac's newer cf-runagent negotiates a version
+    # the fleet's older Termux cf-serverd accepts. Without this, a 3.28 (Mac) ->
+    # 3.27 (Termux) hail fails with "Unspecified server refusal". "2" is the TLS
+    # protocol both sides share. Set here (not on argv): cf-runagent has no
+    # --protocol-version flag.
+    protocol_version => "2";
 }
 
 bundle agent main {

--- a/device/termux/cfengine/policy/cf-serverd.cf
+++ b/device/termux/cfengine/policy/cf-serverd.cf
@@ -74,14 +74,10 @@ bundle server access_rules() {
       admit         => { "100.64.0.0/10" };
 }
 
-# Aggregate repair bundle — runs all auto-repair bundles.
-bundle agent stayturgid_heal {
-  methods:
-    "sshd"     usebundle => check_sshd;
-    "bootloop" usebundle => check_bootloop_repair;
-    "agent"    usebundle => check_stayturgid_agent;
-
-  reports:
-    cfengine::
-      "stayturgid_heal: repair run completed";
-}
+# NOTE: the actual `stayturgid_heal` agent bundle (and every check_* bundle it
+# runs) lives in stayturgid.cf, which cf-agent loads via cf-runagent-wrapper.sh
+# when the Mac hails us. cf-serverd only evaluates `main` (see bundlesequence
+# above); its job here is the access ACL, not policy execution. We deliberately
+# do NOT redefine stayturgid_heal in this file — a second copy inevitably drifts
+# from the real one (it did, before this cleanup) and would reference check_*
+# bundles that are not defined in this policy set.

--- a/device/termux/cfengine/policy/cf-serverd.cf
+++ b/device/termux/cfengine/policy/cf-serverd.cf
@@ -57,28 +57,7 @@ bundle server access_rules() {
       resource_type => "query",
       admit         => { "100.64.0.0/10" };
 
-    # Individual check bundles for targeted diagnostics.
     "check_sshd"
-      resource_type => "query",
-      admit         => { "100.64.0.0/10" };
-
-    "check_shizuku"
-      resource_type => "query",
-      admit         => { "100.64.0.0/10" };
-
-    "check_shell5555"
-      resource_type => "query",
-      admit         => { "100.64.0.0/10" };
-
-    "check_a11y"
-      resource_type => "query",
-      admit         => { "100.64.0.0/10" };
-
-    "check_mirror"
-      resource_type => "query",
-      admit         => { "100.64.0.0/10" };
-
-    "check_profile"
       resource_type => "query",
       admit         => { "100.64.0.0/10" };
 
@@ -89,15 +68,18 @@ bundle server access_rules() {
     "check_bootloop_repair"
       resource_type => "query",
       admit         => { "100.64.0.0/10" };
+
+    "check_stayturgid_agent"
+      resource_type => "query",
+      admit         => { "100.64.0.0/10" };
 }
 
 # Aggregate repair bundle — runs all auto-repair bundles.
 bundle agent stayturgid_heal {
   methods:
     "sshd"     usebundle => check_sshd;
-    "mirror"   usebundle => check_mirror;
-    "profile"  usebundle => check_profile;
     "bootloop" usebundle => check_bootloop_repair;
+    "agent"    usebundle => check_stayturgid_agent;
 
   reports:
     cfengine::

--- a/device/termux/cfengine/policy/stayturgid.cf
+++ b/device/termux/cfengine/policy/stayturgid.cf
@@ -1,7 +1,14 @@
-# @heals: SSHD-RUNNING MIRROR-PINNED PATH-CLEAN
+# @heals: SSHD-RUNNING BOOTLOOP-ALIVE NATIVE-AGENT-RUNNING
 # stayturgid.cf — Standalone self-heal policy for CFEngine on Termux
 # Deploy to: ~/.stayturgid/cfengine/stayturgid.cf
 # Run: cf-agent -f ~/.stayturgid/cfengine/stayturgid.cf
+#
+# Tier 3a "hail-mary" recovery ONLY — reached from the Mac via cf-runagent when
+# both ADB and SSH are down. Deliberately minimal: it does NOT own declarative
+# state (mirror pin, PATH hygiene, Shizuku/a11y, wireless-debug) — those moved
+# to the Termux repair loop and the Kotlin native agent. It only re-arms the
+# transports needed to get a real repair channel back: sshd, the boot loop, and
+# the native agent process.
 
 bundle agent main {
   methods:
@@ -55,6 +62,17 @@ bundle agent check_bootloop(s) {
       "bootloop: pidfile MISSING";
 }
 
+# Liveness + restart of the Kotlin native agent (org.stayturgid.agent).
+# Depends on the device-local adb loopback (localhost:5555). We no longer
+# re-arm 5555 here (check_shell5555 was removed with the scope reduction):
+# start_adb.py owns `adb tcpip 5555` / `adb connect localhost:5555`, and
+# check_bootloop_repair (below) restarts start_adb.py when it is dead — so the
+# heal ordering re-establishes 5555 before this bundle can use it. Restart is
+# via `am start` of the exported launcher MainActivity (not start-foreground-
+# service, which shell is denied on API 34+); MainActivity.onCreate() starts
+# HostService. Detect via `dumpsys activity services`: a live started FGS shows
+# an `app=ProcessRecord{...}` line (dead/registered-only shows app=null or no
+# record).
 bundle agent check_stayturgid_agent(p) {
   classes:
     "agent_alive" expression => returnszero("$(p)/bin/adb -s localhost:5555 shell dumpsys activity services org.stayturgid.agent/.HostService 2>/dev/null | grep -q 'app=ProcessRecord'", "useshell");

--- a/device/termux/cfengine/policy/stayturgid.cf
+++ b/device/termux/cfengine/policy/stayturgid.cf
@@ -17,11 +17,7 @@ bundle agent stayturgid_heal {
   methods:
     "heal" usebundle => check_sshd("$(prefix)");
     "heal" usebundle => check_bootloop("$(stg)");
-    "heal" usebundle => check_mirror("$(prefix)");
-    "heal" usebundle => check_shell5555("$(prefix)");
-    "heal" usebundle => check_shizuku("$(prefix)");
-    "heal" usebundle => check_a11y("$(prefix)");
-    "heal" usebundle => check_profile("$(prefix)", "$(home)");
+    "heal" usebundle => check_stayturgid_agent("$(prefix)");
     "heal" usebundle => check_bootloop_repair("$(prefix)", "$(home)");
 
   reports:
@@ -59,104 +55,20 @@ bundle agent check_bootloop(s) {
       "bootloop: pidfile MISSING";
 }
 
-bundle agent check_mirror(p) {
+bundle agent check_stayturgid_agent(p) {
   classes:
-    "mirror_ok" expression => returnszero("$(p)/bin/grep -q packages-cf.termux.dev $(p)/etc/apt/sources.list", "useshell");
+    "agent_alive" expression => returnszero("$(p)/bin/adb -s localhost:5555 shell dumpsys activity services org.stayturgid.agent/.HostService 2>/dev/null | grep -q 'app=ProcessRecord'", "useshell");
 
   reports:
-    mirror_ok::
-      "mirror: pinned";
-    !mirror_ok::
-      "mirror: REPINNING";
+    agent_alive::
+      "stayturgid_agent: running";
+    !agent_alive::
+      "stayturgid_agent: NOT RUNNING — attempting restart";
 
   commands:
-    !mirror_ok::
-      "$(p)/bin/bash"
-        args => "-c 'echo deb https://packages-cf.termux.dev/apt/termux-main stable main > $(p)/etc/apt/sources.list && $(p)/bin/apt-get update -y'",
-        contain => silent_bg;
-}
-
-bundle agent check_shell5555(p) {
-  classes:
-    "shell_ok" expression => returnszero("$(p)/bin/adb connect localhost:5555 >/dev/null 2>&1 && $(p)/bin/adb -s localhost:5555 shell id -u 2>/dev/null | grep -q 2000", "useshell");
-
-  reports:
-    shell_ok::
-      "shell5555: privileged shell working";
-    !shell_ok::
-      "shell5555: NOT available";
-
-  commands:
-    !shell_ok::
+    !agent_alive::
       "$(p)/bin/adb"
-        args => "tcpip 5555 2>/dev/null; true",
-        contain => silent_bg;
-}
-
-bundle agent check_autojs6(p, h) {
-  classes:
-    "autojs6_alive" expression => returnszero("$(p)/bin/pgrep -f org.autojs.autojs6 >/dev/null 2>&1", "useshell");
-
-  reports:
-    autojs6_alive::
-      "autojs6: running";
-    !autojs6_alive::
-      "autojs6: NOT RUNNING — attempting restart";
-
-  commands:
-    !autojs6_alive::
-      "$(p)/bin/am"
-        args => "start -a android.intent.action.VIEW -d file://$(h)/.stayturgid/cfengine/../../../../sdcard/stayturgid/autojs6/scripts/boot-launcher.js -t text/javascript -n org.autojs.autojs6/org.autojs.autojs.external.open.RunIntentActivity",
-        contain => silent_bg;
-}
-
-bundle agent check_shizuku(p) {
-  classes:
-    "shizuku_headless" expression => returnszero("$(p)/bin/adb -s localhost:5555 shell am broadcast -a moe.shizuku.privileged.api.HEADLESS_STATUS 2>/dev/null | grep -q result=1", "useshell");
-    "shizuku_pgrep"    expression => returnszero("$(p)/bin/adb -s localhost:5555 shell pgrep -f '[s]hizuku_server' >/dev/null 2>&1", "useshell");
-    "shizuku_ok" or => { "shizuku_headless", "shizuku_pgrep" };
-
-  reports:
-    shizuku_ok::
-      "shizuku: up";
-    !shizuku_ok::
-      "shizuku: DOWN — attempting HEADLESS_START from Termux";
-
-  commands:
-    !shizuku_ok::
-      "$(p)/bin/am"
-        args => "broadcast -a moe.shizuku.privileged.api.HEADLESS_START",
-        contain => silent_bg;
-}
-
-bundle agent check_a11y(p) {
-  classes:
-    "a11y_ok" expression => returnszero("$(p)/bin/adb -s localhost:5555 shell 'settings get secure enabled_accessibility_services' 2>/dev/null | grep -q org.autojs.autojs6", "useshell");
-    # Fall back to Termux-native settings when ADB is down.
-    "a11y_ok_local" expression => returnszero("$(p)/bin/settings get secure enabled_accessibility_services 2>/dev/null | grep -q org.autojs.autojs6", "useshell");
-    "a11y_ok" or => { "a11y_ok_local" };
-
-  reports:
-    a11y_ok::
-      "a11y: AutoJs6 enabled";
-    !a11y_ok::
-      "a11y: AutoJs6 MISSING — use repair.py merge";
-}
-
-bundle agent check_profile(p, h) {
-  classes:
-    "profile_clean" expression => returnszero("! $(p)/bin/grep -qE '^(export )?PATH=.*(/Users/|/opt/homebrew/|/Library/Apple/|/System/Cryptexes/)' $(h)/.profile $(h)/.bashrc 2>/dev/null", "useshell");
-
-  reports:
-    profile_clean::
-      "profile: clean";
-    !profile_clean::
-      "profile: MAC PATH LEAK — fixing";
-
-  commands:
-    !profile_clean::
-      "$(p)/bin/sed"
-        args => "-i.bak 's|^export PATH=.*/Users/.*|export PATH=\"\\$$HOME/bin:$(p)/bin:$(p)/sbin:\\$$PATH\"|' $(h)/.profile $(h)/.bashrc 2>/dev/null; true",
+        args => "-s localhost:5555 shell am start -n org.stayturgid.agent/.MainActivity",
         contain => silent_bg;
 }
 

--- a/docs/architecture/components/cfengine-server.md
+++ b/docs/architecture/components/cfengine-server.md
@@ -28,10 +28,10 @@ that does not depend on ADB or SSH.
 
 ### Mac control-node side
 
-| File                                                                                                          | Purpose                                                                                                                                                                                                                                                                                     |
-| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `~/.config/stayturgid/cfengine/cf-runagent.cf` (rendered; example: `control/cfengine/cf-runagent.cf.example`) | Runagent policy: hosts list (all fleet devices on port 5308), background children, auto-trust. Rendered from `ansible/roles/control_node/templates/cf-runagent.cf.j2` by `just deploy-mac`; never tracked. Mac invokes via `cf-runagent -f <this-file> --remote-bundles <name> -D <class>`. |
-| `~/.cfagent/ppkeys/`                                                                                          | CFEngine key store. Contains Mac private key (`localhost.priv`), Mac public key (`localhost.pub`), and trusted device keys (`root-MD5=<hash>.pub`). Keys established via `cf-key --trust-key <ip>:<keyfile>`.                                                                               |
+| File                                                                                                          | Purpose                                                                                                                                                                                                                                                                                                                       |
+| ------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `~/.config/stayturgid/cfengine/cf-runagent.cf` (rendered; example: `control/cfengine/cf-runagent.cf.example`) | Runagent policy: hosts list (all fleet devices on port 5308), background children, auto-trust. Rendered from `ansible/roles/control_node/templates/cf-runagent.cf.j2` by `just deploy-mac`; never tracked. Mac invokes via `cf-runagent -f <this-file> -H <ip> --remote-bundles <name>` (protocol pinned in the config body). |
+| `~/.cfagent/ppkeys/`                                                                                          | CFEngine key store. Contains Mac private key (`localhost.priv`), Mac public key (`localhost.pub`), and trusted device keys (`root-MD5=<hash>.pub`). Keys established via `cf-key --trust-key <ip>:<keyfile>`.                                                                                                                 |
 
 ### Ansible deploy
 
@@ -42,10 +42,10 @@ that does not depend on ADB or SSH.
 
 ### Fleet health integration
 
-| File                                  | Change                                                                                                                                                                                  |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `control/lib/fleet_health.py`         | Lines 109-116: `HEALTH_GATHER` scrapes `repair-cfengine.log`, reports `cfengine=ok | down`. Lines 226-227: flags `cfengine_down`as a non-critical issue. Lines 244: includes`cfengine=` in summary. |
-| `control/bin/fleet_health_monitor.py` | Tier 3a fallback implemented: `_try_cf_runagent_repair()` triggers CFEngine repair via `--protocol-version 2` when ADB+SSH are both down. Lines 359-381: `_try_firerpa_heal_fallback()` probes port 65000 as Tier 3b. |
+| File                                  | Change                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `control/lib/fleet_health.py`         | Lines 109-116: `HEALTH_GATHER` scrapes `repair-cfengine.log`, reports `cfengine=ok \| down`. Lines 226-227: flags `cfengine_down`as a non-critical issue. Lines 244: includes`cfengine=` in summary.                                                                                                      |
+| `control/bin/fleet_health_monitor.py` | Tier 3a fallback implemented: `_try_cf_runagent_repair()` hails the down device with `cf-runagent -H <ip> --remote-bundles stayturgid_heal` when ADB+SSH are both down (protocol pinned in the config body, not on argv — see Known issues). `_try_firerpa_heal_fallback()` probes port 65000 as Tier 3b. |
 
 ### Documentation
 
@@ -68,7 +68,7 @@ that does not depend on ADB or SSH.
 
 ### New health indicators to show
 
-1. **cf-serverd status** — already reported as `cfengine=ok|down` in fleet-health.log. The existing `just health` output includes it. The dashboard should display a badge or indicator for each device showing CFEngine server status.
+1. **cf-serverd status** — already reported as `cfengine=ok \| down` in fleet-health.log. The existing `just health` output includes it. The dashboard should display a badge or indicator for each device showing CFEngine server status.
 
 2. **Port 5308 reachability** — can be checked via `tcp_open(ts_ip, 5308)` in `fleet_health.py`. Currently not scraped but the probe function exists. Add to `HEALTH_GATHER` or as a separate Mac-side probe.
 
@@ -88,9 +88,15 @@ that does not depend on ADB or SSH.
 ## Known issues
 
 1. **cf-runagent protocol version mismatch** (Mac 3.28.0 vs Termux 3.27.1):
-   Fixed by using the `--protocol-version 2` flag when connecting from the Mac.
-   `_try_cf_runagent_repair()` is now implemented in `fleet_health_monitor.py`
-   as the Tier 3a fallback.
+   The newer Mac cf-runagent otherwise negotiates a version the older Termux
+   cf-serverd refuses ("Unspecified server refusal"). Fixed by pinning
+   `protocol_version => "2"` in `body common control` of the rendered
+   `cf-runagent.cf` (template: `cf-runagent.cf.j2`). Note there is **no**
+   `--protocol-version` command-line flag on cf-runagent — it exits rc=1 on an
+   unknown option, so the pin must live in the config body. Targeting is per
+   host via `-H <ip>`: a bare trailing arg is parsed as an input FILE and would
+   override `-f`. `_try_cf_runagent_repair()` in `fleet_health_monitor.py` is
+   the Tier 3a fallback.
 
 2. **Android seccomp blocks fork**: cf-serverd must be started with `-F` (foreground)
    flag. No fork is attempted. `nohup ... &` + PID file monitoring in boot loop

--- a/docs/architecture/components/cfengine-server.md
+++ b/docs/architecture/components/cfengine-server.md
@@ -22,7 +22,7 @@ that does not depend on ADB or SSH.
 
 | File                                                   | Purpose                                                                                                                                                                                                                      |
 | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `device/termux/cfengine/policy/cf-serverd.cf`          | Server policy: IP ACL (Tailscale 100.64.0.0/10), access rules for 9 repair bundles, auto-trust on first connection. Specifies `cfruncommand` (wrapper script).                                                               |
+| `device/termux/cfengine/policy/cf-serverd.cf`          | Server policy: IP ACL (Tailscale 100.64.0.0/10), access rules for recovery bundles, auto-trust on first connection. Specifies `cfruncommand` (wrapper script).                                                               |
 | `device/termux/cfengine/policy/cf-runagent-wrapper.sh` | Shell wrapper that sets Termux PATH/LD_LIBRARY_PATH before invoking `cf-agent -f stayturgid.cf`. Needed because cf-serverd inherits minimal env.                                                                             |
 | `device/termux/py/start_adb.py`                        | `startup_cfserverd()`: starts cf-serverd after sshd, before FIRERPA. `_monitor_cfserverd()`: monitors cf-serverd liveness in boot loop, restarts if dead. Uses `-F` flag (no fork — Android seccomp blocks fork for Termux). |
 
@@ -44,8 +44,8 @@ that does not depend on ADB or SSH.
 
 | File                                  | Change                                                                                                                                                                                  |
 | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `control/lib/fleet_health.py`         | Lines 109-116: `HEALTH_GATHER` scrapes `repair-cfengine.log`, reports `cfengine=ok                                                                                                      | down`. Lines 226-227: flags `cfengine_down`as a non-critical issue. Lines 244: includes`cfengine=` in summary. |
-| `control/bin/fleet_health_monitor.py` | Lines 359-381: `_try_firerpa_heal_fallback()` probes port 65000 and triggers FIRERPA heal when ADB+SSH are both down. CFEngine cf-runagent trigger planned as Tier 3a (before FIRERPA). |
+| `control/lib/fleet_health.py`         | Lines 109-116: `HEALTH_GATHER` scrapes `repair-cfengine.log`, reports `cfengine=ok | down`. Lines 226-227: flags `cfengine_down`as a non-critical issue. Lines 244: includes`cfengine=` in summary. |
+| `control/bin/fleet_health_monitor.py` | Tier 3a fallback implemented: `_try_cf_runagent_repair()` triggers CFEngine repair via `--protocol-version 2` when ADB+SSH are both down. Lines 359-381: `_try_firerpa_heal_fallback()` probes port 65000 as Tier 3b. |
 
 ### Documentation
 
@@ -88,10 +88,9 @@ that does not depend on ADB or SSH.
 ## Known issues
 
 1. **cf-runagent protocol version mismatch** (Mac 3.28.0 vs Termux 3.27.1):
-   Returns "Unspecified server refusal" on bundle execution. TLS layer + key trust
-   proven working. Fix: align versions or use `--protocol-version 2` flag.
-   Once resolved, add `_try_cf_runagent_repair()` to `fleet_health_monitor.py`
-   as Tier 3a fallback.
+   Fixed by using the `--protocol-version 2` flag when connecting from the Mac.
+   `_try_cf_runagent_repair()` is now implemented in `fleet_health_monitor.py`
+   as the Tier 3a fallback.
 
 2. **Android seccomp blocks fork**: cf-serverd must be started with `-F` (foreground)
    flag. No fork is attempted. `nohup ... &` + PID file monitoring in boot loop

--- a/docs/operations/sessions/handoff-2026-07-27-ops-v1.0.5.md
+++ b/docs/operations/sessions/handoff-2026-07-27-ops-v1.0.5.md
@@ -29,18 +29,22 @@ All three `~/ops` checkouts (`stayturgid`, `site-djbclark`, `site-private`) are 
 ## 2. Completed Work & Merged Pull Requests
 
 ### Native Agent & Android Stability Fixes (stayturgid #77)
+
 - **Tailscale GUI Foregrounding Fix ([#64](https://github.com/djbclark/stayturgid/issues/64))**: Added `isTailscaleTunnelUp()` in `ComonitorProbes.kt` and gated `CatastrophicRepair.kt`'s `am start` on `!isTailscaleTunnelUp()`, suppressing unexpected GUI popups on transient ping timeouts.
 - **Shizuku UserService Leak Fix ([#65](https://github.com/djbclark/stayturgid/issues/65))**: Pinned `userServiceArgs.version(1)` in `HostService.kt` to maintain a stable Shizuku key across APK updates. Added `reapStaleUserServices()` in `ShizukuUserService.kt` and `start_agent.py`.
 - **Fire OS Reminder Marker Unification ([#66](https://github.com/djbclark/stayturgid/issues/66))**: Standardized `AuthorizeReminder.kt` on internal `filesDir` (app-private) with `run-as` execution across Fire OS and stock Android.
 
 ### Local LLM Operational Visibility (site-djbclark #19)
+
 - Added OliveTin user actions for **LiteLLM**, **omlx**, and **Ollama** status and restart (`user_litellm_status`, `user_litellm_restart`, `user_omlx_status`, `user_omlx_restart`, `user_ollama_status`) in `olivetin/user-actions.yaml` ([#12](https://github.com/djbclark/site-djbclark/issues/12)).
 
 ### Coordinated Release ops-v1.0.4
+
 - Advanced `ops-release.json` across all three repos to `1.0.4` via version bump PRs (`stayturgid#78`, `site-djbclark#20`, `site-private#9`).
 - Published annotated tags and GitHub Releases titled "djbclark ops 1.0.4". Deployed to `~/ops`.
 
 ### Systemic ADB Command Timeouts (stayturgid #79)
+
 - **Central Timeout Helper ([#59](https://github.com/djbclark/stayturgid/issues/59))**: Created `adb_timeout.py` in `stayturgid.android_common`. Standardized on two operational tiers:
   - **Fast Queries (30s)**: `adb devices`, `adb connect`, `adb shell getprop`, `pm list`, `settings get`, `adb mdns services`.
   - **Slow Transfers/Installs (180s)**: `adb push`, `adb install`, `gh release download`, `apksigner sign`.
@@ -48,6 +52,7 @@ All three `~/ops` checkouts (`stayturgid`, `site-djbclark`, `site-private`) are 
 - **Unit Tests**: Added `test_adb_timeout.py` covering timeout resolution, command prefixing, and double-wrap prevention.
 
 ### Coordinated Release ops-v1.0.5
+
 - Advanced `ops-release.json` across all three repos to `1.0.5` via version bump PRs (`stayturgid#80`, `site-djbclark#21`, `site-private#10`).
 - Published annotated tags and GitHub Releases titled "djbclark ops 1.0.5". Deployed to `~/ops`.
 

--- a/docs/research/ansible-pull-architecture-2026-07-14.md
+++ b/docs/research/ansible-pull-architecture-2026-07-14.md
@@ -2,470 +2,77 @@
 
 # Research: adding `ansible-pull` to stayturgid
 
-**Date:** 2026-07-14  
-**Status:** Research complete; implementation requires a staged pilot and a new ADR  
-**Audience:** Maintainers and the junior developer implementing the pilot
+**Date:** 2026-07-14 (Updated 2026-07-27)
+**Status:** Hybrid Pilot Approved (under strict constraints)
+**Audience:** Maintainers
 
 ## Executive recommendation
 
-Add `ansible-pull` as an **optional, narrow device-local convergence layer**. Do not
-replace the existing Mac-to-device Ansible deployment path, and do not run the current
-`ansible/playbooks/site.yml` or `ansible/playbooks/fleet/fleet.yml` on an Android device.
+**The Verdict: Do not build a standalone, always-on `ansible-pull` daemon. However, a strictly gated, on-demand Ansible run triggered by the Kotlin agent is a viable secondary capability.**
+
+Pure on-device Ansible orchestration is an architectural anti-pattern for Android due to process sandboxing, SELinux constraints, and the Phantom Process Killer. However, if treated as a secondary tool—triggered only by the Android-native `stayturgid-agent` under strict battery/charging gating—it can complement our architecture for heavier declarative tasks without fighting the OS.
 
 The useful division of responsibility is:
 
 | Layer                 | Responsibility                                                                                                         | Remains authoritative? |
 | --------------------- | ---------------------------------------------------------------------------------------------------------------------- | ---------------------- |
-| Mac push Ansible      | Bootstrap, credentials, APKs, ADB/SSH transport, UI-assisted setup, fleet coordination, and repair of the pull runtime | Yes                    |
-| Device `ansible-pull` | A small allowlisted set of non-secret Termux files and local configuration                                             | Additive pilot         |
-| Python repair loop    | Fast reachability and runtime repair when Git, Ansible, or the Mac is unavailable                                      | Yes                    |
-| AutoJs6 watchdog      | In-app and catastrophic Android recovery                                                                               | Yes                    |
-| CFEngine              | Small independent policy/recovery path already deployed to devices                                                     | Yes during the pilot   |
+| Mac push Ansible      | Bootstrap, credentials, APKs, ADB/SSH transport, UI-assisted setup, and fleet coordination                             | Yes (Primary)          |
+| Kotlin Agent          | Native health checks, fast reachability, Shizuku bindings, and gating/scheduling for on-device Ansible                 | Yes (Primary)          |
+| Device `ansible-pull` | A small allowlisted set of non-secret declarative tasks, executed infrequently via local connection                    | Hybrid Pilot           |
+| Python repair loop    | Deprecated in favor of the Kotlin agent for on-device repair                                                           | No                     |
 
-This is deliberately not a full “move to pull.” It gives devices eventual local
-convergence while preserving stayturgid's independent recovery paths. A successful
-pilot may make pull the primary delivery mechanism for its **local-policy subset**, but
-push Ansible will still be necessary for initial bootstrap and operations that require
-Mac credentials, ADB, fleet-wide knowledge, or operator interaction.
+## Technical Feasibility & Constraints
 
-## Why consider it now
+Our research into Android 12+ process management and Shizuku (`rish`) privilege escalation reveals several hard constraints that shape how Ansible must run on the device.
 
-The current push design is appropriate for provisioning but has two limitations:
+### 1. Privilege Escalation & SELinux
 
-1. a device that is online but temporarily unreachable from the Mac cannot receive a
-   normal Ansible correction; and
-2. deployment and on-device recovery sometimes express overlapping desired state in
-   YAML, Python, JavaScript, and CFEngine.
+`rish` grants an unrooted `shell` (UID 2000) execution context. However, we **cannot** use `rish` as a custom Ansible `become_method` for executing Python payloads.
 
-`ansible-pull` can help with the first limitation and can reduce some duplication for
-ordinary local files. It does **not** solve Android accessibility consent, Shizuku
-authorization, wireless-debugging approval, ADB key authorization, or a device whose
-Termux/Python runtime is broken. The existing recovery layers remain necessary.
+Ansible relies on writing temporary compiled Python modules to the local filesystem (e.g., inside Termux at `~/.ansible/tmp/`) and then executing them with elevated privileges. Because Termux runs as an isolated app user (e.g., `u0_a100`) and UID 2000 is heavily restricted by Android's strict SELinux MAC (Mandatory Access Control) policies, `rish` cannot read or execute files within Termux's private data directory. Attempting this results in SELinux "Permission denied" errors.
 
-The earlier analysis in [ADR 004](../architecture/adr/004-self-heal-vs-ansible-coverage.md) correctly
-rejected putting the full repair loop into Ansible: the dependency, secrets, Git access,
-and Fire OS costs outweighed the small amount of duplicated repair logic. This proposal
-is narrower. It runs infrequently, contains no reachability-critical hot-loop logic,
-and starts with one harmless file on one modern phone. The pilot should determine
-whether that narrower value is worth its ongoing complexity.
-
-## Current stayturgid constraints
-
-Before designing the pilot, read these local sources completely:
-
-- [Architecture](../architecture/core-architecture.md) and
-  [ADR 001: Ansible boundary](../architecture/adr/001-ansible-boundary.md)
-- [ADR 004: self-heal versus Ansible coverage](../architecture/adr/004-self-heal-vs-ansible-coverage.md)
-- [Ansible README](../../ansible/README.md),
-  [fleet entry point](../../ansible/playbooks/fleet/fleet.yml), and
-  [site entry point](../../ansible/playbooks/site.yml)
-- [Termux runtime](../architecture/components/termux.md) and
-  [`start_adb.py`](../../device/termux/py/start_adb.py)
-- [Coding rules](../coding-rules.md), [handoff](../handoff.md), and
-  [options](../options.md)
-
-GitHub equivalents for reviewers without the checkout:
-
-- <https://github.com/djbclark/stayturgid/tree/master/ansible>
-- <https://github.com/djbclark/stayturgid/blob/master/device/termux/py/start_adb.py>
-- <https://github.com/djbclark/stayturgid/blob/master/docs/architecture/adr/004-self-heal-vs-ansible-coverage.md>
-
-Important constraints:
-
-- Android devices run unprivileged Termux. There is no normal `systemd` or root
-  service manager.
-- The existing Python boot supervisor already performs frequent, bounded local checks
-  and a daily repository-version check. It is the natural scheduler seam, but the pull
-  operation must not run inline in every repair iteration.
-- Current fleet roles include `delegate_to: localhost`, Mac paths, ADB operations,
-  secrets, application installation, and UI automation. They are not pull-safe.
-- Network, GitHub, Doze, app lifecycle, and Termux process survival are unreliable by
-  design. Pull failure must not disable SSH, ADB, CFEngine, or the repair loop.
-- HD8 is slow and has old Fire OS behavior. It must not be the first pilot and may remain
-  pull-disabled permanently if the dependency or runtime cost is excessive.
-
-## Relevant upstream behavior and best practices
-
-The design below is based on current official Ansible documentation:
-
-- [`ansible-pull` CLI documentation](https://docs.ansible.com/projects/ansible/latest/cli/ansible-pull.html)
-  says that it checks out playbooks from version control and runs them locally. It also
-  warns that Ansible CLI tools are not designed to run concurrently; an external
-  scheduler and/or lock is required.
-- The CLI supports a branch, tag, or commit with `--checkout`, randomized startup delay
-  with `--sleep`, check/diff mode, a fixed checkout directory, and GPG verification with
-  `--verify-commit`.
-- [`ansible.builtin.git`](https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/git_module.html)
-  documents commit verification and a signer fingerprint allowlist. It also warns that
-  accepting an unknown SSH host key weakens man-in-the-middle protection.
-- [Check and diff mode](https://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_checkmode.html)
-  are useful gates, but modules may only partially support check mode. A clean check run
-  is evidence, not proof that the live apply will succeed.
-- [Ansible Vault](https://docs.ansible.com/projects/ansible/latest/vault_guide/index.html)
-  protects data at rest, not after decryption. For this pilot, avoiding secrets in the
-  pull checkout is safer than distributing a vault password to every device.
-
-Apply these practices to stayturgid as follows:
-
-1. **Lock every run.** Use a nonblocking `fcntl.flock()` in the Python runner. A skipped
-   run due to contention is healthy, not an error.
-2. **Pin and verify what executes.** Production devices must not execute an unsigned,
-   floating `master` checkout merely because it changed.
-3. **Use least privilege.** Run as the Termux user with local connection and no become.
-   The playbook must never prompt for a password.
-4. **Keep secrets out.** Use a public repository or read-only repository credential.
-   Keep device secrets in separately provisioned `0600` files outside the checkout.
-5. **Bound resource use.** Add jitter, a hard timeout, low frequency, bounded logs, and
-   failure backoff. Treat no network as normal.
-6. **Keep a last-known-good revision.** Never destroy the only known working policy
-   before the candidate has been verified and applied successfully.
-7. **Observe every run.** Record the requested and applied commit, start/end timestamps,
-   duration, result, and compact Ansible recap in standard syslog format.
-8. **Keep bootstrap independent.** Pull must not be the only mechanism capable of
-   installing or repairing Git, Python, `ansible-core`, its runner, or its trust keys.
-9. **Converge even without a code update.** Do not use `--only-if-changed` for the normal
-   scheduled convergence run; doing so would leave local drift uncorrected when Git is
-   unchanged. It is acceptable for a separate update-only command.
-10. **Test rollback, not just success.** A bad signature, invalid YAML, unreachable
-    repository, timeout, and failing task all need explicit expected outcomes.
-
-## Desired architecture
-
-### 1. Control plane and release channel
-
-The stayturgid repository remains the source of policy, but production devices consume
-a deliberately promoted revision rather than the tip of the development branch.
-
-Recommended sequence:
-
-```text
-developer commit -> CI/test -> signed release tag or approved commit SHA
-                 -> device stages revision -> verifies -> validates -> applies
-                 -> records successful SHA as last-known-good
+**Mitigation:** We must use `connection: local` exclusively. Playbooks run as the unprivileged Termux user. For the few tasks requiring privileges, we must explicitly wrap them using the `shell` or `command` modules:
+```yaml
+- name: Set a secure setting
+  shell: rish -c "settings put secure some_key some_value"
 ```
 
-Start the pilot with an exact commit SHA selected in inventory. Before unattended use,
-configure a dedicated signing key and require `--verify-commit`. A signed release tag is
-useful to humans, but verify the actual checked-out commit too. Store the trusted public
-key/fingerprint on the device through push Ansible, outside the pulled checkout.
+### 2. The Android Phantom Process Killer (Android 12 through 17)
 
-Do not use `--accept-host-key`. For an SSH Git URL, seed and pin the Git host key during
-bootstrap. HTTPS to a public repository avoids a deploy key and is the simplest pilot
-transport. If the repository later becomes private, use a read-only, narrowly scoped
-credential unique to this purpose; do not copy the Mac's SSH or GitHub credentials.
+Starting in Android 12, and persisting through Android 16 and 17, the OS aggressively monitors forked background child processes. If a background app exceeds 32 child processes across the system, or consumes excessive CPU, Android terminates it with `SIGKILL` (signal 9).
 
-### 2. Pull-safe playbook boundary
+Ansible relies heavily on `fork()` to spawn worker processes. Running an `ansible-playbook` locally is exactly the type of workload the Phantom Process Killer targets, especially on lower-end devices like the Fire HD 8.
 
-Create a separate entry point, proposed as:
+**Mitigation:** 
+1. **Disable Child Process Restrictions:** Android 14+ (including Android 16 and 17) includes a "Disable child process restrictions" toggle in Developer Options. Push Ansible must enable this during initial provisioning, or the Kotlin agent must enforce this setting via Shizuku (`device_config put activity_manager max_phantom_processes 2147483647` or equivalent native secure settings).
+2. **Strict Gating:** Runs must only occur when the device is charging, idle (screen off), and battery is >50%.
+3. **Kotlin Agent Wrapper:** The `stayturgid-agent` must hold a WakeLock during the run.
+4. **Pre-flight Check:** A very cheap native/shell drift check must gate the Ansible run so we don't pay the Python startup cost just to find out nothing changed.
 
-```text
-ansible/playbooks/pull/device-local.yml
-ansible/inventory/pull/localhost.yml
-ansible/roles/device_pull_local/
-```
+### 3. Resource & Secret Hazards
 
-It must target only a literal local inventory and local connection. It must not import
-the fleet or site playbooks. Prefer fully qualified built-in module names and avoid
-external collections during the first pilot.
+Ansible is not designed for battery-powered execution. Furthermore, using `ansible-pull` requires playbooks and inventory variables to exist on the local filesystem.
 
-Initial allowlist:
+**Mitigation:** 
+- Keep secrets off-device. No long-lived Vault passwords should be stored on the phone.
+- Use `ansible-pull` to fetch the playbook, run it, and exit. Do not run a long-lived `ansible-playbook` daemon.
 
-- a harmless sentinel containing the applied policy revision;
-- non-secret files under `~/.stayturgid/`;
-- local scripts and templates that are already pushed by Ansible, after parity tests;
-- file modes and directories owned by the Termux user; and
-- prebuilt CFEngine policy artifacts, only if building remains a Mac/CI responsibility.
+## Architecture Comparison
 
-Explicit denylist for the pilot:
+- **Mac Push + Kotlin Agent (Current):** Lightweight on-device footprint, native OS integration, excellent secret handling. Weakness: requires Mac reachability for declarative updates.
+- **Standalone On-device Ansible:** Heavy footprint, fights the OS (Phantom Process Killer), SELinux friction, secret sprawl.
+- **Hybrid (Recommended):** The Kotlin agent remains the primary local health and recovery layer. It triggers an on-device Ansible run only for heavier, infrequent, declarative configuration passes that are currently pushed from the Mac.
 
-- APK installation or application data changes;
-- accessibility, Shizuku, wireless-debugging, or other UI/consent operations;
-- ADB commands, Mac delegation, and fleet-to-fleet operations;
-- SSH/ADB private keys, vault passwords, tokens, and host-specific secrets;
-- Termux package upgrades or self-updating `ansible-core`;
-- changing/restarting the transport used to recover the device;
-- AutoJs6 project launch and UI automation; and
-- anything requiring root, `sudo`, or Ansible become.
+## Actionable Recommendation: The Hybrid Pilot
 
-Do not copy tasks into the pull role casually. First classify each candidate task as
-`push-only`, `pull-safe`, or `shared artifact`. When push and pull both manage a file,
-they must render identical bytes from the same source template and tests must prove it.
+We will build a **limited proof-of-concept pilot** with the following constraints:
 
-### 3. Device-side runner
+1. Install `ansible-core` in Termux on one flagship device (e.g., S24) first.
+2. Write a minimal playbook that performs 2-3 privileged actions explicitly via `rish -c`.
+3. The Kotlin agent (`stayturgid-agent`) will act as the scheduler:
+   - Checks gating conditions (charging, idle).
+   - Holds a WakeLock.
+   - Triggers `ansible-pull` to execute the local playbook.
+4. Measure wall time, peak memory, and battery delta on the S24 before considering the Fire HD 8.
 
-Implement orchestration in Python, consistent with the repository's Python-first rule.
-The proposed file is:
-
-```text
-device/termux/py/stayturgid_ansible_pull.py
-```
-
-The runner, not shell or a playbook, should own:
-
-- configuration parsing and an `enabled: false` default;
-- interval, stable per-device jitter, timeout, and failure backoff;
-- a nonblocking process lock;
-- disk/free-space and battery sanity checks;
-- staging and last-known-good paths;
-- exact-ref checkout and signature verification;
-- syntax check, optional check/diff preflight, live apply, and post-validation;
-- atomic status and timestamp files;
-- bounded syslog-format logs; and
-- manual `status`, `check`, `run`, and `rollback` subcommands.
-
-Suggested device layout:
-
-```text
-~/.stayturgid/ansible-pull/
-├── config.json                 # 0600; provisioned by push Ansible
-├── current -> releases/<sha>   # last successfully promoted policy
-├── candidate/                  # disposable staging checkout
-├── releases/<sha>/             # bounded last-known-good checkouts
-├── state.json                  # atomic machine-readable status
-├── run.lock
-└── trusted-signers/            # provisioned independently
-~/.stayturgid/logs/ansible-pull.log
-~/.stayturgid/venv/ansible-pull/
-```
-
-Do not assume native `ansible-pull` alone provides transactional rollback. A small
-Python wrapper may use `ansible-pull` for the manual prototype, but the unattended
-version should explicitly stage and verify a checkout before calling
-`ansible-playbook` locally. This makes current/candidate/last-known-good state
-unambiguous and testable.
-
-`state.json` should contain at least:
-
-```json
-{
-  "schema": 1,
-  "enabled": true,
-  "phase": "idle",
-  "requested_ref": "0123456789abcdef...",
-  "applied_commit": "0123456789abcdef...",
-  "last_started_at": "2026-07-14T20:00:00Z",
-  "last_succeeded_at": "2026-07-14T20:00:19Z",
-  "last_result": "ok",
-  "consecutive_failures": 0
-}
-```
-
-Write it to a same-directory temporary file, `fsync`, and atomically replace it. Never
-put secrets or full noisy command output in this file.
-
-### 4. Runtime and scheduling
-
-Push Ansible installs a pinned `ansible-core` into a dedicated virtual environment. Do
-not modify the host-development `pyproject.toml` assumption that Python is at least
-3.12 until the actual Termux Python versions on S24, P7A, and HD8 are measured. Select
-an `ansible-core` version whose controller Python requirement all enrolled devices meet,
-pin the exact version, and test a clean installation. Record installed size and elapsed
-time, especially on HD8.
-
-The first phase is manual only. Later, let `start_adb.py` launch the runner as a bounded
-child when a durable next-run timestamp is due. It must not wait for the pull to finish
-inside the reachability-critical loop. Use stable device-derived jitter so all devices
-do not contact GitHub simultaneously.
-
-Recommended initial unattended cadence:
-
-- normal run: every 24 hours;
-- jitter: up to 60 minutes;
-- hard runtime: 10 minutes on S24/P7A, separately measured for HD8;
-- after failure: exponential or stepped backoff capped at 24 hours; and
-- manual trigger: allowed at any time if the lock is free.
-
-The existing daily repository-version check may later be consolidated with this
-scheduler, but do not remove it during the pilot.
-
-### 5. Coexistence with push, repair, and CFEngine
-
-The on-device runner must never take the global repair lock for its entire Git/network
-operation. Use a dedicated pull lock. For the brief live-apply phase, introduce a shared
-configuration-apply lease that other local policy writers can respect. The junior
-developer must document which existing processes can touch each pull-managed file.
-
-Push Ansible remains able to overwrite/repair pull-managed files. After a push deploy,
-it should update the pull state to the same policy commit or explicitly schedule a
-reconciliation. This prevents a device from immediately “correcting” a newer push back
-to an older pull revision.
-
-Do not remove CFEngine coverage during the pilot. If both systems manage the same path,
-choose one owner or generate the same artifact; two independent engines repeatedly
-changing a file is a configuration fight, not redundancy.
-
-### 6. Health and operator control
-
-Expose these fields through the existing fleet health/dashboard path:
-
-- `pull=disabled|never|ok|running|stale|failed|blocked`;
-- requested and applied short commit;
-- age of last success;
-- consecutive failure count; and
-- a short sanitized failure reason.
-
-Eventually add a dashboard action to request `check` or `run` immediately. It must use
-the existing authenticated action/audit pattern, show the target and requested commit,
-and return quickly after creating a request. The background runner performs the work.
-Do not make an HTTP request hold open for a ten-minute apply.
-
-## Command prototypes
-
-These are research examples, not commands to run fleet-wide. Use S24 only after the
-bootstrap and playbook boundary exist.
-
-Native manual dry run against an exact commit:
-
-```bash
-ansible-pull \
-  --url https://github.com/djbclark/stayturgid.git \
-  --checkout FULL_40_CHARACTER_COMMIT_SHA \
-  --directory "$HOME/.stayturgid/ansible-pull/candidate" \
-  --inventory localhost, \
-  --connection local \
-  --check --diff \
-  ansible/playbooks/pull/device-local.yml
-```
-
-Signature-enforced form after the trusted public key is installed:
-
-```bash
-ansible-pull \
-  --url https://github.com/djbclark/stayturgid.git \
-  --checkout FULL_40_CHARACTER_COMMIT_SHA \
-  --verify-commit \
-  --directory "$HOME/.stayturgid/ansible-pull/candidate" \
-  --inventory localhost, \
-  --connection local \
-  ansible/playbooks/pull/device-local.yml
-```
-
-Do not add `--force`, `--clean`, `--accept-host-key`, `--ask-vault-pass`, or
-`--ask-become-pass` to the unattended command. Do not pass secrets through `--extra-vars`
-because command lines can be exposed in process listings and logs.
-
-The final operator interface should be the Python runner, for example:
-
-```bash
-python3 ~/bin/stayturgid_ansible_pull.py status
-python3 ~/bin/stayturgid_ansible_pull.py check --ref FULL_COMMIT_SHA
-python3 ~/bin/stayturgid_ansible_pull.py run --ref FULL_COMMIT_SHA
-python3 ~/bin/stayturgid_ansible_pull.py rollback
-```
-
-## Junior-developer implementation plan
-
-Only begin this work after the maintainer explicitly selects the ansible-pull pilot.
-Do one phase per reviewable commit. Stop at every approval gate.
-
-### Phase 0 — inventory and feasibility, no device mutation
-
-1. Read every file listed in “Current stayturgid constraints,” plus all repository agent
-   rules and the current handoff.
-2. List every task in the Termux-related fleet roles and classify it as `push-only`,
-   `pull-safe candidate`, or `shared artifact`. Include its file/module, inputs, secrets,
-   transport, privilege, rollback method, and current recovery owner.
-3. Inspect S24, P7A, and HD8 read-only for Python version, available storage, Git version,
-   GPG capability, and whether `ansible-core` can be installed in an isolated venv.
-4. Research the exact supported Python range of the selected pinned `ansible-core`
-   release. Do not simply install the newest release.
-5. Add unit-test fixtures for S24/P7A/HD8 capability results. Do not enroll devices yet.
-
-**Gate:** Present dependency size, install time estimate, compatibility matrix, and task
-classification. Ask before installing Ansible on a device.
-
-### Phase 1 — pull-safe playbook on the Mac
-
-1. Add the dedicated local inventory, playbook, and role described above.
-2. Manage one sentinel file only. It must contain no secret and must not affect recovery.
-3. Assert local connection, the Termux user, allowed path prefixes, and
-   `stayturgid_ansible_pull_enabled`. Fail closed on an unexpected platform or path.
-4. Add syntax, lint, check-mode, idempotence, and molecule/fixture tests appropriate to
-   the repository. Two consecutive applies must report no change on the second run.
-5. Add a CI job that exercises only the pull-safe entry point and rejects imports of the
-   site/fleet/control-node playbooks, `delegate_to`, `become`, and obvious secret paths.
-
-**Gate:** No phone changes. Review the boundary and tests before proceeding.
-
-### Phase 2 — Python runner and failure tests on the Mac
-
-1. Implement the Python runner with dependency injection for clock, subprocess, network,
-   battery, and filesystem boundaries.
-2. Unit-test lock contention, no network, invalid ref, bad signature, syntax failure,
-   check failure, apply timeout, apply failure, validation failure, atomic status writes,
-   successful promotion, and rollback.
-3. Ensure logs use the repository's standard logging helpers and UNIX syslog format.
-4. Ensure every subprocess has an explicit timeout and argument list; do not use
-   `shell=True`.
-5. Add a report-only configuration. `enabled` must default to false everywhere.
-
-**Gate:** Run the full repository checks. Ask before device bootstrap.
-
-### Phase 3 — manual S24 pilot
-
-1. Use push Ansible to install the isolated, pinned runtime and trusted signer on S24.
-2. Seed a known-good exact commit and leave scheduling disabled.
-3. Run `status`, then `check`; inspect logs and state before a live run.
-4. Apply only the sentinel. Run twice and prove idempotence.
-5. Exercise bad signature, network loss, lock contention, timeout, and rollback without
-   impairing SSH, ADB, CFEngine, the repair loop, or AutoJs6.
-6. Reboot S24 and confirm that existing recovery works before any pull is requested.
-
-**Gate:** Observe S24 for at least several normal repair cycles. Review results before
-enabling a schedule or adding managed files.
-
-### Phase 4 — scheduled S24 and limited policy
-
-1. Add the low-frequency scheduler hook with durable timestamps, jitter, and backoff.
-2. Add health output and an operator-visible manual trigger request.
-3. Move at most one low-risk file group at a time into the pull-safe role.
-4. For every file, add push/pull byte-parity and ownership tests.
-5. Verify offline boot, GitHub outage, a bad promoted revision, repeated failure, and
-   recovery by Mac push.
-
-**Gate:** Write a new ADR using measured resource, reliability, and operator results.
-The ADR decides whether to stop, keep an optional hybrid, or expand the local subset.
-
-### Phase 5 — P7A, then an explicit HD8 decision
-
-Enroll P7A only after S24 is stable. Repeat failure tests rather than assuming parity.
-HD8 comes last. Measure installation size, runtime, heat/battery impact, and Doze/Fire OS
-process survival. It is acceptable—and likely prudent—for HD8 to remain disabled while
-still being an active fleet member served by push Ansible, Python repair, and CFEngine.
-
-## Acceptance criteria for a useful pilot
-
-The pilot is successful only if all are true:
-
-- a device converges the sentinel and approved local files without Mac reachability;
-- it never executes an unapproved or unverifiable revision;
-- no pull path contains or retrieves fleet-control secrets;
-- no prompt, root, become, GUI, or operator approval is required during a scheduled run;
-- overlapping runs cannot occur;
-- network loss and failed applies preserve the last-known-good state;
-- push Ansible can repair or disable the pull runtime;
-- SSH/ADB/CFEngine/Python/AutoJs6 recovery continues independently;
-- status is visible and actionable without reading a large raw Ansible log;
-- repeated apply is idempotent; and
-- measured CPU, storage, battery, and elapsed-time cost is acceptable on each enrolled
-  device class.
-
-Stop the pilot if it makes reachability less reliable, creates policy fights, requires
-device-held high-value credentials, or costs more operational complexity than the few
-local files it can safely own.
-
-## Decisions intentionally deferred
-
-The junior developer must not decide these implicitly while coding:
-
-1. whether production promotion uses a signed tag, a signed commit on a deployment
-   branch, or an inventory-pinned SHA distributed by push Ansible;
-2. which signing identity and rotation/revocation procedure to use;
-3. whether the public GitHub repository remains the production source or a release
-   artifact/mirror is introduced;
-4. whether pull eventually owns any CFEngine-generated artifacts;
-5. whether P7A and HD8 enroll; and
-6. whether the successful pilot changes ADR 004's project-wide recommendation.
-
-Record the measured pilot results and these decisions in a new ADR. Do not rewrite
-ADR 004 as though its earlier reasoning never existed.
+If the overhead is acceptable, this will become a complementary self-configuration path. The Kotlin agent remains the primary control plane on the device.

--- a/docs/research/ansible-pull-architecture-2026-07-14.md
+++ b/docs/research/ansible-pull-architecture-2026-07-14.md
@@ -14,12 +14,12 @@ Pure on-device Ansible orchestration is an architectural anti-pattern for Androi
 
 The useful division of responsibility is:
 
-| Layer                 | Responsibility                                                                                                         | Remains authoritative? |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------- | ---------------------- |
-| Mac push Ansible      | Bootstrap, credentials, APKs, ADB/SSH transport, UI-assisted setup, and fleet coordination                             | Yes (Primary)          |
-| Kotlin Agent          | Native health checks, fast reachability, Shizuku bindings, and gating/scheduling for on-device Ansible                 | Yes (Primary)          |
-| Device `ansible-pull` | A small allowlisted set of non-secret declarative tasks, executed infrequently via local connection                    | Hybrid Pilot           |
-| Python repair loop    | Deprecated in favor of the Kotlin agent for on-device repair                                                           | No                     |
+| Layer                 | Responsibility                                                                                         | Remains authoritative? |
+| --------------------- | ------------------------------------------------------------------------------------------------------ | ---------------------- |
+| Mac push Ansible      | Bootstrap, credentials, APKs, ADB/SSH transport, UI-assisted setup, and fleet coordination             | Yes (Primary)          |
+| Kotlin Agent          | Native health checks, fast reachability, Shizuku bindings, and gating/scheduling for on-device Ansible | Yes (Primary)          |
+| Device `ansible-pull` | A small allowlisted set of non-secret declarative tasks, executed infrequently via local connection    | Hybrid Pilot           |
+| Python repair loop    | Deprecated in favor of the Kotlin agent for on-device repair                                           | No                     |
 
 ## Technical Feasibility & Constraints
 
@@ -32,6 +32,7 @@ Our research into Android 12+ process management and Shizuku (`rish`) privilege 
 Ansible relies on writing temporary compiled Python modules to the local filesystem (e.g., inside Termux at `~/.ansible/tmp/`) and then executing them with elevated privileges. Because Termux runs as an isolated app user (e.g., `u0_a100`) and UID 2000 is heavily restricted by Android's strict SELinux MAC (Mandatory Access Control) policies, `rish` cannot read or execute files within Termux's private data directory. Attempting this results in SELinux "Permission denied" errors.
 
 **Mitigation:** We must use `connection: local` exclusively. Playbooks run as the unprivileged Termux user. For the few tasks requiring privileges, we must explicitly wrap them using the `shell` or `command` modules:
+
 ```yaml
 - name: Set a secure setting
   shell: rish -c "settings put secure some_key some_value"
@@ -43,7 +44,8 @@ Starting in Android 12, and persisting through Android 16 and 17, the OS aggress
 
 Ansible relies heavily on `fork()` to spawn worker processes. Running an `ansible-playbook` locally is exactly the type of workload the Phantom Process Killer targets, especially on lower-end devices like the Fire HD 8.
 
-**Mitigation:** 
+**Mitigation:**
+
 1. **Disable Child Process Restrictions:** Android 14+ (including Android 16 and 17) includes a "Disable child process restrictions" toggle in Developer Options. Push Ansible must enable this during initial provisioning, or the Kotlin agent must enforce this setting via Shizuku (`device_config put activity_manager max_phantom_processes 2147483647` or equivalent native secure settings).
 2. **Strict Gating:** Runs must only occur when the device is charging, idle (screen off), and battery is >50%.
 3. **Kotlin Agent Wrapper:** The `stayturgid-agent` must hold a WakeLock during the run.
@@ -53,7 +55,8 @@ Ansible relies heavily on `fork()` to spawn worker processes. Running an `ansibl
 
 Ansible is not designed for battery-powered execution. Furthermore, using `ansible-pull` requires playbooks and inventory variables to exist on the local filesystem.
 
-**Mitigation:** 
+**Mitigation:**
+
 - Keep secrets off-device. No long-lived Vault passwords should be stored on the phone.
 - Use `ansible-pull` to fetch the playbook, run it, and exit. Do not run a long-lived `ansible-playbook` daemon.
 

--- a/tests/healing_registry.json
+++ b/tests/healing_registry.json
@@ -65,26 +65,26 @@
     "PORT5555-OPEN": {
       "description": "Privileged shell on localhost:5555 (wireless debug enabled, uid 2000)",
       "must_cover": ["termux_repair", "native_agent"],
-      "should_cover": ["cfengine", "firerpa"]
+      "should_cover": ["firerpa"]
     },
     "SHIZUKU-HEADLESS": {
       "description": "Shizuku headless server running (HEADLESS_STATUS + pgrep)",
       "must_cover": ["termux_repair", "firerpa", "native_agent"],
-      "should_cover": ["cfengine"]
+      "should_cover": []
     },
     "A11Y-AUTOJS6": {
       "description": "AutoJs6 accessibility service enabled (detection-only; user must enable manually)",
       "must_cover": ["termux_repair", "fleet_health"],
-      "should_cover": ["cfengine", "ansible_deploy"]
+      "should_cover": ["ansible_deploy"]
     },
     "MIRROR-PINNED": {
       "description": "Termux main mirror pinned to packages-cf.termux.dev (deterministic pkg)",
-      "must_cover": ["termux_repair", "cfengine", "ansible_deploy"],
+      "must_cover": ["termux_repair", "ansible_deploy"],
       "should_cover": []
     },
     "PATH-CLEAN": {
       "description": "No leaked Mac-style PATH entries in Termux shell profiles",
-      "must_cover": ["termux_repair", "cfengine", "ansible_deploy"],
+      "must_cover": ["termux_repair", "ansible_deploy"],
       "should_cover": []
     },
     "ET-CONFIG": {
@@ -210,7 +210,7 @@
     "NATIVE-AGENT-RUNNING": {
       "description": "Native-agent release package is the sole installed variant and HostService is running after deploy or upgrade",
       "must_cover": ["ansible_deploy", "fleet_health"],
-      "should_cover": []
+      "should_cover": ["cfengine"]
     },
     "OBTAINIUM-OPS-LOCK": {
       "description": "Obtainium receives the declarative fleet catalog headlessly and cannot background-update ops-locked applications",

--- a/tests/python/test_cf_runagent_repair.py
+++ b/tests/python/test_cf_runagent_repair.py
@@ -1,0 +1,92 @@
+"""Regression tests for the Tier 3a CFEngine cf-runagent fallback.
+
+Guards the two bugs that made the original fallback a no-op against a real
+cf-runagent (CFEngine Core 3.28.0):
+
+  1. `--protocol-version` is not a cf-runagent flag (it exits rc=1). The wire
+     protocol is pinned in the config body instead, so it must never appear on
+     the command line.
+  2. A bare trailing host arg is parsed as an input FILE (overriding -f), not a
+     host — the target must be passed via -H/--hail.
+
+Also checks the cooldown stamp is written on the missing-config early-return so
+an unprovisioned Mac does not re-probe port 5308 every health cycle.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+
+import fleet_health_monitor as monitor
+
+
+def test_cf_runagent_cmd_targets_host_with_hail() -> None:
+    cmd = monitor._cf_runagent_cmd("/opt/homebrew/bin/cf-runagent", "/cfg/cf-runagent.cf", "100.64.0.9")
+
+    # No invalid protocol flag (protocol_version is pinned in the config body).
+    assert "--protocol-version" not in cmd
+    # Host is hailed via -H, immediately followed by the IP.
+    assert "-H" in cmd
+    assert cmd[cmd.index("-H") + 1] == "100.64.0.9"
+    # The IP must not appear as a bare trailing positional (that would be parsed
+    # as an input FILE and override -f).
+    assert cmd[-1] != "100.64.0.9"
+    assert cmd[-2:] == ["--remote-bundles", "stayturgid_heal"]
+    # Config is passed with -f.
+    assert cmd[cmd.index("-f") + 1] == "/cfg/cf-runagent.cf"
+
+
+def _stub_reachable(monkeypatch) -> None:
+    """Make the port-5308 TCP probe always succeed."""
+
+    class _Sock:
+        def close(self) -> None:  # noqa: D401
+            pass
+
+    monkeypatch.setattr(socket, "create_connection", lambda *a, **k: _Sock())
+
+
+def test_missing_config_still_writes_cooldown_stamp(monkeypatch, tmp_path) -> None:
+    """A Mac without a rendered cf-runagent.cf must not re-probe every cycle."""
+    root = tmp_path
+    (root / "state").mkdir()
+    monkeypatch.setattr(monitor, "ROOT", str(root))
+    _stub_reachable(monkeypatch)
+    # cf_config path will not exist under tmp_path -> missing-config branch.
+
+    def _boom(*_a, **_k):  # subprocess must NOT run when config is missing
+        raise AssertionError("subprocess.run should not be called")
+
+    monkeypatch.setattr(monitor.subprocess, "run", _boom)
+
+    monitor._try_cf_runagent_repair("hd8", "100.64.0.9")
+
+    stamp = root / "state" / "cfengine-heal-fallback-hd8"
+    assert stamp.exists(), "cooldown stamp must be written even on missing-config early return"
+
+
+def test_cooldown_suppresses_second_attempt(monkeypatch, tmp_path) -> None:
+    root = tmp_path
+    (root / "state").mkdir()
+    monkeypatch.setattr(monitor, "ROOT", str(root))
+    _stub_reachable(monkeypatch)
+
+    # Pre-write a fresh stamp -> within cooldown window.
+    stamp = root / "state" / "cfengine-heal-fallback-hd8"
+    stamp.write_text("0")
+    os.utime(stamp, None)
+
+    calls = []
+    monkeypatch.setattr(monitor.subprocess, "run", lambda *a, **k: calls.append(a))
+
+    monitor._try_cf_runagent_repair("hd8", "100.64.0.9")
+    assert calls == [], "attempt within cooldown window must be suppressed"
+
+
+def test_no_ts_ip_is_noop(monkeypatch) -> None:
+    def _boom(*_a, **_k):
+        raise AssertionError("should not probe without a ts_ip")
+
+    monkeypatch.setattr(socket, "create_connection", _boom)
+    monitor._try_cf_runagent_repair("hd8", "")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automatic CFEngine recovery fallback when devices are unreachable through standard health checks.
  * Improved recovery of the native Android agent and related repair channels.
  * Enhanced fleet health monitoring with CFEngine repair-log visibility.

* **Bug Fixes**
  * Improved compatibility between different CFEngine client and server versions.
  * Refined recovery checks and access permissions for supported device services.

* **Documentation**
  * Updated CFEngine operations, fallback behavior, and hybrid Ansible pilot guidance.
  * Clarified protocol configuration and recovery procedures.

* **Tests**
  * Added coverage for recovery targeting, cooldown handling, missing configuration, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->