### PR TITLE
fix(cfengine): cf-serverd verbose toggle + correct unverified-fix docs

### DIFF
--- a/ansible/roles/control_node/templates/cf-runagent.cf.j2
+++ b/ansible/roles/control_node/templates/cf-runagent.cf.j2
@@ -7,11 +7,10 @@
 
 body common control {
     bundlesequence => { "main" };
-    # Pin the wire protocol so the Mac's newer cf-runagent negotiates a version
-    # the fleet's older Termux cf-serverd accepts. Without this, a 3.28 (Mac) ->
-    # 3.27 (Termux) hail fails with "Unspecified server refusal". "2" is the TLS
-    # protocol both sides share. Set here (not on argv): cf-runagent has no
-    # --protocol-version flag.
+    # Pin the wire protocol to "2" (TLS) for a deterministic handshake. Set here
+    # (not on argv): cf-runagent has no --protocol-version flag. NOTE: this does
+    # NOT resolve the "Unspecified server refusal" — that persists with both ends
+    # on CFEngine 3.27.1 and has a separate, still-open cause (stayturgid#84).
     protocol_version => "2";
 }
 

--- a/control/cfengine/cf-runagent.cf.example
+++ b/control/cfengine/cf-runagent.cf.example
@@ -6,11 +6,10 @@
 
 body common control {
     bundlesequence => { "main" };
-    # Pin the wire protocol so the Mac's newer cf-runagent negotiates a version
-    # the fleet's older Termux cf-serverd accepts. Without this, a 3.28 (Mac) ->
-    # 3.27 (Termux) hail fails with "Unspecified server refusal". "2" is the TLS
-    # protocol both sides share. Set here (not on argv): cf-runagent has no
-    # --protocol-version flag.
+    # Pin the wire protocol to "2" (TLS) for a deterministic handshake. Set here
+    # (not on argv): cf-runagent has no --protocol-version flag. NOTE: this does
+    # NOT resolve the "Unspecified server refusal" — that persists with both ends
+    # on CFEngine 3.27.1 and has a separate, still-open cause (stayturgid#84).
     protocol_version => "2";
 }
 

--- a/device/termux/cfengine/policy/cf-serverd.cf
+++ b/device/termux/cfengine/policy/cf-serverd.cf
@@ -44,13 +44,14 @@ body server control {
 }
 
 bundle server access_rules() {
-  # Authorize which remote users may trigger cfruncommand execution. WITHOUT a
-  # roles promise, cf-serverd logs "No promise type roles in bundle
-  # access_rules" and answers every cf-runagent exec with "Unspecified server
-  # refusal" — even after TLS + key trust + allowusers all pass. Verified on the
-  # live fleet: this, not a protocol-version mismatch, is why Tier 3a hails were
-  # refused (both ends on CFEngine 3.27.1). The control node connects as root or
-  # the operator SSH user. See stayturgid#84.
+  # Authorize which remote users may trigger cfruncommand execution. Kept as a
+  # CANDIDATE for the cf-runagent "Unspecified server refusal" (stayturgid#84):
+  # cf-serverd logs "No promise type roles in bundle access_rules" when it is
+  # absent. UNVERIFIED — a live e2e test with this promise deployed (both ends
+  # CFEngine 3.27.1, after TLS + key trust + allowusers all pass) STILL got the
+  # refusal, so this is necessary-at-most, not the fix. Root cause is still open;
+  # see #84 for the -v capture plan. The control node connects as root or the
+  # operator SSH user.
   roles:
     ".*"
       authorize => { "root", "{{ stayturgid_control_ssh_user | default(stayturgid_mac_peer.user | default(ansible_user)) }}" };

--- a/device/termux/py/start_adb.py
+++ b/device/termux/py/start_adb.py
@@ -39,6 +39,29 @@ BOOTLOOP_PID_FILE = os.path.join(STG, "run", "bootloop.pid")
 CFENGINE_CF = os.path.join(STG, "cfengine", "stayturgid.cf")
 CF_SERVERD_CF = os.path.join(STG, "cfengine", "cf-serverd.cf")
 CF_SERVERD_PID = os.path.join(STG, "run", "cf-serverd.pid")
+
+
+def _cfserverd_argv() -> list[str]:
+    """cf-serverd argv, with optional verbosity for investigation.
+
+    cf-serverd only survives on Termux as a child of this persistent boot loop;
+    an SSH-launched instance dies on session close, so verbose logging cannot be
+    obtained ad hoc. Set STAYTURGID_CFSERVERD_VERBOSE to make the boot-loop
+    instance log the reason for e.g. cf-runagent "Unspecified server refusal"
+    (stayturgid#84): "1" -> -v, "2"/"debug" -> -d, or an explicit "-<flag>".
+    Unset/"0" keeps the quiet default.
+    """
+    argv = [os.path.join(PREFIX, "bin", "cf-serverd"), "-Ff", CF_SERVERD_CF]
+    v = os.environ.get("STAYTURGID_CFSERVERD_VERBOSE", "").strip()
+    if v in ("1", "v"):
+        argv.append("-v")
+    elif v in ("2", "d", "debug"):
+        argv.append("-d")
+    elif v.startswith("-"):
+        argv.append(v)
+    return argv
+
+
 VERSION_CHECK_STAMP = os.path.join(STG, "state", "last_version_check")
 OTELCOL_START = os.path.join(HOME, ".termux", "boot", "start-otelcol.sh")
 
@@ -191,7 +214,7 @@ def startup_cfserverd() -> None:
     if _pid_alive(CF_SERVERD_PID):
         return
     pid = _run_bg(
-        [os.path.join(PREFIX, "bin", "cf-serverd"), "-Ff", CF_SERVERD_CF],
+        _cfserverd_argv(),
         log_path=os.path.join(STG, "logs", "cf-serverd.log"),
     )
     if pid > 0:
@@ -442,7 +465,7 @@ def _monitor_cfserverd() -> None:
     if not os.access(cf_bin, os.X_OK) or not os.path.isfile(CF_SERVERD_CF):
         return
     pid = _run_bg(
-        [cf_bin, "-Ff", CF_SERVERD_CF],
+        _cfserverd_argv(),
         log_path=os.path.join(STG, "logs", "cf-serverd.log"),
     )
     if pid > 0:

--- a/docs/architecture/components/cfengine-server.md
+++ b/docs/architecture/components/cfengine-server.md
@@ -87,22 +87,31 @@ that does not depend on ADB or SSH.
 
 ## Known issues
 
-1. **cf-runagent "Unspecified server refusal" — root cause is a missing `roles`
-   promise, not a protocol mismatch.** Live-fleet testing (stayturgid#84) showed
-   the refusal persists with **both ends on CFEngine 3.27.1** and after TLS +
-   key trust + `allowusers` all pass. The server debug log is explicit:
-   `No promise type roles in bundle access_rules` — cf-serverd requires a
-   `roles` promise authorizing which remote users may trigger `cfruncommand`
-   execution. Fixed by adding a `roles: ".*" authorize => { root, <operator> }`
-   promise to `cf-serverd.cf`. Version hygiene, applied alongside: the Mac
-   control node is pinned to CFEngine **3.27.1** to match the fleet
-   (`packaging/homebrew/cfengine@3.27.1.rb`, `just cfengine-pin`), and
-   `protocol_version => "2"` is set in the rendered `cf-runagent.cf` body (there
-   is **no** `--protocol-version` CLI flag — cf-runagent exits rc=1 on it).
-   Targeting is per host via `-H <ip>` (a bare trailing arg is parsed as an input
-   FILE, overriding `-f`). `_try_cf_runagent_repair()` in
-   `fleet_health_monitor.py` is the Tier 3a fallback. The roles fix is in the
-   policy source pending a device deploy + final end-to-end verification.
+1. **cf-runagent "Unspecified server refusal" — UNRESOLVED (root cause still
+   open).** Live-fleet testing (stayturgid#84) ruled out the protocol version:
+   the refusal persists with **both ends on CFEngine 3.27.1**, after TLS + key
+   trust + `allowusers` + the `cf_agent_exec_access` ACL all pass. Two candidate
+   changes were tried and **neither fixed it** (both kept as harmless, valid
+   hygiene, not verified fixes):
+   - a `roles: ".*" authorize => { root, <operator> }` promise in
+     `cf-serverd.cf` — cf-serverd logs `No promise type roles in bundle
+access_rules` without one, but the refusal **persisted with it deployed
+     and loaded** on the live device (that debug line is likely incidental);
+   - `protocol_version => "2"` in the rendered `cf-runagent.cf` body (there is
+     **no** `--protocol-version` CLI flag — cf-runagent exits rc=1 on it).
+
+   The refusal fires at the EXEC/`cfruncommand` authorization stage; its
+   server-side reason with `roles` loaded has not been captured because
+   cf-serverd only survives on Termux under the boot-loop daemon (SSH-launched
+   instances die on session close). **Next step:** set
+   `STAYTURGID_CFSERVERD_VERBOSE=1` (or `=debug`) so the boot-loop cf-serverd
+   logs the refusal reason, then reproduce a hail. Confirmed-correct pieces:
+   Mac control node pinned to CFEngine **3.27.1**
+   (`packaging/homebrew/cfengine@3.27.1.rb`, `just cfengine-pin`); per-host
+   targeting via `-H <ip>` (a bare trailing arg is parsed as an input FILE,
+   overriding `-f`); `_try_cf_runagent_repair()` in `fleet_health_monitor.py`
+   builds a valid argv. The working repair path today is SSH-based
+   (`just cf-run`); cf-runagent is only needed when SSH is also down.
 
 2. **Android seccomp blocks fork**: cf-serverd must be started with `-F` (foreground)
    flag. No fork is attempted. `nohup ... &` + PID file monitoring in boot loop

--- a/tests/python/test_start_adb.py
+++ b/tests/python/test_start_adb.py
@@ -11,6 +11,23 @@ sys.path.insert(0, str(REPO / "device" / "termux" / "py"))
 import start_adb
 
 
+def test_cfserverd_argv_quiet_by_default(monkeypatch):
+    monkeypatch.delenv("STAYTURGID_CFSERVERD_VERBOSE", raising=False)
+    argv = start_adb._cfserverd_argv()
+    assert argv[-2:] == ["-Ff", start_adb.CF_SERVERD_CF]
+    assert "-v" not in argv and "-d" not in argv
+
+
+def test_cfserverd_argv_verbose_toggle(monkeypatch):
+    for val, flag in [("1", "-v"), ("v", "-v"), ("2", "-d"), ("debug", "-d")]:
+        monkeypatch.setenv("STAYTURGID_CFSERVERD_VERBOSE", val)
+        assert start_adb._cfserverd_argv()[-1] == flag, val
+    monkeypatch.setenv("STAYTURGID_CFSERVERD_VERBOSE", "0")
+    assert start_adb._cfserverd_argv()[-1] == start_adb.CF_SERVERD_CF
+    monkeypatch.setenv("STAYTURGID_CFSERVERD_VERBOSE", "--log-level=verbose")
+    assert start_adb._cfserverd_argv()[-1] == "--log-level=verbose"
+
+
 def test_shell_transport_prefers_localhost_adb(monkeypatch):
     monkeypatch.setattr(start_adb, "_run", lambda *args, **kwargs: 0)
     monkeypatch.setattr(start_adb, "_capture", lambda *args, **kwargs: (0, "2000\n"))


### PR DESCRIPTION
Follow-up to the #84 investigation.

- **cf-serverd verbose toggle**: `STAYTURGID_CFSERVERD_VERBOSE` (=1 → -v, =debug → -d) in `start_adb.py` so the **boot-loop** cf-serverd can log the refusal reason. SSH-launched cf-serverd dies on session close; only the persistent daemon survives — this is the only reliable way to capture the server-side reason on Termux. +unit tests.
- **Doc corrections**: the ops-v1.0.7 `roles` change did **not** resolve the refusal (live e2e on p7a, both ends 3.27.1, roles loaded → still refused). Reframed `cfengine-server.md` Known Issues as UNRESOLVED; softened the `cf-serverd.cf` roles comment and `cf-runagent.cf` protocol_version comments to unverified-candidate/hygiene.

Refs #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)