### PR TITLE
fix: tier-1 Ansible self-heal for otelcol-contrib + SSH preflight

### DIFF
--- a/ansible/playbooks/fleet/preflight.yml
+++ b/ansible/playbooks/fleet/preflight.yml
@@ -34,12 +34,48 @@
   vars:
     stayturgid_ssh_keys_dir: "{{ lookup('env', 'HOME') }}/.ssh"
   tasks:
+    # Best-effort (#103): a fully backgrounded/killed Termux can leave `pkg`
+    # and other userland commands unusable via plain `run-as` until the app's
+    # own activity has run at least once since it was last killed — matching
+    # control/bin/firerpa_heal.py's restart_sshd() technique. Foreground it
+    # before the real bootstrap attempt below; ignore failures here, since
+    # the bootstrap task's own re-probe/assert is still the source of truth.
+    - name: Wake a possibly-backgrounded Termux before SSH bootstrap
+      ansible.builtin.command:
+        argv:
+          - adb
+          - -s
+          - "{{ lookup('stayturgid.android_common.adb_device', inventory_hostname) }}"
+          - shell
+          - am
+          - start
+          - -n
+          - com.termux/.app.TermuxActivity
+      delegate_to: localhost
+      changed_when: false
+      failed_when: false
+      when:
+        - not ansible_check_mode
+        - not (_ssh_preflight_ok | default(false) | bool)
+
+    - name: Pause for Termux to come to foreground
+      ansible.builtin.pause:
+        seconds: 3
+      when:
+        - not ansible_check_mode
+        - not (_ssh_preflight_ok | default(false) | bool)
+
     - name: Bootstrap Termux authorized_keys and sshd over adb
       stayturgid.termux.termux_ssh_bootstrap:
         device: "{{ lookup('stayturgid.android_common.adb_device', inventory_hostname) }}"
         keys_dir: "{{ stayturgid_ssh_keys_dir }}"
         public_key_files: "{{ stayturgid_ssh_public_key_files | default([]) }}"
       delegate_to: localhost
+      # A module failure here (#103: e.g. `pkg: inaccessible` on a Termux that
+      # was fully backgrounded) must not end the play with that raw error —
+      # "Re-probe"/"Assert" below are the real source of truth and already
+      # have a clearer fail_msg pointing at bootstrap_ssh.py.
+      ignore_errors: true
       when:
         - not ansible_check_mode
         - not (_ssh_preflight_ok | default(false) | bool)

--- a/ansible_collections/stayturgid/termux/roles/termux_userland/tasks/otelcol.yml
+++ b/ansible_collections/stayturgid/termux/roles/termux_userland/tasks/otelcol.yml
@@ -164,9 +164,41 @@
   args:
     executable: "{{ termux_prefix }}/bin/bash"
   changed_when: false
+  failed_when: false
+  register: _otelcol_verify
   when:
     - stayturgid_otelcol_enabled | bool
     - not ansible_check_mode
+
+# Self-heal (#103): Android can kill a backgrounded Termux process between an
+# earlier task in this role and this verify, independent of whether the boot
+# script template itself changed this run (so the "restart otelcol" handler
+# above may never have fired). Retry once via the same start/stop path the
+# handler uses before treating this as a hard failure.
+- name: Restart otelcol-contrib when not found running
+  ansible.builtin.shell: |
+    {{ stayturgid_otelcol_boot_script | quote }} stop >/dev/null 2>&1 || true
+    {{ stayturgid_otelcol_boot_script | quote }}
+  args:
+    executable: "{{ termux_prefix }}/bin/bash"
+  changed_when: true
+  when:
+    - stayturgid_otelcol_enabled | bool
+    - not ansible_check_mode
+    - _otelcol_verify.rc | default(0) != 0
+
+- name: Re-verify otelcol-contrib is running after self-heal restart
+  ansible.builtin.shell: |
+    pid="$(cat {{ stayturgid_otelcol_pid_file | quote }} 2>/dev/null || true)"
+    [ -n "$pid" ] && [ -d "/proc/$pid" ] &&
+      tr '\0' ' ' <"/proc/$pid/cmdline" | grep -Fq -- {{ stayturgid_otelcol_binary | quote }}
+  args:
+    executable: "{{ termux_prefix }}/bin/bash"
+  changed_when: false
+  when:
+    - stayturgid_otelcol_enabled | bool
+    - not ansible_check_mode
+    - _otelcol_verify.rc | default(0) != 0
 
 - name: Remove otelcol-contrib boot integration when disabled
   ansible.builtin.file:

--- a/tests/python/test_otelcol_edge.py
+++ b/tests/python/test_otelcol_edge.py
@@ -237,6 +237,23 @@ def test_role_orders_mac_prerequisites_before_device_and_integrates_supervision(
     assert "_monitor_otelcol()" in supervisor
 
 
+def test_otelcol_verify_self_heals_once_before_hard_failing() -> None:
+    """#103: a self-heal retry must run between the first verify and any hard
+    failure, using the same start/stop path as the "restart otelcol" handler,
+    and the retry itself must be skippable when the first verify already
+    passed (never fires on the happy path)."""
+    tasks = (ROLE / "tasks/otelcol.yml").read_text()
+    assert tasks.index("Verify otelcol-contrib is running") < tasks.index(
+        "Restart otelcol-contrib when not found running"
+    )
+    assert tasks.index("Restart otelcol-contrib when not found running") < tasks.index(
+        "Re-verify otelcol-contrib is running after self-heal restart"
+    )
+    assert "failed_when: false" in tasks
+    assert "_otelcol_verify.rc | default(0) != 0" in tasks
+    assert "stayturgid_otelcol_boot_script | quote }} stop" in tasks
+
+
 def test_vector_reloads_launchd_job_when_credential_plist_changes() -> None:
     tasks = (REPO / "ansible/roles/serverapp_vector/tasks/main.yml").read_text()
     assert "Boot out site-namespace vector when its launchd plist changed" in tasks

--- a/tests/python/test_preflight.py
+++ b/tests/python/test_preflight.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+PREFLIGHT = REPO / "ansible/playbooks/fleet/preflight.yml"
+
+
+def test_ssh_bootstrap_wakes_termux_before_attempting_and_ignores_module_failure() -> None:
+    """#103: a fully backgrounded Termux can leave `pkg`/run-as unusable until
+    its activity has run since last killed (same technique as
+    control/bin/firerpa_heal.py's restart_sshd()). The wake step must run
+    before the bootstrap attempt, and a bootstrap module failure must not
+    pre-empt the existing re-probe/assert (which has the clearer fail_msg)."""
+    text = PREFLIGHT.read_text()
+    assert text.index("Wake a possibly-backgrounded Termux before SSH bootstrap") < text.index(
+        "Bootstrap Termux authorized_keys and sshd over adb"
+    )
+    assert "com.termux/.app.TermuxActivity" in text
+    assert text.index("Bootstrap Termux authorized_keys and sshd over adb") < text.index(
+        "Re-probe Termux SSH after bootstrap"
+    )
+    assert text.index("Re-probe Termux SSH after bootstrap") < text.index("Assert Termux SSH is reachable")
+    # ignore_errors must apply to the bootstrap task specifically, not the
+    # whole play — check it's the nearest ignore_errors after that task name.
+    bootstrap_idx = text.index("Bootstrap Termux authorized_keys and sshd over adb")
+    reprobe_idx = text.index("Re-probe Termux SSH after bootstrap")
+    assert "ignore_errors: true" in text[bootstrap_idx:reprobe_idx]


### PR DESCRIPTION
Addresses the tier-1 (deploy-time self-heal) recommendation from #103.

## What this does

1. **`otelcol.yml`**: "Verify otelcol-contrib is running" now retries once — via the same start/stop path the existing "restart otelcol" handler uses — before hard-failing. Handles Android killing the process between an earlier task in this role and the verify, independent of whether the boot script template itself changed this run (so the handler's own change-triggered reload may never have fired).
2. **`preflight.yml`**: best-effort `am start -n com.termux/.app.TermuxActivity` + a brief pause before attempting SSH bootstrap — the same technique already used in `control/bin/firerpa_heal.py`'s `restart_sshd()` — since a fully backgrounded Termux can leave `pkg`/`run-as` unusable until its activity has run since it was last killed (this is literally what happened tonight: `pkg: inaccessible or not found`). Also marks the bootstrap task `ignore_errors: true` so a module-level failure there doesn't pre-empt the existing "Re-probe"/"Assert Termux SSH is reachable" tasks, which already have a clearer `fail_msg` pointing at `bootstrap_ssh.py`.

## What this does *not* do (see the #103 comment thread)

Withdraws my earlier suggestion of a CFEngine `processes:` promise for otelcol-contrib continuous supervision — `device/termux/py/start_adb.py`'s boot-loop daemon already has this (`_monitor_otelcol()`, tagged `@heals: OTELCOL-RUNNING`, re-running the idempotent boot script every iteration). The real gap when this bit tonight was the boot-loop supervisor's *own* reliability (p7a's `just health` showed the bootloop/repair mechanism itself failing repeatedly), which is squarely #86's scope — not something to duplicate here.

## Verification

- `just check` clean.
- Two new lightweight structural tests, matching this repo's existing convention for this file (`test_role_orders_mac_prerequisites_before_device_and_integrates_supervision` already does the same "read the task file, assert names/ordering" pattern) — since there's no live Termux to exercise the actual retry against in CI:
  - `test_otelcol_verify_self_heals_once_before_hard_failing`
  - `test_ssh_bootstrap_wakes_termux_before_attempting_and_ignores_module_failure` (new `tests/python/test_preflight.py`)
- All existing tests in `test_otelcol_edge.py` still pass unmodified (task orderings/substrings it already asserts on are preserved).

**Not merging automatically** — leaving for operator review. Untested against a live device (p7a is currently marked offline per stayturgid PR #108/site-djbclark PR #32, pending #103's actual resolution) — recommend re-enabling p7a and running a real `deploy_fleet.py p7a` against this branch before merging, to confirm the self-heal actually recovers a killed otelcol-contrib in practice.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>