### PR TITLE
fix(ansible): make just deploy-check (dry-run) work

### DIFF
--- a/ansible/roles/serverapp_blackbox_exporter/tasks/main.yml
+++ b/ansible/roles/serverapp_blackbox_exporter/tasks/main.yml
@@ -51,6 +51,8 @@
     state: directory
     prefix: blackbox_exporter-
   register: _bbe_tmp
+  # Run in check mode too, so downstream `.path` resolves during a dry-run.
+  check_mode: false
   when: not (_bbe_bin_stat.stat.exists | default(false))
 
 - name: Download, extract, and install blackbox_exporter binary when missing

--- a/ansible/roles/serverapp_olivetin/tasks/main.yml
+++ b/ansible/roles/serverapp_olivetin/tasks/main.yml
@@ -57,6 +57,8 @@
     state: directory
     prefix: olivetin-
   register: _ot_tmp
+  # Run in check mode too, so downstream `.path` resolves during a dry-run.
+  check_mode: false
   when: not (_ot_bin_stat.stat.exists | default(false)) or not (_ot_webui_stat.stat.isdir | default(false))
 
 - name: Download, extract, and install OliveTin binary/webui when missing

--- a/ansible/roles/serverapp_openobserve/tasks/main.yml
+++ b/ansible/roles/serverapp_openobserve/tasks/main.yml
@@ -51,6 +51,8 @@
     state: directory
     prefix: openobserve-
   register: _oo_tmp
+  # Run in check mode too, so downstream `.path` resolves during a dry-run.
+  check_mode: false
   when: not (_oo_bin_stat.stat.exists | default(false))
 
 - name: Download, extract, and install OpenObserve binary when missing

--- a/ansible_collections/stayturgid/firerpa/roles/firerpa/tasks/install.yml
+++ b/ansible_collections/stayturgid/firerpa/roles/firerpa/tasks/install.yml
@@ -25,6 +25,8 @@
     state: directory
     prefix: firerpa-
   register: _firerpa_tmp
+  # Run in check mode too, so downstream `.path` resolves during a dry-run.
+  check_mode: false
   delegate_to: localhost
 
 - name: Download FIRERPA server archive on Mac

--- a/ansible_collections/stayturgid/fleet/roles/shizuku_config/tasks/main.yml
+++ b/ansible_collections/stayturgid/fleet/roles/shizuku_config/tasks/main.yml
@@ -26,6 +26,10 @@
     prefix: "shizuku-fleet-{{ inventory_hostname }}-"
     suffix: .json
   register: _shizuku_fleet_tmp
+  # Run in check mode too, so downstream tasks can resolve `.path` — otherwise
+  # `just deploy-check` fails with "dict has no attribute 'path'". Creating a
+  # temp file is harmless in a dry-run.
+  check_mode: false
   delegate_to: localhost
 
 - name: Push Shizuku fleet profile to Download

--- a/ansible_collections/stayturgid/termux/roles/termux_userland/tasks/main.yml
+++ b/ansible_collections/stayturgid/termux/roles/termux_userland/tasks/main.yml
@@ -111,6 +111,10 @@
   delegate_to: localhost
   run_once: true
   changed_when: false
+  # Build even in check mode: the downstream copy/template tasks read from the
+  # (gitignored) out/masterfiles/ artifact, so `just deploy-check` fails to find
+  # it otherwise. Building is a harmless local no-op in a dry-run.
+  check_mode: false
   when: "'cfengine' in stayturgid_termux_packages"
 
 - name: Deploy CFEngine Build artifact to device


### PR DESCRIPTION
Two check-mode breakages made `just deploy-check` fail while real deploys were fine:

- `tempfile` tasks skip in check mode → downstream `{{ _tmp.path }}` undefined → "dict has no attribute 'path'" (shizuku_config, firerpa, 3 serverapp roles). → `check_mode: false`.
- `cfbs build` command skips in check mode → gitignored `out/masterfiles/` never built → CFEngine copy/template can't find `stayturgid.cf`. → `check_mode: false`.

Verified: `CHECK=1 deploy_fleet.py p7a` completes (ok=162, failed=0). Real deploys unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)