### PR TITLE
fix(cfengine): make cf-runagent Tier 3a hail-mary work (#84)

### DIFF
--- a/ansible/roles/control_node/templates/cf-runagent.cf.j2
+++ b/ansible/roles/control_node/templates/cf-runagent.cf.j2
@@ -8,9 +8,9 @@
 body common control {
     bundlesequence => { "main" };
     # Pin the wire protocol to "2" (TLS) for a deterministic handshake. Set here
-    # (not on argv): cf-runagent has no --protocol-version flag. NOTE: this does
-    # NOT resolve the "Unspecified server refusal" — that persists with both ends
-    # on CFEngine 3.27.1 and has a separate, still-open cause (stayturgid#84).
+    # (not on argv): cf-runagent has no --protocol-version flag. Kept as hygiene;
+    # it was NOT what fixed the "Unspecified server refusal" (that was the
+    # cf-serverd resource_type/cfruncommand grants — stayturgid#84, resolved).
     protocol_version => "2";
 }
 

--- a/control/cfengine/cf-runagent.cf.example
+++ b/control/cfengine/cf-runagent.cf.example
@@ -7,9 +7,9 @@
 body common control {
     bundlesequence => { "main" };
     # Pin the wire protocol to "2" (TLS) for a deterministic handshake. Set here
-    # (not on argv): cf-runagent has no --protocol-version flag. NOTE: this does
-    # NOT resolve the "Unspecified server refusal" — that persists with both ends
-    # on CFEngine 3.27.1 and has a separate, still-open cause (stayturgid#84).
+    # (not on argv): cf-runagent has no --protocol-version flag. Kept as hygiene;
+    # it was NOT what fixed the "Unspecified server refusal" (that was the
+    # cf-serverd resource_type/cfruncommand grants — stayturgid#84, resolved).
     protocol_version => "2";
 }
 

--- a/device/termux/cfengine/policy/cf-serverd.cf
+++ b/device/termux/cfengine/policy/cf-serverd.cf
@@ -34,55 +34,56 @@ body server control {
     trustkeysfrom => { "100.64.0.0/10" };
     allowusers    => { "root", "{{ stayturgid_control_ssh_user | default(stayturgid_mac_peer.user | default(ansible_user)) }}" };
 
-    # Direct cf-agent — no arguments needed. Policy data is sent inline
-    # by cf-runagent and cf-agent reads it from stdin.
-    cfruncommand  => "/data/data/com.termux/files/usr/bin/cf-agent";
+    # Run cf-agent via the wrapper so it loads OUR policy (stayturgid.cf, where
+    # stayturgid_heal + the check_* bundles live) with the Termux env. A bare
+    # cf-agent loads the default inputs (no promises.cf) -> failsafe -> "Bundle
+    # 'stayturgid_heal' … was not found". cf-serverd appends --bundlesequence
+    # <name> from cf-runagent --remote-bundles. See stayturgid#84.
+    cfruncommand  => "/data/data/com.termux/files/home/.stayturgid/cfengine/cf-runagent-wrapper.sh";
 
     port          => "5308";
     maxconnections => "5";
     denybadclocks  => "false";
 }
 
+# cf-runagent remote execution needs TWO access grants, each with the CORRECT
+# resource_type (verified end-to-end on the live fleet, stayturgid#84 — earlier
+# guesses of roles/protocol_version were red herrings):
+#   1. the cfruncommand executable, as resource_type "path" (NOT "literal") —
+#      a literal grant leaves the path ACL empty and cf-serverd answers
+#      "EXEC denied due to ACL for file: <cfruncommand>";
+#   2. each activatable bundle name, as resource_type "bundle" (NOT "query";
+#      query is for cf-runagent -s style reporting) — otherwise cf-serverd
+#      answers "Access denied to: <bundle> / EXEC denied bundle activation".
+# No `roles` promise is required; bundle activation is authorized purely by the
+# access admit (IP/host/key) here.
 bundle server access_rules() {
-  # Authorize which remote users may trigger cfruncommand execution. Kept as a
-  # CANDIDATE for the cf-runagent "Unspecified server refusal" (stayturgid#84):
-  # cf-serverd logs "No promise type roles in bundle access_rules" when it is
-  # absent. UNVERIFIED — a live e2e test with this promise deployed (both ends
-  # CFEngine 3.27.1, after TLS + key trust + allowusers all pass) STILL got the
-  # refusal, so this is necessary-at-most, not the fix. Root cause is still open;
-  # see #84 for the -v capture plan. The control node connects as root or the
-  # operator SSH user.
-  roles:
-    ".*"
-      authorize => { "root", "{{ stayturgid_control_ssh_user | default(stayturgid_mac_peer.user | default(ansible_user)) }}" };
-
   access:
-    # Allow remote execution of the cf-agent binary (the cfruncommand).
-    # Without this, cf-runagent connections get "EXEC denied due to ACL".
-    "/data/data/com.termux/files/usr/bin/cf-agent"
+    # Allow remote execution of the cfruncommand (the wrapper).
+    "/data/data/com.termux/files/home/.stayturgid/cfengine/cf-runagent-wrapper.sh"
       handle        => "cf_agent_exec_access",
-      resource_type => "literal",
+      resource_type => "path",
       admit         => { "100.64.0.0/10" };
 
     # Mac can trigger stayturgid_heal bundle for full repair.
     "stayturgid_heal"
-      resource_type => "query",
+      resource_type => "bundle",
       admit         => { "100.64.0.0/10" };
 
     "check_sshd"
-      resource_type => "query",
+      resource_type => "bundle",
       admit         => { "100.64.0.0/10" };
 
     "check_bootloop"
-      resource_type => "query",
+      resource_type => "bundle",
       admit         => { "100.64.0.0/10" };
 
     "check_bootloop_repair"
-      resource_type => "query",
+      resource_type => "bundle",
       admit         => { "100.64.0.0/10" };
 
     "check_stayturgid_agent"
-      resource_type => "query",
+      resource_type => "bundle",
       admit         => { "100.64.0.0/10" };
 }
 

--- a/docs/architecture/components/cfengine-server.md
+++ b/docs/architecture/components/cfengine-server.md
@@ -9,12 +9,12 @@ that does not depend on ADB or SSH.
 
 ## Connection fallback chain (4 tiers)
 
-| Tier | Transport    | Port  | Protocol | Auth                     | Status                         |
-| ---- | ------------ | ----- | -------- | ------------------------ | ------------------------------ |
-| 1    | ADB          | 5555  | ADB      | RSA keypair              | ✅                             |
-| 2    | SSH          | 8022  | SSH      | stayturgid CA cert + key | ✅                             |
-| 3a   | CFEngine     | 5308  | TLS      | Peer-to-peer key trust   | ✅ TLS proven, bundle exec WIP |
-| 3b   | FIRERPA gRPC | 65000 | gRPC/TLS | gRPC auth                | ✅                             |
+| Tier | Transport    | Port  | Protocol | Auth                     | Status                       |
+| ---- | ------------ | ----- | -------- | ------------------------ | ---------------------------- |
+| 1    | ADB          | 5555  | ADB      | RSA keypair              | ✅                           |
+| 2    | SSH          | 8022  | SSH      | stayturgid CA cert + key | ✅                           |
+| 3a   | CFEngine     | 5308  | TLS      | Peer-to-peer key trust   | ✅ bundle exec working (#84) |
+| 3b   | FIRERPA gRPC | 65000 | gRPC/TLS | gRPC auth                | ✅                           |
 
 ## New files
 
@@ -87,31 +87,35 @@ that does not depend on ADB or SSH.
 
 ## Known issues
 
-1. **cf-runagent "Unspecified server refusal" — UNRESOLVED (root cause still
-   open).** Live-fleet testing (stayturgid#84) ruled out the protocol version:
-   the refusal persists with **both ends on CFEngine 3.27.1**, after TLS + key
-   trust + `allowusers` + the `cf_agent_exec_access` ACL all pass. Two candidate
-   changes were tried and **neither fixed it** (both kept as harmless, valid
-   hygiene, not verified fixes):
-   - a `roles: ".*" authorize => { root, <operator> }` promise in
-     `cf-serverd.cf` — cf-serverd logs `No promise type roles in bundle
-access_rules` without one, but the refusal **persisted with it deployed
-     and loaded** on the live device (that debug line is likely incidental);
-   - `protocol_version => "2"` in the rendered `cf-runagent.cf` body (there is
-     **no** `--protocol-version` CLI flag — cf-runagent exits rc=1 on it).
+1. **cf-runagent "Unspecified server refusal" — RESOLVED (stayturgid#84).**
+   Captured the server-side reason with `STAYTURGID_CFSERVERD_VERBOSE` and fixed
+   it end-to-end on the live fleet (Mac 3.27.1 → p7a: `cf-serverd executing
+cfruncommand … --bundlesequence stayturgid_heal`, `R: … stayturgid heal on
+termux`, exit 0). The refusal was **three wrong `cf-serverd.cf` grants**, each
+   revealed as the previous one was fixed — not a protocol or `roles` problem
+   (both were red herrings; the `protocol_version` pin and Mac 3.27.1 pin are
+   kept only as hygiene):
+   - the cfruncommand grant used `resource_type => "literal"`, so the _path_ ACL
+     stayed empty → `EXEC denied due to ACL for file: <cfruncommand>`. Fix:
+     `resource_type => "path"`.
+   - each bundle grant used `resource_type => "query"` (that is for `-s`
+     reporting), so `-b` activation was refused → `Access denied to: <bundle> /
+EXEC denied bundle activation`. Fix: `resource_type => "bundle"`. No
+     `roles` promise is needed — bundle activation is authorized by the access
+     `admit` alone.
+   - `cfruncommand` was bare `cf-agent`, which loads the default (empty) inputs
+     → failsafe → `Bundle 'stayturgid_heal' … was not found`. Fix: point it (and
+     the exec ACL) at `cf-runagent-wrapper.sh`, which runs
+     `cf-agent -f stayturgid.cf "$@"` with the Termux env.
 
-   The refusal fires at the EXEC/`cfruncommand` authorization stage; its
-   server-side reason with `roles` loaded has not been captured because
-   cf-serverd only survives on Termux under the boot-loop daemon (SSH-launched
-   instances die on session close). **Next step:** set
-   `STAYTURGID_CFSERVERD_VERBOSE=1` (or `=debug`) so the boot-loop cf-serverd
-   logs the refusal reason, then reproduce a hail. Confirmed-correct pieces:
-   Mac control node pinned to CFEngine **3.27.1**
+   Also confirmed correct along the way: Mac pinned to CFEngine **3.27.1**
    (`packaging/homebrew/cfengine@3.27.1.rb`, `just cfengine-pin`); per-host
    targeting via `-H <ip>` (a bare trailing arg is parsed as an input FILE,
-   overriding `-f`); `_try_cf_runagent_repair()` in `fleet_health_monitor.py`
-   builds a valid argv. The working repair path today is SSH-based
-   (`just cf-run`); cf-runagent is only needed when SSH is also down.
+   overriding `-f`); `_try_cf_runagent_repair()` builds a valid argv. Note the
+   heal bundle's individual _actions_ can still fail per device (e.g. Shizuku
+   restart) — that is repair logic, independent of this transport. On-device,
+   `STAYTURGID_CFSERVERD_VERBOSE` (in `~/.stayturgid/env`; `1`→`-v`, `debug`→`-d`)
+   makes the boot-loop cf-serverd log EXEC decisions for future debugging.
 
 2. **Android seccomp blocks fork**: cf-serverd must be started with `-F` (foreground)
    flag. No fork is attempted. `nohup ... &` + PID file monitoring in boot loop


### PR DESCRIPTION
Fixes #84 — verified end-to-end on the live fleet (Mac 3.27.1 → p7a: `cf-serverd executing cfruncommand … --bundlesequence stayturgid_heal`, `R: … stayturgid heal on termux`, **exit 0**).

Captured cf-serverd's verbose EXEC decisions (via the new `STAYTURGID_CFSERVERD_VERBOSE` toggle). The "Unspecified server refusal" was **three wrong grants** in `cf-serverd.cf`, each surfacing as the prior was fixed — not protocol_version, not roles:

1. cfruncommand grant `resource_type => "literal"` → path ACL empty → `EXEC denied due to ACL for file`. → `"path"`.
2. bundle grants `resource_type => "query"` (that's `-s` reporting) → `Access denied to: <bundle>`. → `"bundle"`. No `roles` promise needed (removed the 1.0.7 wrong guess).
3. `cfruncommand` bare `cf-agent` → empty inputs → failsafe → `Bundle 'stayturgid_heal' … not found`. → point it (and the exec ACL) at `cf-runagent-wrapper.sh`.

Docs: Known Issues #1 → RESOLVED; fallback-chain 3a → "bundle exec working"; protocol_version comments corrected to hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved CFEngine remote execution on Termux through wrapper-based policy loading and bundle sequencing.
  * Updated authorization handling for remote policy execution while preserving existing network restrictions.

* **Bug Fixes**
  * Resolved the CFEngine “Unspecified server refusal” issue.

* **Documentation**
  * Updated architecture documentation to reflect the working CFEngine connection tier and the confirmed resolution details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->