### PR TITLE
fix(ansible): pin product roles/collections in ansible_exec (deploy-mac)

### DIFF
--- a/control/bin/ansible_exec.py
+++ b/control/bin/ansible_exec.py
@@ -8,7 +8,6 @@ pinning product assets to this checkout.
 
 from __future__ import annotations
 
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -17,7 +16,12 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from control.lib.ansible_context import AnsibleConfigError, require_inventory, resolve_ansible_context
+from control.lib.ansible_context import (
+    AnsibleConfigError,
+    require_inventory,
+    resolve_ansible_context,
+    resolved_env,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -27,15 +31,19 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     try:
-        context = resolve_ansible_context(REPO_ROOT)
+        # Silent resolve for the inventory preflight; resolved_env() re-resolves
+        # (announcing once) and — crucially — also pins ANSIBLE_ROLES_PATH and
+        # ANSIBLE_COLLECTIONS_PATH to this checkout. Without those, a site
+        # overlay whose ansible.cfg omits product paths (the norm) can't find
+        # the product roles/collections, so e.g. `just deploy-mac` failed with
+        # "role 'control_node' was not found". Matches deploy_fleet.py.
+        context = resolve_ansible_context(REPO_ROOT, announce=False)
         require_inventory(context)
+        env = resolved_env(REPO_ROOT)
     except AnsibleConfigError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
 
-    env = os.environ.copy()
-    env["ANSIBLE_CONFIG"] = str(context.config)
-    env["STAYTURGID_ROOT"] = str(REPO_ROOT)
     command = ["ansible-playbook", "-e", f"stayturgid_repo_root={REPO_ROOT}", *args[1:]]
     try:
         return subprocess.run(command, cwd=REPO_ROOT, env=env).returncode

--- a/tests/python/test_ansible_exec.py
+++ b/tests/python/test_ansible_exec.py
@@ -4,17 +4,30 @@ import ansible_exec as ae
 from ansible_context import AnsibleContext
 
 
-def test_ansible_exec_preserves_resolved_config_and_product_root(monkeypatch, tmp_path):
+def test_ansible_exec_delegates_env_to_resolved_env(monkeypatch, tmp_path):
     context = AnsibleContext(
         config=tmp_path / "ansible.cfg",
         inventory=tmp_path / "inventory" / "hosts.yml",
         collections_path=tmp_path / "collections",
         source="ANSIBLE_CONFIG",
     )
+    # Regression (stayturgid#85): ansible_exec must build the subprocess env via
+    # resolved_env(), which pins ANSIBLE_ROLES_PATH/ANSIBLE_COLLECTIONS_PATH to
+    # this checkout. resolved_env()'s composition is covered in
+    # test_ansible_context.py; here we only assert the delegation. Previously
+    # ansible_exec set ANSIBLE_CONFIG alone, so a site overlay whose ansible.cfg
+    # omits product paths failed with "role 'control_node' was not found".
+    fake_env = {
+        "ANSIBLE_CONFIG": str(context.config),
+        "STAYTURGID_ROOT": str(ae.REPO_ROOT),
+        "ANSIBLE_ROLES_PATH": f"{ae.REPO_ROOT / 'ansible' / 'roles'}",
+        "ANSIBLE_COLLECTIONS_PATH": f"{ae.REPO_ROOT / '.ansible' / 'collections'}:{ae.REPO_ROOT}",
+    }
     seen = {}
 
-    monkeypatch.setattr(ae, "resolve_ansible_context", lambda repo: context)
+    monkeypatch.setattr(ae, "resolve_ansible_context", lambda repo, *a, **k: context)
     monkeypatch.setattr(ae, "require_inventory", lambda selected: None)
+    monkeypatch.setattr(ae, "resolved_env", lambda repo: dict(fake_env))
 
     def fake_run(command, **kwargs):
         seen["command"] = command
@@ -36,6 +49,5 @@ def test_ansible_exec_preserves_resolved_config_and_product_root(monkeypatch, tm
         "ansible/playbooks/site.yml",
         "--syntax-check",
     ]
-    assert seen["env"]["ANSIBLE_CONFIG"] == str(context.config)
-    assert seen["env"]["STAYTURGID_ROOT"] == str(ae.REPO_ROOT)
+    assert seen["env"] == fake_env
     assert seen["cwd"] == ae.REPO_ROOT


### PR DESCRIPTION
Fixes #85.

`just deploy-mac`/`just syntax` failed with "role 'control_node' was not found". `ansible_exec.py` set only `ANSIBLE_CONFIG` (the site overlay's, which deliberately omits product `roles_path`/`collections_path`), so ansible searched the site dir instead of this checkout. `deploy_fleet.py` already uses `resolved_env()` (which composes `ANSIBLE_ROLES_PATH`+`ANSIBLE_COLLECTIONS_PATH`); `ansible_exec.py` claimed to but didn't. Now routed through `resolved_env()`.

Verified: `control_node/site.yml --syntax-check` and `just syntax` pass. Unblocks the Mac cfengine pin + `cf-runagent.cf` render (ops-v1.0.7/1.0.9). Test now asserts the delegation (the old test only checked ANSIBLE_CONFIG, which is why this slipped through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)