### PR TITLE
release: advance ops suite to 1.0.7

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.0.6"
+  "version": "1.0.7"
 }


### PR DESCRIPTION
Coordinated ops suite release 1.0.7. stayturgid ships the Mac CFEngine 3.27.1 pin + cf-serverd roles auth fix (#87, refs #84); site-* carry the version bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application release version to 1.0.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->