### PR TITLE
feat: fleet device offline flag + deploy wall-clock timeout

### DIFF
--- a/control/bin/deploy_fleet.py
+++ b/control/bin/deploy_fleet.py
@@ -49,6 +49,17 @@ SITE_PLAYBOOK = REPO_ROOT / "ansible" / "playbooks" / "site.yml"
 MAC_SITE_PLAYBOOK = REPO_ROOT / "ansible" / "playbooks" / "control_node" / "site.yml"
 REQUIREMENTS = REPO_ROOT / "ansible" / "requirements.yml"
 
+# Wall-clock cap per ansible-playbook invocation. Historical full-fleet runs
+# take ~13-15 minutes; this gives a ~2x margin for one genuine retry without
+# letting a hung or endlessly-retrying rollout run indefinitely (see #104).
+# Override with STAYTURGID_DEPLOY_TIMEOUT_SECONDS for unusually large fleets.
+DEPLOY_TIMEOUT_SECONDS = int(os.environ.get("STAYTURGID_DEPLOY_TIMEOUT_SECONDS", "1800"))
+
+# Inventory field marking a fleet device excluded from deploys by default
+# (see #104). Distinct from site_litellm's site_host_status, which is that
+# group's own unrelated scheme.
+FLEET_STATUS_VAR = "stayturgid_fleet_status"
+
 
 class Scope(str, Enum):
     FULL = "full"
@@ -108,7 +119,7 @@ def parse_inventory_hosts(data: dict, group: str = "stayturgid") -> list[str]:
     return list(hosts.keys())
 
 
-def inventory_hosts(group: str = "stayturgid") -> list[str]:
+def inventory_list(group: str = "stayturgid") -> dict:
     context = resolve_ansible_context(REPO_ROOT)
     require_inventory(context)
     result = subprocess.run(
@@ -119,11 +130,34 @@ def inventory_hosts(group: str = "stayturgid") -> list[str]:
         env=repo_env(),
         cwd=REPO_ROOT,
     )
-    return parse_inventory_hosts(json.loads(result.stdout), group)
+    return json.loads(result.stdout)
+
+
+def inventory_hosts(group: str = "stayturgid") -> list[str]:
+    return parse_inventory_hosts(inventory_list(group), group)
+
+
+def offline_hosts(data: dict, hosts: list[str]) -> list[str]:
+    """Hosts among `hosts` whose FLEET_STATUS_VAR is 'offline'."""
+    hostvars = data.get("_meta", {}).get("hostvars", {})
+    return [h for h in hosts if hostvars.get(h, {}).get(FLEET_STATUS_VAR) == "offline"]
 
 
 def resolve_hosts(hosts: list[str]) -> list[str]:
-    return hosts if hosts else inventory_hosts()
+    if hosts:
+        # Explicit hosts on the command line are an intentional override —
+        # never filtered, even if marked offline.
+        return hosts
+    data = inventory_list()
+    all_hosts = parse_inventory_hosts(data)
+    skipped = offline_hosts(data, all_hosts)
+    if skipped:
+        print(
+            f"deploy_fleet.py: skipping offline host(s) {', '.join(skipped)} "
+            f"({FLEET_STATUS_VAR}: offline) — pass explicitly to override",
+            file=sys.stderr,
+        )
+    return [h for h in all_hosts if h not in skipped]
 
 
 def require_ansible() -> None:
@@ -226,7 +260,15 @@ def run_playbook(
         cmd.extend(extra_vars)
     if verbose:
         cmd.append("-" + "v" * min(verbose, 4))
-    return subprocess.run(cmd, env=repo_env(), cwd=REPO_ROOT).returncode
+    try:
+        return subprocess.run(cmd, env=repo_env(), cwd=REPO_ROOT, timeout=DEPLOY_TIMEOUT_SECONDS).returncode
+    except subprocess.TimeoutExpired:
+        print(
+            f"ERROR: {playbook.name} exceeded {DEPLOY_TIMEOUT_SECONDS}s wall-clock cap — aborted. "
+            f"Override with STAYTURGID_DEPLOY_TIMEOUT_SECONDS if this fleet genuinely needs longer.",
+            file=sys.stderr,
+        )
+        return 124
 
 
 def deploy_mac(*, check: bool, tags: str = "mac", verbose: int = 0) -> int:
@@ -247,6 +289,15 @@ def deploy(scope: Scope, hosts: list[str], *, check: bool, verbose: int = 0, dev
     install_collections()
 
     targets = resolve_hosts(hosts)
+    if not targets:
+        # An empty limit string falls back to "all" in require_limit_hosts,
+        # which would silently deploy to every host — the opposite of
+        # intended when every host happens to be marked offline.
+        print(
+            "ERROR: every fleet host is marked offline and none were passed explicitly — nothing to deploy",
+            file=sys.stderr,
+        )
+        return 1
     # A limit that matches no inventory hosts must fail loudly instead of
     # letting an empty play report a green deploy.
     require_limit_hosts(context, ",".join(targets))

--- a/tests/python/test_deploy_fleet.py
+++ b/tests/python/test_deploy_fleet.py
@@ -156,6 +156,48 @@ def test_install_collections_reruns_when_collections_dir_missing(monkeypatch, tm
     assert len(calls) == 1
 
 
+def test_resolve_hosts_explicit_offline_not_filtered(monkeypatch):
+    """Naming an offline host explicitly is an intentional override (#104)."""
+
+    def fail_inventory_list(*_args, **_kwargs):
+        raise AssertionError("inventory_list must not be called when hosts is non-empty")
+
+    monkeypatch.setattr(df, "inventory_list", fail_inventory_list)
+    assert df.resolve_hosts(["p7a"]) == ["p7a"]
+
+
+def test_offline_hosts_filters_by_fleet_status_var():
+    data = {
+        "_meta": {
+            "hostvars": {
+                "s24": {},
+                "p7a": {"stayturgid_fleet_status": "offline"},
+                "hd8": {"stayturgid_fleet_status": "online"},
+            }
+        }
+    }
+    assert df.offline_hosts(data, ["s24", "p7a", "hd8"]) == ["p7a"]
+
+
+def test_resolve_hosts_default_skips_offline(monkeypatch, capsys):
+    data = {
+        "stayturgid": {"hosts": {"s24": {}, "p7a": {}, "hd8": {}}},
+        "_meta": {"hostvars": {"p7a": {"stayturgid_fleet_status": "offline"}}},
+    }
+    monkeypatch.setattr(df, "inventory_list", lambda group="stayturgid": data)
+    assert df.resolve_hosts([]) == ["s24", "hd8"]
+    assert "skipping offline host(s) p7a" in capsys.readouterr().err
+
+
+def test_resolve_hosts_all_offline_returns_empty(monkeypatch):
+    data = {
+        "stayturgid": {"hosts": {"p7a": {}}},
+        "_meta": {"hostvars": {"p7a": {"stayturgid_fleet_status": "offline"}}},
+    }
+    monkeypatch.setattr(df, "inventory_list", lambda group="stayturgid": data)
+    assert df.resolve_hosts([]) == []
+
+
 def _stub_deploy_deps(monkeypatch, calls, *, playbook_rc=0):
     monkeypatch.setattr(df, "require_ansible", lambda: None)
     monkeypatch.setattr(df, "warn_prerequisites", lambda scope: None)
@@ -243,6 +285,50 @@ def test_deploy_check_skips_bootstrap(monkeypatch):
     assert calls == [
         ("playbook", "fdroid", True, "bootstrap"),
     ]
+
+
+def test_deploy_all_hosts_offline_refuses_not_all_fallback(monkeypatch, capsys):
+    """An empty limit string falls back to 'all' in require_limit_hosts — must
+    never reach there when every host is offline (#104)."""
+    calls = []
+    _stub_deploy_deps(monkeypatch, calls)
+
+    def fail_require_limit_hosts(*_args, **_kwargs):
+        raise AssertionError("require_limit_hosts must not be called with zero targets")
+
+    monkeypatch.setattr(df, "require_limit_hosts", fail_require_limit_hosts)
+    monkeypatch.setattr(df, "resolve_hosts", lambda hosts: [])
+    rc = df.deploy(df.Scope.FULL, [], check=False)
+    assert rc == 1
+    assert calls == []
+    assert "every fleet host is marked offline" in capsys.readouterr().err
+
+
+def test_run_playbook_timeout_returns_124(monkeypatch):
+    import subprocess as sp
+
+    def fake_run(cmd, **kwargs):
+        raise sp.TimeoutExpired(cmd, kwargs.get("timeout"))
+
+    monkeypatch.setattr(df.subprocess, "run", fake_run)
+    rc = df.run_playbook(df.SITE_PLAYBOOK, limit=["oneui-device"], check=False, tags=None)
+    assert rc == 124
+
+
+def test_run_playbook_passes_configured_timeout(monkeypatch):
+    seen_kwargs = {}
+
+    def fake_run(cmd, **kwargs):
+        seen_kwargs.update(kwargs)
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    monkeypatch.setattr(df.subprocess, "run", fake_run)
+    df.run_playbook(df.SITE_PLAYBOOK, limit=["oneui-device"], check=False, tags=None)
+    assert seen_kwargs["timeout"] == df.DEPLOY_TIMEOUT_SECONDS
 
 
 def test_deploy_blocks_concurrent_run(monkeypatch):


### PR DESCRIPTION
Addresses #104.

## What this does

- **Offline flag**: `deploy_fleet.py`'s default (no explicit hosts) fleet-deploy path now skips hosts whose inventory var `stayturgid_fleet_status == "offline"`, printing which were skipped to stderr. Naming a host explicitly on the CLI (`deploy_fleet.py p7a`) is treated as an intentional override — never filtered. This is a single new inventory field, not reusing `site_litellm`'s `site_host_status` (unrelated group/scheme, per operator instruction).
- **Timeout**: `run_playbook` now wraps each `ansible-playbook` invocation with a wall-clock cap (default 1800s / 30min, override via `STAYTURGID_DEPLOY_TIMEOUT_SECONDS`), returning exit 124 with a clear message on timeout instead of hanging indefinitely.

## Edge case handled

If every fleet host happened to be marked offline and no host was passed explicitly, an empty limit string would otherwise fall back to `"all"` in `require_limit_hosts` — silently deploying to *every* host, the opposite of intended. `deploy()` now checks for this explicitly and refuses with a clear error instead.

## Explicitly out of scope (see #104 for why)

Device targeting is fragmented today across three mechanisms — `deploy_fleet.py` (this PR), `just cf-run` (separate SSH config aliases, different host names entirely), and `agent-rollout` (`rollout.py`). This PR only wires the flag into `deploy_fleet.py`, the primary fleet-deploy entry point. Making `cf-run`/`rollout.py` consult the same flag is real, larger follow-up work, not done here.

## Verification

- `just check` clean.
- 7 new unit tests in `tests/python/test_deploy_fleet.py`: explicit-host override not filtered, offline filtering logic, default-path skip + stderr message, all-hosts-offline refusal (specifically asserting `require_limit_hosts` is never reached with an empty limit), timeout → exit 124, and the configured timeout value is actually passed to `subprocess.run`. All 25 tests in the file pass.

Paired with a `site-djbclark` PR marking p7a `offline` (pending #103).

**Not merging automatically** — leaving for operator review.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployments now stop after a configurable timeout and return a clear error status.
  * Offline hosts are automatically excluded from fleet-wide deployments.
  * Deployments fail safely when all fleet hosts are offline, preventing empty-target runs.
  * Explicitly selected hosts continue to deploy, including hosts marked offline.

* **Tests**
  * Added coverage for offline-host filtering, explicit host selection, and deployment timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->