### PR TITLE
feat: brew pinning and unified update monitor

### DIFF
--- a/ansible/roles/control_node/tasks/agents.yml
+++ b/ansible/roles/control_node/tasks/agents.yml
@@ -154,6 +154,13 @@
     mode: "0644"
   register: fire_help_plist
 
+- name: Render update-monitor launchd agent
+  ansible.builtin.template:
+    src: update-monitor.plist.j2
+    dest: "{{ agents_dir }}/com.stayturgid.update-monitor.plist"
+    mode: "0644"
+  register: update_monitor_plist
+
 - name: Render nightly Termux pkg update/upgrade launchd agent
   ansible.builtin.template:
     src: termux-pkg-nightly.plist.j2
@@ -331,6 +338,7 @@
         + (['com.stayturgid.access-monitor'] if monitor_plist.changed else [])
         + (['com.stayturgid.fleet-health'] if health_plist.changed else [])
         + (['com.stayturgid.fire-help'] if fire_help_plist.changed else [])
+        + (['com.stayturgid.update-monitor'] if update_monitor_plist is defined and update_monitor_plist.changed else [])
         + (['com.stayturgid.termux-pkg-nightly']
            if (termux_pkg_nightly_plist is defined
                and termux_pkg_nightly_plist.changed) else [])

--- a/ansible/roles/control_node/tasks/hermes.yml
+++ b/ansible/roles/control_node/tasks/hermes.yml
@@ -12,6 +12,13 @@
   when: stayturgid_hermes_enabled | default(true) | bool
   register: _hermes_brew_install
 
+- name: Pin hermes-agent formula in Homebrew to prevent drift
+  ansible.builtin.command:
+    cmd: brew pin hermes-agent
+  register: _hermes_pin
+  changed_when: "'already pinned' not in (_hermes_pin.stderr | default(''))"
+  when: stayturgid_hermes_enabled | default(true) | bool
+
 - name: Resolve Hermes libexec python (for optional Telegram deps)
   ansible.builtin.shell: |
     set -euo pipefail

--- a/ansible/roles/control_node/tasks/hermes.yml
+++ b/ansible/roles/control_node/tasks/hermes.yml
@@ -17,6 +17,13 @@
     cmd: brew pin hermes-agent
   register: _hermes_pin
   changed_when: "'already pinned' not in (_hermes_pin.stderr | default(''))"
+  # Degrade gracefully if the formula is somehow absent (e.g. a failed install)
+  # instead of aborting the play; only a genuine unexpected error fails.
+  failed_when:
+    - _hermes_pin.rc != 0
+    - "'already pinned' not in (_hermes_pin.stderr | default(''))"
+    - "'not installed' not in (_hermes_pin.stderr | default(''))"
+    - "'No available formula' not in (_hermes_pin.stderr | default(''))"
   when: stayturgid_hermes_enabled | default(true) | bool
 
 - name: Resolve Hermes libexec python (for optional Telegram deps)

--- a/ansible/roles/control_node/templates/termux-pkg-nightly.plist.j2
+++ b/ansible/roles/control_node/templates/termux-pkg-nightly.plist.j2
@@ -30,8 +30,12 @@
         <key>Minute</key>
         <integer>{{ stayturgid_termux_pkg_nightly_minute | int }}</integer>
     </dict>
+    <!-- RunAtLoad is false: a full `pkg update && pkg upgrade` must not fire on
+         every load (boot/deploy/wake), and a mid-deploy plist rewrite could
+         upgrade deps under a running deploy. StartCalendarInterval already
+         catches up a missed scheduled run on wake. -->
     <key>RunAtLoad</key>
-    <true/>
+    <false/>
     <key>StandardOutPath</key>
     <string>{{ conf_dir }}/logs/termux-pkg-nightly.launchd.out.log</string>
     <key>StandardErrorPath</key>

--- a/ansible/roles/control_node/templates/termux-pkg-nightly.plist.j2
+++ b/ansible/roles/control_node/templates/termux-pkg-nightly.plist.j2
@@ -31,7 +31,7 @@
         <integer>{{ stayturgid_termux_pkg_nightly_minute | int }}</integer>
     </dict>
     <key>RunAtLoad</key>
-    <false/>
+    <true/>
     <key>StandardOutPath</key>
     <string>{{ conf_dir }}/logs/termux-pkg-nightly.launchd.out.log</string>
     <key>StandardErrorPath</key>

--- a/ansible/roles/control_node/templates/update-monitor.plist.j2
+++ b/ansible/roles/control_node/templates/update-monitor.plist.j2
@@ -19,9 +19,22 @@
         <key>HOMEBREW_NO_AUTO_UPDATE</key>
         <string>1</string>
     </dict>
-    <!-- Run every 12 hours (43200 seconds) to avoid GitHub rate limits -->
-    <key>StartInterval</key>
-    <integer>43200</integer>
+    <!-- Run twice a day. If asleep during these times, launchd will run it immediately upon waking. -->
+    <key>StartCalendarInterval</key>
+    <array>
+        <dict>
+            <key>Hour</key>
+            <integer>10</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+        <dict>
+            <key>Hour</key>
+            <integer>22</integer>
+            <key>Minute</key>
+            <integer>0</integer>
+        </dict>
+    </array>
     <key>RunAtLoad</key>
     <true/>
     <key>StandardOutPath</key>

--- a/ansible/roles/control_node/templates/update-monitor.plist.j2
+++ b/ansible/roles/control_node/templates/update-monitor.plist.j2
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.stayturgid.update-monitor</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/env</string>
+        <string>python3</string>
+        <string>{{ stayturgid_repo_root | realpath }}/control/bin/update_monitor.py</string>
+        <string>--repo-root</string>
+        <string>{{ stayturgid_repo_root | realpath }}</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOMEBREW_NO_AUTO_UPDATE</key>
+        <string>1</string>
+    </dict>
+    <!-- Run every 12 hours (43200 seconds) to avoid GitHub rate limits -->
+    <key>StartInterval</key>
+    <integer>43200</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>{{ conf_dir }}/logs/update_monitor.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{ conf_dir }}/logs/update_monitor.err</string>
+</dict>
+</plist>

--- a/ansible/roles/serverapp_caddy/tasks/main.yml
+++ b/ansible/roles/serverapp_caddy/tasks/main.yml
@@ -24,6 +24,13 @@
     cmd: brew pin caddy
   register: _caddy_pin
   changed_when: "'already pinned' not in (_caddy_pin.stderr | default(''))"
+  # Degrade gracefully if the formula is somehow absent (e.g. a failed install)
+  # instead of aborting the play; only a genuine unexpected error fails.
+  failed_when:
+    - _caddy_pin.rc != 0
+    - "'already pinned' not in (_caddy_pin.stderr | default(''))"
+    - "'not installed' not in (_caddy_pin.stderr | default(''))"
+    - "'No available formula' not in (_caddy_pin.stderr | default(''))"
 
 - name: Resolve caddy binary after install
   ansible.builtin.command:

--- a/ansible/roles/serverapp_caddy/tasks/main.yml
+++ b/ansible/roles/serverapp_caddy/tasks/main.yml
@@ -19,6 +19,12 @@
     state: present
   when: _caddy_brew_list.rc != 0
 
+- name: Pin caddy formula in Homebrew to prevent drift
+  ansible.builtin.command:
+    cmd: brew pin caddy
+  register: _caddy_pin
+  changed_when: "'already pinned' not in (_caddy_pin.stderr | default(''))"
+
 - name: Resolve caddy binary after install
   ansible.builtin.command:
     cmd: brew --prefix caddy

--- a/ansible/roles/serverapp_grafana/tasks/main.yml
+++ b/ansible/roles/serverapp_grafana/tasks/main.yml
@@ -17,6 +17,12 @@
     state: present
   when: _gf_brew_list.rc != 0
 
+- name: Pin grafana formula in Homebrew to prevent drift
+  ansible.builtin.command:
+    cmd: brew pin grafana
+  register: _gf_pin
+  changed_when: "'already pinned' not in (_gf_pin.stderr | default(''))"
+
 - name: Resolve grafana binary after install
   ansible.builtin.command:
     cmd: brew --prefix grafana

--- a/ansible/roles/serverapp_grafana/tasks/main.yml
+++ b/ansible/roles/serverapp_grafana/tasks/main.yml
@@ -22,6 +22,13 @@
     cmd: brew pin grafana
   register: _gf_pin
   changed_when: "'already pinned' not in (_gf_pin.stderr | default(''))"
+  # Degrade gracefully if the formula is somehow absent (e.g. a failed install)
+  # instead of aborting the play; only a genuine unexpected error fails.
+  failed_when:
+    - _gf_pin.rc != 0
+    - "'already pinned' not in (_gf_pin.stderr | default(''))"
+    - "'not installed' not in (_gf_pin.stderr | default(''))"
+    - "'No available formula' not in (_gf_pin.stderr | default(''))"
 
 - name: Resolve grafana binary after install
   ansible.builtin.command:

--- a/ansible/roles/serverapp_vector/tasks/main.yml
+++ b/ansible/roles/serverapp_vector/tasks/main.yml
@@ -20,6 +20,12 @@
     state: present
   when: _vector_brew_list.rc != 0
 
+- name: Pin vector formula in Homebrew to prevent drift
+  ansible.builtin.command:
+    cmd: brew pin vector
+  register: _vector_pin
+  changed_when: "'already pinned' not in (_vector_pin.stderr | default(''))"
+
 - name: Resolve vector binary after install
   ansible.builtin.command:
     cmd: brew --prefix vector

--- a/ansible/roles/serverapp_vector/tasks/main.yml
+++ b/ansible/roles/serverapp_vector/tasks/main.yml
@@ -25,6 +25,13 @@
     cmd: brew pin vector
   register: _vector_pin
   changed_when: "'already pinned' not in (_vector_pin.stderr | default(''))"
+  # Degrade gracefully if the formula is somehow absent (e.g. a failed install)
+  # instead of aborting the play; only a genuine unexpected error fails.
+  failed_when:
+    - _vector_pin.rc != 0
+    - "'already pinned' not in (_vector_pin.stderr | default(''))"
+    - "'not installed' not in (_vector_pin.stderr | default(''))"
+    - "'No available formula' not in (_vector_pin.stderr | default(''))"
 
 - name: Resolve vector binary after install
   ansible.builtin.command:

--- a/ansible/roles/serverapp_victoriametrics/tasks/main.yml
+++ b/ansible/roles/serverapp_victoriametrics/tasks/main.yml
@@ -16,6 +16,12 @@
     state: present
   when: _vm_brew_list.rc != 0
 
+- name: Pin victoriametrics formula in Homebrew to prevent drift
+  ansible.builtin.command:
+    cmd: brew pin victoriametrics
+  register: _vm_pin
+  changed_when: "'already pinned' not in (_vm_pin.stderr | default(''))"
+
 - name: Resolve victoria-metrics binary after install
   ansible.builtin.command:
     cmd: brew --prefix victoriametrics

--- a/ansible/roles/serverapp_victoriametrics/tasks/main.yml
+++ b/ansible/roles/serverapp_victoriametrics/tasks/main.yml
@@ -21,6 +21,13 @@
     cmd: brew pin victoriametrics
   register: _vm_pin
   changed_when: "'already pinned' not in (_vm_pin.stderr | default(''))"
+  # Degrade gracefully if the formula is somehow absent (e.g. a failed install)
+  # instead of aborting the play; only a genuine unexpected error fails.
+  failed_when:
+    - _vm_pin.rc != 0
+    - "'already pinned' not in (_vm_pin.stderr | default(''))"
+    - "'not installed' not in (_vm_pin.stderr | default(''))"
+    - "'No available formula' not in (_vm_pin.stderr | default(''))"
 
 - name: Resolve victoria-metrics binary after install
   ansible.builtin.command:

--- a/ansible/roles/serverapp_victoriametrics/templates/scrape.yml.j2
+++ b/ansible/roles/serverapp_victoriametrics/templates/scrape.yml.j2
@@ -22,9 +22,18 @@ scrape_configs:
     params:
       module: ["{{ module }}"]
     static_configs:
-      - targets:
-{% for target in targets %}
-          - "{{ target }}"
+{% for item in targets %}
+{% if item is string %}
+      - targets: ["{{ item }}"]
+{% else %}
+      - targets: ["{{ item.target }}"]
+{% if item.labels is defined %}
+        labels:
+{% for k, v in item.labels.items() %}
+          {{ k }}: "{{ v }}"
+{% endfor %}
+{% endif %}
+{% endif %}
 {% endfor %}
     relabel_configs:
       - source_labels: [__address__]

--- a/control/bin/update_monitor.py
+++ b/control/bin/update_monitor.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+Update monitor: checks for Homebrew updates and new GitHub releases for non-brew software.
+Emits Prometheus metrics via HTTP POST to VictoriaMetrics.
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+from typing import Dict, List, Optional, Tuple
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+def fetch_github_latest_release(repo: str) -> Optional[str]:
+    """Fetches the latest stable release tag from GitHub."""
+    url = f"https://api.github.com/repos/{repo}/releases/latest"
+    req = urllib.request.Request(url, headers={"User-Agent": "stayturgid-update-monitor"})
+    try:
+        with urllib.request.urlopen(req, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            tag = data.get("tag_name", "")
+            return tag.lstrip("v")
+    except Exception as e:
+        logging.error(f"Failed to fetch {repo} latest release: {e}")
+        return None
+
+
+def get_ansible_version(role_path: str, var_name: str) -> Optional[str]:
+    """Reads a version string from an Ansible defaults/main.yml file using regex to avoid yaml dependency."""
+    try:
+        with open(os.path.join(role_path, "defaults", "main.yml"), "r") as f:
+            for line in f:
+                match = re.match(rf'^{var_name}:\s*"(.*?)"', line.strip())
+                if match:
+                    return match.group(1)
+                # handle unquoted values just in case
+                match_unquoted = re.match(rf'^{var_name}:\s*([^\s#]+)', line.strip())
+                if match_unquoted:
+                    return match_unquoted.group(1)
+        return None
+    except Exception as e:
+        logging.error(f"Failed to read {var_name} from {role_path}: {e}")
+        return None
+
+
+def get_brew_outdated() -> List[Dict[str, str]]:
+    """Runs brew outdated --json and returns a list of dicts with name, current_version, and latest_version."""
+    try:
+        result = subprocess.run(["brew", "outdated", "--json"], capture_output=True, text=True, check=True)
+        data = json.loads(result.stdout)
+        formulae = data.get("formulae", [])
+        
+        outdated = []
+        for item in formulae:
+            name = item.get("name")
+            installed = item.get("installed_versions", [""])[0]
+            latest = item.get("current_version", "")
+            outdated.append({"name": name, "current": installed, "latest": latest})
+        return outdated
+    except Exception as e:
+        logging.error(f"Failed to run brew outdated: {e}")
+        return []
+
+
+def push_to_victoriametrics(metrics: List[str], vm_url: str = "http://127.0.0.1:8428/api/v1/import/prometheus"):
+    """POSTs Prometheus metrics to VictoriaMetrics."""
+    payload = "\n".join(metrics) + "\n"
+    req = urllib.request.Request(vm_url, data=payload.encode("utf-8"), headers={"Content-Type": "text/plain"}, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as response:
+            if response.status not in (200, 204):
+                logging.error(f"VictoriaMetrics returned {response.status}: {response.read()}")
+            else:
+                logging.info(f"Successfully pushed {len(metrics)} metrics to VictoriaMetrics.")
+    except Exception as e:
+        logging.error(f"Failed to push to VictoriaMetrics: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Stayturgid Update Monitor")
+    parser.add_argument("--repo-root", required=True, help="Path to stayturgid repo root")
+    args = parser.parse_args()
+
+    metrics = []
+
+    # 1. Check GitHub Releases
+    github_apps = [
+        {"name": "openobserve", "repo": "openobserve/openobserve", "role": "serverapp_openobserve", "var": "serverapp_openobserve_version"},
+        {"name": "olivetin", "repo": "OliveTin/OliveTin", "role": "serverapp_olivetin", "var": "serverapp_olivetin_version"}
+    ]
+
+    for app in github_apps:
+        role_path = os.path.join(args.repo_root, "ansible", "roles", app["role"])
+        current_version = get_ansible_version(role_path, app["var"])
+        if not current_version:
+            continue
+            
+        latest_version = fetch_github_latest_release(app["repo"])
+        if not latest_version:
+            continue
+            
+        # Clean versions for comparison
+        clean_current = current_version.lstrip("v")
+        clean_latest = latest_version.lstrip("v")
+        
+        has_update = 1 if clean_current != clean_latest else 0
+        metrics.append(f'software_update_available{{package="{app["name"]}", type="github", current="{clean_current}", latest="{clean_latest}"}} {has_update}')
+        
+        if has_update:
+            logging.info(f"Update available for {app['name']}: {clean_current} -> {clean_latest}")
+
+    # 2. Check Homebrew Packages
+    brew_outdated = get_brew_outdated()
+    # For every package that is outdated, it has an update available
+    for pkg in brew_outdated:
+        metrics.append(f'software_update_available{{package="{pkg["name"]}", type="homebrew", current="{pkg["current"]}", latest="{pkg["latest"]}"}} 1')
+        logging.info(f"Update available for {pkg['name']}: {pkg['current']} -> {pkg['latest']}")
+
+    if not metrics:
+        # Push a heartbeat metric so we know it ran
+        metrics.append("software_update_monitor_last_run_seconds_total 1")
+
+    push_to_victoriametrics(metrics)
+
+
+if __name__ == "__main__":
+    main()

--- a/control/bin/update_monitor.py
+++ b/control/bin/update_monitor.py
@@ -10,17 +10,36 @@ import logging
 import os
 import re
 import subprocess
-import sys
+import time
 import urllib.request
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+# Homebrew formulae pinned to Tier-1 on the control node (see the brew-pin
+# tasks in ansible/roles/serverapp_* and control_node/tasks/hermes.yml). The
+# update monitor runs only on the control node (it pushes to localhost
+# VictoriaMetrics), so hermes-agent is always part of the monitored set. We
+# emit an explicit 0/1 for every formula here each run so the
+# software_update_available series is resettable rather than leaving a stale
+# "1" sample lingering after a package stops being outdated.
+MONITORED_BREW_FORMULAE = ["caddy", "grafana", "vector", "victoriametrics", "hermes-agent"]
+
+
+def escape_label_value(value: str) -> str:
+    """Escapes a Prometheus exposition-format label value (backslash, quote, newline)."""
+    return str(value).replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
 
 
 def fetch_github_latest_release(repo: str) -> Optional[str]:
     """Fetches the latest stable release tag from GitHub."""
     url = f"https://api.github.com/repos/{repo}/releases/latest"
-    req = urllib.request.Request(url, headers={"User-Agent": "stayturgid-update-monitor"})
+    headers = {"User-Agent": "stayturgid-update-monitor"}
+    # Best-effort auth to lift the 60/hr unauthenticated shared-IP rate limit.
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers)
     try:
         with urllib.request.urlopen(req, timeout=10) as response:
             data = json.loads(response.read().decode("utf-8"))
@@ -40,7 +59,7 @@ def get_ansible_version(role_path: str, var_name: str) -> Optional[str]:
                 if match:
                     return match.group(1)
                 # handle unquoted values just in case
-                match_unquoted = re.match(rf'^{var_name}:\s*([^\s#]+)', line.strip())
+                match_unquoted = re.match(rf"^{var_name}:\s*([^\s#]+)", line.strip())
                 if match_unquoted:
                     return match_unquoted.group(1)
         return None
@@ -55,11 +74,13 @@ def get_brew_outdated() -> List[Dict[str, str]]:
         result = subprocess.run(["brew", "outdated", "--json"], capture_output=True, text=True, check=True)
         data = json.loads(result.stdout)
         formulae = data.get("formulae", [])
-        
+
         outdated = []
         for item in formulae:
             name = item.get("name")
-            installed = item.get("installed_versions", [""])[0]
+            # `installed_versions` can be an empty list ([]), not just absent;
+            # the dict default only covers absence, so `or [""]` guards the [0].
+            installed = (item.get("installed_versions") or [""])[0]
             latest = item.get("current_version", "")
             outdated.append({"name": name, "current": installed, "latest": latest})
         return outdated
@@ -68,10 +89,31 @@ def get_brew_outdated() -> List[Dict[str, str]]:
         return []
 
 
+def get_brew_installed_versions(formulae: List[str]) -> Dict[str, str]:
+    """Returns {name: installed_version} for whichever of `formulae` are installed."""
+    versions: Dict[str, str] = {}
+    try:
+        result = subprocess.run(
+            ["brew", "list", "--versions", *formulae],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        for line in result.stdout.splitlines():
+            parts = line.split()
+            if len(parts) >= 2:
+                versions[parts[0]] = parts[1]
+    except Exception as e:
+        logging.error(f"Failed to run brew list --versions: {e}")
+    return versions
+
+
 def push_to_victoriametrics(metrics: List[str], vm_url: str = "http://127.0.0.1:8428/api/v1/import/prometheus"):
     """POSTs Prometheus metrics to VictoriaMetrics."""
     payload = "\n".join(metrics) + "\n"
-    req = urllib.request.Request(vm_url, data=payload.encode("utf-8"), headers={"Content-Type": "text/plain"}, method="POST")
+    req = urllib.request.Request(
+        vm_url, data=payload.encode("utf-8"), headers={"Content-Type": "text/plain"}, method="POST"
+    )
     try:
         with urllib.request.urlopen(req, timeout=10) as response:
             if response.status not in (200, 204):
@@ -91,8 +133,18 @@ def main():
 
     # 1. Check GitHub Releases
     github_apps = [
-        {"name": "openobserve", "repo": "openobserve/openobserve", "role": "serverapp_openobserve", "var": "serverapp_openobserve_version"},
-        {"name": "olivetin", "repo": "OliveTin/OliveTin", "role": "serverapp_olivetin", "var": "serverapp_olivetin_version"}
+        {
+            "name": "openobserve",
+            "repo": "openobserve/openobserve",
+            "role": "serverapp_openobserve",
+            "var": "serverapp_openobserve_version",
+        },
+        {
+            "name": "olivetin",
+            "repo": "OliveTin/OliveTin",
+            "role": "serverapp_olivetin",
+            "var": "serverapp_olivetin_version",
+        },
     ]
 
     for app in github_apps:
@@ -100,31 +152,51 @@ def main():
         current_version = get_ansible_version(role_path, app["var"])
         if not current_version:
             continue
-            
+
         latest_version = fetch_github_latest_release(app["repo"])
         if not latest_version:
             continue
-            
+
         # Clean versions for comparison
         clean_current = current_version.lstrip("v")
         clean_latest = latest_version.lstrip("v")
-        
+
         has_update = 1 if clean_current != clean_latest else 0
-        metrics.append(f'software_update_available{{package="{app["name"]}", type="github", current="{clean_current}", latest="{clean_latest}"}} {has_update}')
-        
+        metrics.append(
+            f'software_update_available{{package="{escape_label_value(app["name"])}", '
+            f'type="github", current="{escape_label_value(clean_current)}", '
+            f'latest="{escape_label_value(clean_latest)}"}} {has_update}'
+        )
+
         if has_update:
             logging.info(f"Update available for {app['name']}: {clean_current} -> {clean_latest}")
 
-    # 2. Check Homebrew Packages
-    brew_outdated = get_brew_outdated()
-    # For every package that is outdated, it has an update available
-    for pkg in brew_outdated:
-        metrics.append(f'software_update_available{{package="{pkg["name"]}", type="homebrew", current="{pkg["current"]}", latest="{pkg["latest"]}"}} 1')
-        logging.info(f"Update available for {pkg['name']}: {pkg['current']} -> {pkg['latest']}")
+    # 2. Check Homebrew Packages (Tier-1 pinned set).
+    # Emit an explicit 0/1 for every monitored formula each run so the series
+    # is resettable: once a formula stops being outdated, its 0 sample clears
+    # the alert instead of a stale 1 lingering until retention.
+    outdated_map = {pkg["name"]: pkg for pkg in get_brew_outdated()}
+    installed_versions = get_brew_installed_versions(MONITORED_BREW_FORMULAE)
+    for name in MONITORED_BREW_FORMULAE:
+        if name in outdated_map:
+            current = outdated_map[name]["current"]
+            latest = outdated_map[name]["latest"]
+            has_update = 1
+            logging.info(f"Update available for {name}: {current} -> {latest}")
+        else:
+            # Up to date (or not installed on this node): current == latest, value 0.
+            current = latest = installed_versions.get(name, "")
+            has_update = 0
+        metrics.append(
+            f'software_update_available{{package="{escape_label_value(name)}", '
+            f'type="homebrew", current="{escape_label_value(current)}", '
+            f'latest="{escape_label_value(latest)}"}} {has_update}'
+        )
 
-    if not metrics:
-        # Push a heartbeat metric so we know it ran
-        metrics.append("software_update_monitor_last_run_seconds_total 1")
+    # Unconditional liveness gauge: the monitor's last successful run as an
+    # epoch timestamp. Emitted every run (not only when there are no updates)
+    # so the Grafana alert can detect a stalled monitor via staleness.
+    metrics.append(f"software_update_monitor_last_success_timestamp {int(time.time())}")
 
     push_to_victoriametrics(metrics)
 

--- a/control/site_contract/sync_templates/fragments/grafana/alerting/rules.yaml.j2
+++ b/control/site_contract/sync_templates/fragments/grafana/alerting/rules.yaml.j2
@@ -73,7 +73,12 @@ groups:
         data:
           - refId: A
             relativeTimeRange:
-              from: 600
+              # 24h lookback (2x the 12h update-monitor push cadence at 10:00/22:00)
+              # so a single fresh sample latches across a full push cycle. A narrow
+              # 10-min window (as on the blackbox probe) would see data only ~10 min
+              # per cycle and silently resolve to OK the rest of the time, missing
+              # notifications. Pairs with the resettable series + last-success gauge.
+              from: 86400
               to: 0
             datasourceUid: stayturgid-victoriametrics
             model:

--- a/control/site_contract/sync_templates/fragments/grafana/alerting/rules.yaml.j2
+++ b/control/site_contract/sync_templates/fragments/grafana/alerting/rules.yaml.j2
@@ -54,7 +54,7 @@ groups:
           # {% raw %}{{ $labels.* }}{% endraw %} below is Grafana's own Go-template
           # annotation syntax, evaluated by Grafana at alert-fire time — not Jinja.
           # {% raw %}
-          summary: "{{ $labels.instance }} ({{ $labels.job }}) has failed its blackbox probe for 5+ minutes"
+          summary: "{{ if $labels.machine_name }}{{ $labels.machine_name }} ({{ $labels.instance }}){{ else }}{{ $labels.instance }}{{ end }} ({{ $labels.job }}) has failed its blackbox probe for 5+ minutes"
           # {% endraw %}
         labels:
           severity: warning

--- a/control/site_contract/sync_templates/fragments/grafana/alerting/rules.yaml.j2
+++ b/control/site_contract/sync_templates/fragments/grafana/alerting/rules.yaml.j2
@@ -58,3 +58,41 @@ groups:
           # {% endraw %}
         labels:
           severity: warning
+
+  - orgId: 1
+    name: stayturgid-system
+    folder: stayturgid
+    interval: 10m
+    rules:
+      - uid: stayturgid-software-update-available
+        title: "Software update available"
+        condition: C
+        for: 5m
+        noDataState: OK
+        execErrState: Error
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: stayturgid-victoriametrics
+            model:
+              refId: A
+              expr: software_update_available > 0
+              instant: true
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+        annotations:
+          # {% raw %}
+          summary: "Update available for {{ $labels.package }} ({{ $labels.type }}): {{ $labels.current }} -> {{ $labels.latest }}"
+          # {% endraw %}
+        labels:
+          severity: warning


### PR DESCRIPTION
Implements pinned homebrew tier-1 packages, machine_name labels in blackbox alerts, and a robust unified update monitor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scheduled software update monitoring with GitHub and Homebrew checks.
  - Published update metrics to VictoriaMetrics for dashboarding and alerting.
  - Added support for per-target labels in blackbox monitoring configuration.

- **Improvements**
  - Homebrew-managed services now resist unintended formula upgrades.
  - Update monitoring runs automatically twice daily on macOS.
  - Monitoring alerts now display machine names when available, improving clarity.
  - Improved handling of unavailable or already-pinned Homebrew packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->