### PR TITLE
release: advance ops suite to 1.0.12

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.0.11"
+  "version": "1.0.12"
 }


### PR DESCRIPTION
Coordinated ops suite 1.0.12. stayturgid: make just deploy-check (dry-run) work (#98); site-* version bump only.