### PR TITLE
release: advance ops suite to 1.0.6

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.0.5"
+  "version": "1.0.6"
 }


### PR DESCRIPTION
Coordinated ops suite release 1.0.6.

Bumps `ops-release.json` to 1.0.6. In stayturgid this release ships the Tier 3a cf-runagent fix (PR #81). site-djbclark and site-private carry the version bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application release version to 1.0.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->