### PR TITLE
fix: dependency-free numeric version compare in update_monitor.py

### DIFF
--- a/control/bin/update_monitor.py
+++ b/control/bin/update_monitor.py
@@ -31,6 +31,30 @@ def escape_label_value(value: str) -> str:
     return str(value).replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
 
 
+def versions_differ(current: str, latest: str) -> bool:
+    """True if `current`/`latest` represent different versions.
+
+    Compares dotted-integer segments numerically so "1.2" and "1.2.0" (or a
+    CalVer tag like "2026.7.20") compare equal/ordered correctly instead of
+    the raw strings just happening to differ. Avoids a hard dependency (this
+    script intentionally has none — see get_ansible_version's regex parsing)
+    by falling back to plain string inequality for anything that doesn't
+    parse as dotted integers.
+    """
+
+    def parse(v: str):
+        parts = v.split(".")
+        if parts and all(p.isdigit() for p in parts):
+            return tuple(int(p) for p in parts)
+        return None
+
+    a, b = parse(current), parse(latest)
+    if a is None or b is None:
+        return current != latest
+    length = max(len(a), len(b))
+    return a + (0,) * (length - len(a)) != b + (0,) * (length - len(b))
+
+
 def fetch_github_latest_release(repo: str) -> Optional[str]:
     """Fetches the latest stable release tag from GitHub."""
     url = f"https://api.github.com/repos/{repo}/releases/latest"
@@ -161,7 +185,7 @@ def main():
         clean_current = current_version.lstrip("v")
         clean_latest = latest_version.lstrip("v")
 
-        has_update = 1 if clean_current != clean_latest else 0
+        has_update = 1 if versions_differ(clean_current, clean_latest) else 0
         metrics.append(
             f'software_update_available{{package="{escape_label_value(app["name"])}", '
             f'type="github", current="{escape_label_value(clean_current)}", '

--- a/tests/python/test_update_monitor.py
+++ b/tests/python/test_update_monitor.py
@@ -1,0 +1,54 @@
+"""Unit tests for control/bin/update_monitor.py — dependency-free version compare."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _load_module():
+    path = REPO / "control" / "bin" / "update_monitor.py"
+    spec = importlib.util.spec_from_file_location("update_monitor", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["update_monitor"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+um = _load_module()
+
+
+def test_equal_dotted_versions_no_update():
+    assert um.versions_differ("1.2.3", "1.2.3") is False
+
+
+def test_zero_padding_equivalence_no_false_positive():
+    """The bug this fix addresses: "1.2" and "1.2.0" are the same version."""
+    assert um.versions_differ("1.2", "1.2.0") is False
+    assert um.versions_differ("1.2.0", "1.2") is False
+
+
+def test_numeric_ordering_still_detects_real_differences():
+    assert um.versions_differ("1.2.3", "1.2.4") is True
+    assert um.versions_differ("1.9.0", "1.10.0") is True  # not a string-lexical trap
+    assert um.versions_differ("0.91.1", "0.91.4") is True
+
+
+def test_calver_style_tags_compare_correctly():
+    assert um.versions_differ("2026.7.20", "2026.7.20") is False
+    assert um.versions_differ("2026.7.20", "2026.7.21") is True
+
+
+def test_non_numeric_segments_fall_back_to_string_inequality():
+    """A tag that doesn't parse as dotted integers must never raise — just
+    fall back to plain string comparison."""
+    assert um.versions_differ("1.2.3-rc1", "1.2.3-rc1") is False
+    assert um.versions_differ("1.2.3-rc1", "1.2.3-rc2") is True
+    assert um.versions_differ("v1.2.3", "1.2.3") is True  # caller strips "v" before calling
+
+
+def test_escape_label_value_handles_prometheus_special_chars():
+    assert um.escape_label_value('1.2"x') == '1.2\\"x'
+    assert um.escape_label_value("a\\b\nc") == "a\\\\b\\nc"


### PR DESCRIPTION
Addresses a low-priority item deferred from the #97 consolidated review (item 5, "low: semver-aware compare"), which the ops-v1.0.13 ship intentionally left for a follow-up rather than scope-creep that release.

## What this does

Replaces raw string inequality (\`clean_current != clean_latest\`) in the GitHub-release comparison path with \`versions_differ()\`: compares dotted-integer segments numerically when both sides parse cleanly, so \`"1.2"\` vs \`"1.2.0"\` (same version, different zero-padding) no longer false-positives as an update. Also correctly handles CalVer-style tags (\`"2026.7.20"\`) and avoids the \`"1.9" < "1.10"\` string-lexical trap. Falls back to plain string inequality for anything that doesn't parse as dotted integers (e.g. an \`-rc1\` suffix) — never raises.

**No new dependency** — this script deliberately has none (see \`get_ansible_version\`'s regex-based YAML-avoidance for the existing precedent). A dependency-free approach was chosen over \`packaging.version\` for that reason, even though \`packaging\` happens to be present via Homebrew's own Python on this machine — it isn't guaranteed on every Mac this script might run on.

Only wired into the GitHub-release path (openobserve/olivetin) — the homebrew path already gets correct version comparison for free from \`brew outdated --json\` itself, so there was nothing to fix there.

## Verification

- 6 new unit tests in new `tests/python/test_update_monitor.py` (this file had zero test coverage before): equal versions, the zero-padding false-positive this fix addresses, real numeric differences (including the 1.9-vs-1.10 lexical trap), CalVer tags, non-numeric fallback, and a quick check of the existing `escape_label_value` while the harness was already in place.
- `just check` clean.

**Not merging automatically** — leaving for operator review.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>