### PR TITLE
fix(site-sync): emit portable paths for generated templates

### DIFF
--- a/control/site_contract/site_sync.py
+++ b/control/site_contract/site_sync.py
@@ -383,7 +383,7 @@ def _shell_quote(value: object) -> str:
     return shlex.quote(str(value))
 
 
-def _make_product_file_filter(product_root: str | None):
+def _make_product_file_filter(product_root_path: Path | None):
     """Jinja filter emitting a product file verbatim, so a thin sync template
     can re-publish a product-owned source (e.g. taxonomy group_vars) into the
     site's generated tree without duplicating its content into the template.
@@ -405,8 +405,8 @@ def _make_product_file_filter(product_root: str | None):
         # mode, which renders against a synthetic product_root (/srv/...) for
         # path-determinism yet still needs the real source content.
         candidates: list[Path] = []
-        if product_root:
-            candidates.append(_resolve(Path(product_root), rel_path))
+        if product_root_path:
+            candidates.append(_resolve(product_root_path, rel_path))
         candidates.append(_resolve(REPO_ROOT, rel_path))
         for target in candidates:
             if target.is_file():
@@ -417,7 +417,7 @@ def _make_product_file_filter(product_root: str | None):
     return _product_file
 
 
-def _render_template(template_path: Path, context: dict[str, Any]) -> bytes:
+def _render_template(template_path: Path, context: dict[str, Any], product_root_path: Path | None = None) -> bytes:
     environment = Environment(  # nosemgrep
         undefined=StrictUndefined,
         keep_trailing_newline=True,
@@ -425,7 +425,7 @@ def _render_template(template_path: Path, context: dict[str, Any]) -> bytes:
     )
     environment.filters["json_string_escape"] = _json_string_escape
     environment.filters["shell_quote"] = _shell_quote
-    environment.filters["product_file"] = _make_product_file_filter(context.get("product_root"))
+    environment.filters["product_file"] = _make_product_file_filter(product_root_path)
     text = template_path.read_text(encoding="utf-8")
     try:
         rendered = environment.from_string(text).render(**context)
@@ -545,9 +545,9 @@ def _site_render_context(
     """
     context: dict[str, Any] = {
         "product": PRODUCT,
-        "product_root": str(product_root.resolve()),
-        "stayturgid_root": str(product_root.resolve()),
-        "site_dir": str(site_dir.resolve()),
+        "product_root": f"${{OPS_ROOT:-/Users/djbclark/ops}}/{product_root.name}",
+        "stayturgid_root": f"${{OPS_ROOT:-/Users/djbclark/ops}}/{product_root.name}",
+        "site_dir": f"${{OPS_ROOT:-/Users/djbclark/ops}}/{site_dir.name}",
         "product_version": product_version,
         "product_commit": product_commit,
         "source_template": source_template,
@@ -707,7 +707,7 @@ def build_plan(
             source_template=source_template,
             site_map=site_map,
         )
-        content = _render_template(template_path, context)
+        content = _render_template(template_path, context, product_root_path=product)
         _assert_rendered_content_parses(entry.path, content)
         digest = _sha256_bytes(content)
         new_hashes.append((entry.path, digest))
@@ -1010,7 +1010,7 @@ def _docs_markdown() -> str:
             "inventory_hosts": [{"name": "example-host", "ansible_host": "192.0.2.10"}],
             "openobserve_http_prefix": "",
         }
-        _render_template(template_path, context)
+        _render_template(template_path, context, product_root_path=None)
 
     example_hashes = [
         (

--- a/control/site_contract/site_sync.py
+++ b/control/site_contract/site_sync.py
@@ -407,7 +407,8 @@ def _make_product_file_filter(product_root_path: Path | None):
         candidates: list[Path] = []
         if product_root_path:
             candidates.append(_resolve(product_root_path, rel_path))
-        candidates.append(_resolve(REPO_ROOT, rel_path))
+        else:
+            candidates.append(_resolve(REPO_ROOT, rel_path))
         for target in candidates:
             if target.is_file():
                 return target.read_text(encoding="utf-8")

--- a/docs/operations/sessions/handoff-2026-07-28-site-sync-portable.md
+++ b/docs/operations/sessions/handoff-2026-07-28-site-sync-portable.md
@@ -1,0 +1,17 @@
+# Handoff: site-sync portable paths (Agent 2)
+
+Date: 2026-07-28
+Issue: stayturgid#100
+
+## Work Completed
+- Fixed `site_sync.py` to emit the portable `${OPS_ROOT:-/Users/djbclark/ops}/...` form for `site_dir` and `product_root` in Jinja contexts by default, allowing it to correctly generate `provider.yaml` and `stayturgid_actions.yaml` paths regardless of the sync execution directory (worktree or not).
+- Made `_make_product_file_filter` accept real `Path` objects, decoupling the real lookup path from the portable strings passed to template bodies.
+- Tested `just site-sync` successfully within the worktree to demonstrate it no longer bakes absolute worktree paths into the generated files. 
+- Implemented a drift guard in `site-djbclark/bin/registry_lint.py` that specifically inspects the two path-bearing artifacts and exits with code 2 if it finds any line starting with `cd /` or `path: /` (enforcing the `${OPS_ROOT...}` prefix).
+- Verified `just lint` correctly executes and tests the drift guard.
+- Opened PRs against `stayturgid` and `site-djbclark`.
+
+## Next Steps
+- Review and merge PRs.
+- Once deployed, `~/.config/djbclark/olivetin/config.yaml` will be re-synced via `site-serverapps`/`site-sync` against `~/ops` to correctly point to the `${OPS_ROOT}`-based path instead of the legacy `brew-pinning` path.
+- The `~/src/ops-worktrees/brew-pinning/` directory can then be safely removed by the operator.

--- a/docs/operations/sessions/handoff-2026-07-28-site-sync-portable.md
+++ b/docs/operations/sessions/handoff-2026-07-28-site-sync-portable.md
@@ -4,14 +4,16 @@ Date: 2026-07-28
 Issue: stayturgid#100
 
 ## Work Completed
+
 - Fixed `site_sync.py` to emit the portable `${OPS_ROOT:-/Users/djbclark/ops}/...` form for `site_dir` and `product_root` in Jinja contexts by default, allowing it to correctly generate `provider.yaml` and `stayturgid_actions.yaml` paths regardless of the sync execution directory (worktree or not).
 - Made `_make_product_file_filter` accept real `Path` objects, decoupling the real lookup path from the portable strings passed to template bodies.
-- Tested `just site-sync` successfully within the worktree to demonstrate it no longer bakes absolute worktree paths into the generated files. 
+- Tested `just site-sync` successfully within the worktree to demonstrate it no longer bakes absolute worktree paths into the generated files.
 - Implemented a drift guard in `site-djbclark/bin/registry_lint.py` that specifically inspects the two path-bearing artifacts and exits with code 2 if it finds any line starting with `cd /` or `path: /` (enforcing the `${OPS_ROOT...}` prefix).
 - Verified `just lint` correctly executes and tests the drift guard.
 - Opened PRs against `stayturgid` and `site-djbclark`.
 
 ## Next Steps
+
 - Review and merge PRs.
 - Once deployed, `~/.config/djbclark/olivetin/config.yaml` will be re-synced via `site-serverapps`/`site-sync` against `~/ops` to correctly point to the `${OPS_ROOT}`-based path instead of the legacy `brew-pinning` path.
 - The `~/src/ops-worktrees/brew-pinning/` directory can then be safely removed by the operator.

--- a/tests/python/test_site_sync.py
+++ b/tests/python/test_site_sync.py
@@ -705,7 +705,7 @@ def test_product_file_filter_emits_product_source_verbatim(tmp_path: Path) -> No
     tpl = tmp_path / "t.j2"
     tpl.write_text("# header\n{{ 'sub/data.yml' | product_file }}", encoding="utf-8")
 
-    out = ss._render_template(tpl, {"product_root": str(product)}).decode("utf-8")
+    out = ss._render_template(tpl, {"product_root": str(product)}, product_root_path=product).decode("utf-8")
     assert out == "# header\n---\nkey: value  # product-owned\n"
 
 
@@ -716,7 +716,7 @@ def test_product_file_filter_rejects_path_escape(tmp_path: Path) -> None:
     tpl = tmp_path / "t.j2"
     tpl.write_text("{{ '../secret.yml' | product_file }}", encoding="utf-8")
     try:
-        ss._render_template(tpl, {"product_root": str(product)})
+        ss._render_template(tpl, {"product_root": str(product)}, product_root_path=product)
     except ss.SiteSyncError as exc:
         assert "escapes product root" in str(exc)
     else:

--- a/tests/python/test_site_sync.py
+++ b/tests/python/test_site_sync.py
@@ -721,3 +721,17 @@ def test_product_file_filter_rejects_path_escape(tmp_path: Path) -> None:
         assert "escapes product root" in str(exc)
     else:
         raise AssertionError("expected SiteSyncError for path escape")
+
+
+def test_product_file_filter_no_silent_fallback_when_explicit_root_given(tmp_path: Path) -> None:
+    product = tmp_path / "product"
+    product.mkdir()
+    tpl = tmp_path / "t.j2"
+    tpl.write_text("{{ 'missing.yml' | product_file }}", encoding="utf-8")
+    try:
+        ss._render_template(tpl, {"product_root": str(product)}, product_root_path=product)
+    except ss.SiteSyncError as exc:
+        assert "product_file source missing" in str(exc)
+        assert str(product) in str(exc)
+    else:
+        raise AssertionError("expected SiteSyncError for missing explicit product file")


### PR DESCRIPTION
Fixes #100. Emits portable paths instead of absolute worktree paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved site synchronization with portable product paths using an `OPS_ROOT`-style prefix.
  * Product-owned source files can be republished from an explicitly specified product root.
* **Bug Fixes**
  * Template rendering and generated documentation no longer embed environment-specific absolute filesystem paths.
  * Added stronger validation to prevent unsafe absolute path usage in generated configurations.
* **Documentation**
  * Added a new handoff page covering the “site-sync portable paths (Agent 2)” workflow.
* **Tests**
  * Updated site-sync tests to reflect the new template rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->