### PR TITLE
fix(deploy): make a normal deploy fully apply CFEngine changes

### DIFF
--- a/ansible/roles/control_node/defaults/main.yml
+++ b/ansible/roles/control_node/defaults/main.yml
@@ -61,6 +61,9 @@ stayturgid_mac_uv_tools:
   - uiautomator2
   - mypy
   - bandit
+  # Builds the device CFEngine policy artifact (cfbs build) during a fleet
+  # deploy — the termux_userland role delegates the build to the control node.
+  - cfbs
 
 # ── Hermes Agent (control-node messaging gateway) ─────────────────────────
 # Desktop/CLI agent with OpenCode Zen API + optional Telegram remote.

--- a/ansible/roles/control_node/tasks/prereqs.yml
+++ b/ansible/roles/control_node/tasks/prereqs.yml
@@ -18,6 +18,31 @@
     name: "{{ stayturgid_mac_brew_packages_base }}"
     state: present
 
+# CFEngine is intentionally NOT in the base list: we want the version pinned to
+# the Termux fleet (3.27.1), not homebrew-core's latest. Install the vendored
+# formula, drop the plain formula, and pin so `brew upgrade` won't bump it.
+# Mirrors `just cfengine-pin`; see packaging/homebrew/README.md.
+- name: Pin control-node CFEngine to the fleet version (3.27.1)
+  ansible.builtin.shell: |
+    set -uo pipefail
+    if cf-runagent --version 2>/dev/null | grep -q "3\.27\.1" \
+       && brew list --pinned 2>/dev/null | grep -qx "cfengine@3.27.1"; then
+      echo "ALREADY_PINNED"; exit 0
+    fi
+    tap="cfengine-local/cfengine"
+    brew tap-new "$tap" >/dev/null 2>&1 || true
+    cp "{{ stayturgid_repo_root }}/packaging/homebrew/cfengine@3.27.1.rb" \
+       "$(brew --repo "$tap")/Formula/"
+    brew list --versions cfengine@3.27.1 >/dev/null 2>&1 \
+       || brew install "$tap/cfengine@3.27.1"
+    brew uninstall --ignore-dependencies cfengine >/dev/null 2>&1 || true
+    brew link --overwrite cfengine@3.27.1 >/dev/null 2>&1 || true
+    brew pin cfengine@3.27.1
+    echo "PINNED"
+  register: _cfengine_pin
+  changed_when: "'PINNED' in _cfengine_pin.stdout"
+  failed_when: _cfengine_pin.rc != 0 and 'ALREADY_PINNED' not in _cfengine_pin.stdout
+  when: ansible_facts['os_family'] == 'Darwin'
 
 - name: Install app-store Homebrew formulae when enabled
   community.general.homebrew:

--- a/ansible_collections/stayturgid/termux/roles/termux_userland/handlers/main.yml
+++ b/ansible_collections/stayturgid/termux/roles/termux_userland/handlers/main.yml
@@ -5,6 +5,22 @@
   ansible.builtin.command: "{{ termux_prefix }}/bin/termux-reload-settings"
   changed_when: true
 
+# Restart cf-serverd so a redeployed policy (roles/ACL) takes effect. We only
+# KILL it here (by PIDFILE): the boot loop's _monitor_cfserverd restarts it
+# properly daemonized within its cycle, and a co-notified "restart boot loop"
+# (defined below, so it runs after this) restarts it immediately via
+# startup_cfserverd since it is now dead. cf-serverd launched directly from an
+# SSH/handler shell does not survive session close, so we never start it here.
+- name: restart cf-serverd
+  ansible.builtin.shell: |
+    pidf="$HOME/.stayturgid/run/cf-serverd.pid"
+    old="$(cat "$pidf" 2>/dev/null || true)"
+    [ -n "$old" ] && kill "$old" 2>/dev/null || true
+    true
+  args:
+    executable: "{{ termux_prefix }}/bin/bash"
+  changed_when: true
+
 # Restart the Termux self-heal loop by PIDFILE, never `pkill -f start-adb.sh`:
 # Ansible runs this handler via `bash -c '<script>'`, so the script text (which
 # names the path) is in the handler's OWN cmdline — `pkill -f` matched and

--- a/ansible_collections/stayturgid/termux/roles/termux_userland/tasks/main.yml
+++ b/ansible_collections/stayturgid/termux/roles/termux_userland/tasks/main.yml
@@ -132,6 +132,9 @@
     src: "{{ stayturgid_repo_root }}/device/termux/cfengine/out/masterfiles/cf-serverd.cf"
     dest: "{{ termux_home }}/.stayturgid/cfengine/cf-serverd.cf"
     mode: "0644"
+  # cf-serverd only reads its policy at startup — replacing the file is not
+  # enough for a new roles/ACL to take effect. Restart it (see handler).
+  notify: restart cf-serverd
   when: "'cfengine' in stayturgid_termux_packages"
 
 - name: Detect Termux account owning termux_home

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -16,7 +16,12 @@ To keep both ends on the **same** version we pin the Mac to CFEngine Core
 (includes the `libntech` submodule — the GitHub git-archive tarball does not, so
 a naive `@3.27` source build fails at `make install`).
 
-### Install / re-pin (manual, until deploy-mac is fixed — see stayturgid#85)
+### Install / re-pin
+
+The control-node deploy applies this automatically: the `control_node` role's
+`prereqs.yml` installs + pins `cfengine@3.27.1` (idempotent, macOS-only). That
+runs via `just deploy-mac`, which is currently blocked by stayturgid#85 — until
+that is fixed, apply it manually:
 
 ```bash
 just cfengine-pin            # tap + install cfengine@3.27.1 + brew pin + drop plain cfengine


### PR DESCRIPTION
So a routine deploy (e.g. when s24 rejoins) actually applies every CFEngine change, not just drops files.

**Device (termux_userland):**
- **Restart cf-serverd after its policy re-renders** — cf-serverd reads policy only at startup, so the new roles/ACL never took effect on deploy (kept old policy until reboot). New `restart cf-serverd` handler kills by PIDFILE; the boot-loop daemon restarts it (promptly via `startup_cfserverd` on a full deploy, else `_monitor_cfserverd` within its cycle). We never launch cf-serverd from the handler (SSH-launched dies on session close).
- Confirmed `stayturgid.cf` needs no restart (cf-agent reads it per run) and the gitignored `out/masterfiles` is rebuilt by `cfbs build` at deploy time — verified the build emits the roles + scope changes.

**Control node:**
- **Pin CFEngine 3.27.1 during deploy** (idempotent, macOS-only), mirroring `just cfengine-pin` — was manual-only, so `deploy-mac` left the Mac on latest. Gated behind #85.
- Add `cfbs` to control-node uv tools — the device deploy delegates `cfbs build` to the control node; a fresh Mac needs it.

Refs #84, #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS control-node deployments now install and pin CFEngine 3.27.1 for consistent fleet policy management.
  * Added the `cfbs` build tool to the control-node toolkit.
  * Updated device policy deployments automatically restart the CFEngine server so changes take effect immediately.

* **Documentation**
  * Added guidance for installing and re-pinning the macOS CFEngine version, including current deployment limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->