### PR TITLE
fix(cfengine): pin Mac to 3.27.1 + add cf-serverd roles auth

### DIFF
--- a/device/termux/cfengine/policy/cf-serverd.cf
+++ b/device/termux/cfengine/policy/cf-serverd.cf
@@ -44,6 +44,17 @@ body server control {
 }
 
 bundle server access_rules() {
+  # Authorize which remote users may trigger cfruncommand execution. WITHOUT a
+  # roles promise, cf-serverd logs "No promise type roles in bundle
+  # access_rules" and answers every cf-runagent exec with "Unspecified server
+  # refusal" — even after TLS + key trust + allowusers all pass. Verified on the
+  # live fleet: this, not a protocol-version mismatch, is why Tier 3a hails were
+  # refused (both ends on CFEngine 3.27.1). The control node connects as root or
+  # the operator SSH user. See stayturgid#84.
+  roles:
+    ".*"
+      authorize => { "root", "{{ stayturgid_control_ssh_user | default(stayturgid_mac_peer.user | default(ansible_user)) }}" };
+
   access:
     # Allow remote execution of the cf-agent binary (the cfruncommand).
     # Without this, cf-runagent connections get "EXEC denied due to ACL".

--- a/docs/architecture/components/cfengine-server.md
+++ b/docs/architecture/components/cfengine-server.md
@@ -87,16 +87,22 @@ that does not depend on ADB or SSH.
 
 ## Known issues
 
-1. **cf-runagent protocol version mismatch** (Mac 3.28.0 vs Termux 3.27.1):
-   The newer Mac cf-runagent otherwise negotiates a version the older Termux
-   cf-serverd refuses ("Unspecified server refusal"). Fixed by pinning
-   `protocol_version => "2"` in `body common control` of the rendered
-   `cf-runagent.cf` (template: `cf-runagent.cf.j2`). Note there is **no**
-   `--protocol-version` command-line flag on cf-runagent — it exits rc=1 on an
-   unknown option, so the pin must live in the config body. Targeting is per
-   host via `-H <ip>`: a bare trailing arg is parsed as an input FILE and would
-   override `-f`. `_try_cf_runagent_repair()` in `fleet_health_monitor.py` is
-   the Tier 3a fallback.
+1. **cf-runagent "Unspecified server refusal" — root cause is a missing `roles`
+   promise, not a protocol mismatch.** Live-fleet testing (stayturgid#84) showed
+   the refusal persists with **both ends on CFEngine 3.27.1** and after TLS +
+   key trust + `allowusers` all pass. The server debug log is explicit:
+   `No promise type roles in bundle access_rules` — cf-serverd requires a
+   `roles` promise authorizing which remote users may trigger `cfruncommand`
+   execution. Fixed by adding a `roles: ".*" authorize => { root, <operator> }`
+   promise to `cf-serverd.cf`. Version hygiene, applied alongside: the Mac
+   control node is pinned to CFEngine **3.27.1** to match the fleet
+   (`packaging/homebrew/cfengine@3.27.1.rb`, `just cfengine-pin`), and
+   `protocol_version => "2"` is set in the rendered `cf-runagent.cf` body (there
+   is **no** `--protocol-version` CLI flag — cf-runagent exits rc=1 on it).
+   Targeting is per host via `-H <ip>` (a bare trailing arg is parsed as an input
+   FILE, overriding `-f`). `_try_cf_runagent_repair()` in
+   `fleet_health_monitor.py` is the Tier 3a fallback. The roles fix is in the
+   policy source pending a device deploy + final end-to-end verification.
 
 2. **Android seccomp blocks fork**: cf-serverd must be started with `-F` (foreground)
    flag. No fork is attempted. `nohup ... &` + PID file monitoring in boot loop

--- a/just/cfengine.just
+++ b/just/cfengine.just
@@ -1,5 +1,22 @@
 # CFEngine Build project commands. Policy logic remains in device/termux/cfengine.
 
+# Pin the Mac control-node CFEngine to 3.27.1 to match the Termux fleet, and
+# stop brew upgrade from bumping it. Idempotent. See packaging/homebrew/README.md.
+cfengine-pin:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    tap="cfengine-local/cfengine"
+    brew tap-new "$tap" >/dev/null 2>&1 || true
+    cp "{{ repo }}/packaging/homebrew/cfengine@3.27.1.rb" "$(brew --repo "$tap")/Formula/"
+    if ! brew list --versions cfengine@3.27.1 >/dev/null 2>&1; then
+      brew install "$tap/cfengine@3.27.1"
+    fi
+    brew uninstall --ignore-dependencies cfengine >/dev/null 2>&1 || true
+    brew link --overwrite cfengine@3.27.1 >/dev/null 2>&1 || true
+    brew pin cfengine@3.27.1 >/dev/null 2>&1 || true
+    echo "pinned: $(brew list --pinned | grep cfengine || echo NONE)"
+    cf-runagent --version | head -1
+
 cfbs-validate:
     cd device/termux/cfengine && cfbs validate
     cf-promises -f "{{ repo }}/device/termux/cfengine/policy/stayturgid.cf"

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,41 @@
+# Mac control-node Homebrew formulae
+
+## `cfengine@3.27.1` — pinned to match the Termux fleet
+
+The Mac control node talks to the fleet's Termux `cf-serverd` (via `cf-runagent`,
+Tier 3a hail-mary recovery). Termux CFEngine is **3.27.1**. Homebrew-core's
+`cfengine` formula tracks the latest (3.28.0+), and a newer control-node
+CFEngine is one variable that can complicate the already-fragile 3.27↔newer
+`cf-runagent`↔`cf-serverd` handshake.
+
+To keep both ends on the **same** version we pin the Mac to CFEngine Core
+**3.27.1** and prevent `brew upgrade` from bumping it.
+
+`cfengine@3.27.1.rb` is the homebrew-core `cfengine` formula as it stood at
+3.27.1 (`brew extract`), pointing at the official community dist tarball
+(includes the `libntech` submodule — the GitHub git-archive tarball does not, so
+a naive `@3.27` source build fails at `make install`).
+
+### Install / re-pin (manual, until deploy-mac is fixed — see stayturgid#85)
+
+```bash
+just cfengine-pin            # tap + install cfengine@3.27.1 + brew pin + drop plain cfengine
+# or manually:
+brew tap-new cfengine-local/cfengine 2>/dev/null || true
+cp packaging/homebrew/cfengine@3.27.1.rb \
+   "$(brew --repo cfengine-local/cfengine)/Formula/"
+brew uninstall --ignore-dependencies cfengine 2>/dev/null || true
+brew install cfengine-local/cfengine/cfengine@3.27.1
+brew link --overwrite cfengine@3.27.1
+brew pin cfengine@3.27.1
+```
+
+### Verify
+
+```bash
+cf-runagent --version      # => CFEngine Core 3.27.1  (matches Termux cf-serverd)
+brew list --pinned | grep cfengine   # => cfengine@3.27.1
+```
+
+To intentionally move both ends later, bump the device CFEngine first, then
+re-`brew extract` the matching Mac formula here and update the pin.

--- a/packaging/homebrew/cfengine@3.27.1.rb
+++ b/packaging/homebrew/cfengine@3.27.1.rb
@@ -1,0 +1,74 @@
+class CfengineAT3271 < Formula
+  desc "Help manage and understand IT infrastructure"
+  homepage "https://cfengine.com/"
+  url "https://cfengine-package-repos.s3.amazonaws.com/tarballs/cfengine-community-3.27.1.tar.gz"
+  sha256 "878e52c4a6cc3bd28048b527a920fba86ce4cd99c5760adc42417a811efa6e6b"
+  license all_of: ["BSD-3-Clause", "GPL-2.0-or-later", "GPL-3.0-only", "LGPL-2.0-or-later"]
+
+  livecheck do
+    url "https://cfengine-package-repos.s3.amazonaws.com/release-data/community/releases.json"
+    strategy :json do |json|
+      json["releases"]&.map do |release|
+        next if release["beta"] || release["debug"]
+
+        release["version"]
+      end
+    end
+  end
+
+  depends_on "librsync"
+  depends_on "lmdb"
+  depends_on "openssl@3"
+  depends_on "pcre2"
+
+  uses_from_macos "curl", since: :ventura # uses CURLOPT_PROTOCOLS_STR, available since curl 7.85.0
+  uses_from_macos "libxml2"
+
+  on_linux do
+    depends_on "linux-pam"
+  end
+
+  resource "masterfiles" do
+    url "https://cfengine-package-repos.s3.amazonaws.com/tarballs/cfengine-masterfiles-3.27.1.tar.gz"
+    sha256 "fd32c1255c0114d55929b496a15a6a6f48231f108be23f50ad3b8abc2e734ccf"
+
+    livecheck do
+      formula :parent
+    end
+  end
+
+  def install
+    odie "masterfiles resource needs to be updated" if version != resource("masterfiles").version
+
+    args = %W[
+      --with-workdir=#{var}/cfengine
+      --with-lmdb=#{formula_opt_prefix("lmdb")}
+      --with-pcre2=#{formula_opt_prefix("pcre2")}
+      --without-mysql
+      --without-postgresql
+    ]
+
+    args << "--with-systemd-service=no" if OS.linux?
+
+    system "./configure", *args, *std_configure_args
+    system "make", "install"
+    (pkgshare/"CoreBase").install resource("masterfiles")
+  end
+
+  def post_install
+    workdir = var/"cfengine"
+    secure_dirs = %W[
+      #{workdir}/inputs
+      #{workdir}/outputs
+      #{workdir}/ppkeys
+      #{workdir}/plugins
+    ]
+    chmod 0700, secure_dirs
+    chmod 0750, workdir/"state"
+    chmod 0755, workdir/"modules"
+  end
+
+  test do
+    assert_equal "CFEngine Core #{version}", shell_output("#{bin}/cf-agent -V").chomp
+  end
+end


### PR DESCRIPTION
## Summary
From the live-fleet investigation of the Tier 3a cf-runagent hail-mary (ops-v1.0.6, #81).

**Root cause of "Unspecified server refusal" (#84): a missing `roles` promise, not a protocol mismatch.** It persists with both ends on CFEngine 3.27.1 and after TLS + key-trust + `allowusers` all pass. Server debug log: `No promise type roles in bundle access_rules`. Fix: add `roles: ".*" authorize => { root, <operator> }` to `cf-serverd.cf` (cf-promises-validated; Jinja2 parses). Pending device deploy + final e2e verification.

**Mac CFEngine pinned to 3.27.1** to match the fleet and stop `brew upgrade` bumping it:
- `packaging/homebrew/cfengine@3.27.1.rb` (official community dist tarball — the git-archive tarball omits `libntech` and fails `make install`).
- `just cfengine-pin` (idempotent). Applied locally: all cf-* binaries report 3.27.1, pinned.

Refs #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved remote agent execution reliability by authorizing supported roles, preventing unexplained server refusals.

- **New Features**
  - Added a command to install and pin CFEngine 3.27.1 on macOS, keeping control-node and device versions aligned.
  - Added a packaged CFEngine 3.27.1 Homebrew formula.

- **Documentation**
  - Updated troubleshooting guidance for remote execution failures, protocol configuration, host targeting, version alignment, and recovery behavior.
  - Added instructions for installing, verifying, and updating the pinned macOS CFEngine version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->