### PR TITLE
release: advance ops suite to 1.0.10

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.0.9"
+  "version": "1.0.10"
 }


### PR DESCRIPTION
Coordinated ops suite 1.0.10. stayturgid: fix deploy-mac ansible role/collections resolution (#93, fixes #85); site-* version bump only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application release version from 1.0.9 to 1.0.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->