### PR TITLE
feat: loopback/Shizuku-independent native-agent liveness + restart (#86)

### DIFF
--- a/control/lib/fleet_health.py
+++ b/control/lib/fleet_health.py
@@ -25,6 +25,17 @@ WATCHDOG_FRESH_SEC = 1800  # 30 min
 REPAIR_FRESH_SEC = 2700  # 45 min
 SSH_PORT = 8022
 
+# Durable, Shizuku-independent native-agent heartbeat (#86). 3x the 120s
+# HostService heartbeat interval (see HeartbeatWriter.HEARTBEAT_INTERVAL_MS in
+# device/native-agent/.../Heartbeat.kt) + 60s jitter margin. MUST match
+# FRESHNESS_SEC in device/termux/cfengine/policy/stayturgid.cf — both read the
+# same /sdcard/Download/stayturgid-agent.heartbeat.txt file (the .txt is
+# MediaStore's own doing — see HeartbeatWriter.FILE_NAME's comment) with the
+# same threshold so the on-device and Mac-side liveness checks cannot disagree
+# (unify rule, #86). This — not the old agent_age below, which stays
+# Shizuku-coupled — is what drives agent_missing/agent_stale.
+AGENT_HEARTBEAT_FRESH_SEC = 420  # 7 min
+
 
 # Resolved at import via stayturgid_device when available; absolute path for launchd.
 def _adb_bin() -> str:
@@ -100,6 +111,22 @@ _agent_age() {
     + r"""
 }
 echo "agent_age=$(_agent_age)"
+# Native agent durable heartbeat (#86): Shizuku/loopback-independent, written
+# by HostService.kt's dedicated heartbeat thread regardless of whether the
+# Shizuku-bound co-monitor (agent_age, above) is able to run at all. This is
+# the authoritative liveness signal — see AGENT_HEARTBEAT_FRESH_SEC.
+_agent_heartbeat_age() {
+  hb="/sdcard/Download/stayturgid-agent.heartbeat.txt"
+  ts=$(grep -oE 'ts_sec=[0-9]+' "$hb" 2>/dev/null | head -1 | cut -d= -f2)
+  if [ -z "$ts" ]; then echo missing; return; fi
+  echo $(($(date +%s) - ts))
+}
+echo "agent_heartbeat_age=$(_agent_heartbeat_age)"
+if [ -f ~/.stayturgid/state/agent_reboot_candidate ]; then
+  echo "agent_reboot_candidate=yes"
+else
+  echo "agent_reboot_candidate=no"
+fi
 # Prefer freshest STATUS among watchdog, repair, and native agent.
 status=$( {
   grep -h 'STATUS port=' "$SD/logs/watchdog.log" /sdcard/stayturgid/logs/watchdog.log ~/.stayturgid/logs/repair.log 2>/dev/null
@@ -198,11 +225,18 @@ def evaluate_health(report: dict[str, str], *, alias: str | None = None) -> list
     if report.get("shell5555") == "down":
         issues.append("shell5555_down")
 
-    aage = _int_age(report.get("agent_age"))
-    if report.get("agent_age") == "missing":
+    # agent_missing/agent_stale gate on the durable heartbeat (#86,
+    # Shizuku/loopback-independent), not the older agent_age (still reported
+    # above for its own diagnostic value — it reflects the Shizuku-bound
+    # co-monitor specifically, and stays coupled to Shizuku on purpose).
+    hbage = _int_age(report.get("agent_heartbeat_age"))
+    if report.get("agent_heartbeat_age") == "missing":
         issues.append("agent_missing")
-    elif aage is not None and aage >= WATCHDOG_FRESH_SEC:
+    elif hbage is not None and hbage >= AGENT_HEARTBEAT_FRESH_SEC:
         issues.append("agent_stale")
+
+    if report.get("agent_reboot_candidate") == "yes":
+        issues.append("agent_reboot_candidate")
 
     rage = _int_age(report.get("repair_age"))
     if report.get("repair_age") == "missing":
@@ -247,6 +281,7 @@ def summarize(report: dict[str, str], issues: list[str]) -> str:
         "shell5555=%s" % report.get("shell5555", "?"),
         "watchdog_age=%s" % report.get("watchdog_age", "?"),
         "agent_age=%s" % report.get("agent_age", "?"),
+        "agent_heartbeat_age=%s" % report.get("agent_heartbeat_age", "?"),
         "repair_age=%s" % report.get("repair_age", "?"),
         "port=%s" % report.get("port", "?"),
         "shizuku=%s" % report.get("shizuku", "?"),
@@ -342,6 +377,17 @@ print("unknown")
   echo "agent_age=$age"
 else
   echo "agent_age=missing"
+fi
+hb_ts=$(grep -oE 'ts_sec=[0-9]+' /sdcard/Download/stayturgid-agent.heartbeat.txt 2>/dev/null | head -1 | cut -d= -f2)
+if [ -n "$hb_ts" ]; then
+  echo "agent_heartbeat_age=$(($(date +%s) - hb_ts))"
+else
+  echo "agent_heartbeat_age=missing"
+fi
+if [ -f /data/data/com.termux/files/home/.stayturgid/state/agent_reboot_candidate ]; then
+  echo "agent_reboot_candidate=yes"
+else
+  echo "agent_reboot_candidate=no"
 fi
 list=$(settings get secure enabled_accessibility_services 2>/dev/null | tr -d '\r')
 echo "a11y_list=$list"

--- a/control/lib/fleet_health.py
+++ b/control/lib/fleet_health.py
@@ -230,9 +230,9 @@ def evaluate_health(report: dict[str, str], *, alias: str | None = None) -> list
     # above for its own diagnostic value — it reflects the Shizuku-bound
     # co-monitor specifically, and stays coupled to Shizuku on purpose).
     hbage = _int_age(report.get("agent_heartbeat_age"))
-    if report.get("agent_heartbeat_age") == "missing":
+    if hbage is None:
         issues.append("agent_missing")
-    elif hbage is not None and hbage >= AGENT_HEARTBEAT_FRESH_SEC:
+    elif hbage >= AGENT_HEARTBEAT_FRESH_SEC:
         issues.append("agent_stale")
 
     if report.get("agent_reboot_candidate") == "yes":

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/HeartbeatWriter.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/HeartbeatWriter.kt
@@ -1,0 +1,173 @@
+package org.stayturgid.agent
+
+import android.content.ContentUris
+import android.content.ContentValues
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import android.util.Log
+import java.io.BufferedWriter
+import java.io.IOException
+import java.io.OutputStreamWriter
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Durable, Shizuku-independent liveness heartbeat (#86).
+ *
+ * Ticks on its own dedicated single-thread executor — never the coroutine scope HostService uses
+ * for Shizuku/UserService work — so a hung Shizuku binder call can never delay or block a tick.
+ * "Top of the heartbeat tick" in the same loop as co-monitor was explicitly ruled out during
+ * review: a wedged `runComonitor()` call would stall that loop's next iteration and silently stop
+ * the heartbeat too, recreating the exact blind spot #86 exists to fix.
+ *
+ * Writes to the MediaStore Downloads collection so Termux (unprivileged app uid, no Shizuku, no
+ * adb) can read it as a plain file with no new permission grant. HostService cannot write
+ * `/sdcard/stayturgid/...` directly without `MANAGE_EXTERNAL_STORAGE` — only the Shizuku-bound
+ * UserService (uid 2000) can, and that coupling is exactly the "trap" #86 routes around. A
+ * ContentProvider (the plan's first-choice transport) was tried and dropped: the real fleet's
+ * Termux has no `content` binary (only am/pm/settings — confirmed live via SSH on hd8), so a
+ * `content query` probe is not reachable from the CFEngine side. MediaStore is the plan's own
+ * documented fallback and needs no new on-device package.
+ *
+ * Lands at /sdcard/Download/[FILE_NAME] (the .txt is MediaStore's own doing — see the constant's
+ * comment). File format is a single plain-text line, `ts_sec=<epoch> seq=<n>`, parsed on the read
+ * side with a plain `grep -oE 'ts_sec=[0-9]+'` (see device/termux/cfengine/policy/stayturgid.cf and
+ * control/lib/fleet_health.py) — keep [formatLine], [FILE_NAME], and that shell contract in sync.
+ */
+object HeartbeatWriter {
+    private const val TAG = "StayTurgidHeartbeat"
+
+    // MediaStore enforces MIME_TYPE <-> extension agreement and silently appends the extension if
+    // DISPLAY_NAME lacks one — verified live on hd8: a "text/plain" insert with DISPLAY_NAME
+    // "stayturgid-agent.heartbeat" actually landed at .../Download/stayturgid-agent.heartbeat.txt.
+    // Naming it explicitly here keeps the constant truthful instead of fighting that behavior.
+    const val FILE_NAME = "stayturgid-agent.heartbeat.txt"
+    private const val MIME_TYPE = "text/plain"
+
+    /**
+     * Tick cadence. Must stay well under the freshness threshold on the reader side (420s in
+     * stayturgid.cf / fleet_health.py — see those files for the full "2-3x + jitter" rationale).
+     */
+    const val HEARTBEAT_INTERVAL_MS: Long = 120_000L
+
+    private val seq = AtomicLong(0)
+    private var cachedUri: Uri? = null
+    private var executor: ScheduledExecutorService? = null
+    private var loggedUnsupported = false
+
+    /** Pure formatting — no Android runtime — so the shell-parsing contract is unit-testable. */
+    fun formatLine(nowEpochSec: Long, seqValue: Long): String =
+        "ts_sec=$nowEpochSec seq=$seqValue\n"
+
+    @Synchronized
+    fun start(context: Context) {
+        if (executor != null) return
+        val appContext = context.applicationContext
+        val exec =
+            Executors.newSingleThreadScheduledExecutor { r ->
+                Thread(r, "stayturgid-heartbeat").apply { isDaemon = true }
+            }
+        executor = exec
+        exec.scheduleWithFixedDelay(
+            { tickSafely(appContext) },
+            0L,
+            HEARTBEAT_INTERVAL_MS,
+            TimeUnit.MILLISECONDS,
+        )
+    }
+
+    @Synchronized
+    fun stop() {
+        executor?.shutdownNow()
+        executor = null
+    }
+
+    // A periodic executor task must survive literally anything thrown inside it (see comment
+    // below) — that is a deliberate boundary, not an oversight, so the generic catch stays.
+    @Suppress("TooGenericExceptionCaught")
+    private fun tickSafely(context: Context) {
+        try {
+            tick(context)
+        } catch (t: Throwable) {
+            // A ScheduledExecutorService silently drops all future runs of a periodic task after
+            // an uncaught exception — never let that happen here, or this reintroduces the same
+            // silent blind spot #86 exists to fix.
+            Log.w(TAG, "heartbeat tick failed: ${t.message}")
+        }
+    }
+
+    // MediaStore/ParcelFileDescriptor I/O can throw several undocumented runtime exception types
+    // across OEMs; any of them must fall back to "re-resolve next tick", not propagate (tickSafely
+    // is the last-resort net, but this catch keeps a single flaky write from dropping the cache
+    // unnecessarily — see the catch body below).
+    @Suppress("TooGenericExceptionCaught")
+    private fun tick(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            if (!loggedUnsupported) {
+                Log.w(
+                    TAG,
+                    "heartbeat needs API 29+ (MediaStore.Downloads); skipping on ${Build.VERSION.SDK_INT}",
+                )
+                loggedUnsupported = true
+            }
+            return
+        }
+        val nowSec = System.currentTimeMillis() / 1000L
+        val body = formatLine(nowSec, seq.incrementAndGet())
+        val resolver = context.contentResolver
+        val uri = cachedUri ?: resolveOrCreate(context) ?: return
+        try {
+            val stream =
+                resolver.openOutputStream(uri, "wt") ?: throw IOException("openOutputStream null")
+            stream.use { out -> BufferedWriter(OutputStreamWriter(out)).use { it.write(body) } }
+            cachedUri = uri
+        } catch (t: Throwable) {
+            // The cached row may have been invalidated (e.g. the user cleared Downloads) — drop
+            // the cache so the next tick re-resolves (query-or-insert) instead of failing forever.
+            Log.w(TAG, "heartbeat write failed, will re-resolve: ${t.message}")
+            cachedUri = null
+        }
+    }
+
+    // Same rationale as tick() above: MediaStore query/insert failure modes vary by OEM and must
+    // degrade to "return null, try again next tick" rather than propagate.
+    @Suppress("TooGenericExceptionCaught")
+    private fun resolveOrCreate(context: Context): Uri? {
+        val resolver = context.contentResolver
+        val collection = MediaStore.Downloads.EXTERNAL_CONTENT_URI
+        val relativePath = Environment.DIRECTORY_DOWNLOADS + "/"
+        val projection = arrayOf(MediaStore.MediaColumns._ID)
+        val selection =
+            "${MediaStore.MediaColumns.DISPLAY_NAME} = ? AND " +
+                "${MediaStore.MediaColumns.RELATIVE_PATH} = ?"
+        try {
+            resolver
+                .query(collection, projection, selection, arrayOf(FILE_NAME, relativePath), null)
+                ?.use { c ->
+                    if (c.moveToFirst()) {
+                        val id = c.getLong(c.getColumnIndexOrThrow(MediaStore.MediaColumns._ID))
+                        return ContentUris.withAppendedId(collection, id)
+                    }
+                }
+        } catch (t: Throwable) {
+            Log.w(TAG, "heartbeat query failed: ${t.message}")
+        }
+        val values =
+            ContentValues().apply {
+                put(MediaStore.MediaColumns.DISPLAY_NAME, FILE_NAME)
+                put(MediaStore.MediaColumns.MIME_TYPE, MIME_TYPE)
+                put(MediaStore.MediaColumns.RELATIVE_PATH, relativePath)
+            }
+        return try {
+            resolver.insert(collection, values)
+        } catch (t: Throwable) {
+            Log.w(TAG, "heartbeat insert failed: ${t.message}")
+            null
+        }
+    }
+}

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/HostService.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/HostService.kt
@@ -137,6 +137,10 @@ class HostService : Service() {
 
         val pm = getSystemService(PowerManager::class.java)
         screenOn = pm?.isInteractive == true
+        // Durable liveness heartbeat (#86): its own dedicated thread, started
+        // before anything Shizuku-related so it never depends on — or can be
+        // blocked by — the co-monitor bind/IPC below.
+        HeartbeatWriter.start(applicationContext)
         // Co-monitor always (screen-independent); inject only while interactive.
         startHeartbeatLoop()
         // Peer-start (issue #61): screen-independent, app-process (no local
@@ -178,6 +182,7 @@ class HostService : Service() {
 
     override fun onDestroy() {
         stopPingLoop()
+        HeartbeatWriter.stop()
         heartbeatJob?.cancel()
         heartbeatJob = null
         peerStartJob?.cancel()

--- a/device/native-agent/app/src/test/kotlin/org/stayturgid/agent/HeartbeatWriterTest.kt
+++ b/device/native-agent/app/src/test/kotlin/org/stayturgid/agent/HeartbeatWriterTest.kt
@@ -1,0 +1,36 @@
+package org.stayturgid.agent
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure heartbeat line formatting (no Android runtime — the MediaStore write path itself needs a
+ * real device and is exercised live on hd8/p7a per #86's device-testing requirement, not here).
+ */
+class HeartbeatWriterTest {
+    @Test
+    fun formatLineIsExactKeyValueShape() {
+        assertEquals("ts_sec=1700000000 seq=42\n", HeartbeatWriter.formatLine(1_700_000_000L, 42L))
+    }
+
+    @Test
+    fun formatLineFieldsSurviveTheShellReaderContract() {
+        // device/termux/cfengine/policy/stayturgid.cf and control/lib/fleet_health.py both parse
+        // this line with `grep -oE 'ts_sec=[0-9]+'` — pin the exact token shape so a reformat here
+        // can't silently break that contract on the read side.
+        val line = HeartbeatWriter.formatLine(123L, 7L)
+        val ts = Regex("""ts_sec=(\d+)""").find(line)?.groupValues?.get(1)
+        val seqField = Regex("""seq=(\d+)""").find(line)?.groupValues?.get(1)
+        assertEquals("123", ts)
+        assertEquals("7", seqField)
+    }
+
+    @Test
+    fun heartbeatIntervalIsWellUnderTheDocumentedFreshnessThreshold() {
+        // Freshness threshold (stayturgid.cf FRESHNESS_SEC / fleet_health.py
+        // AGENT_HEARTBEAT_FRESH_SEC) is documented as ~3x this interval + jitter margin — guard the
+        // "well under" relationship so the two files can't silently drift apart on a future edit.
+        val freshnessSec = 420L
+        assertEquals(true, HeartbeatWriter.HEARTBEAT_INTERVAL_MS / 1000L * 3 <= freshnessSec)
+    }
+}

--- a/device/termux/cfengine/policy/stayturgid.cf
+++ b/device/termux/cfengine/policy/stayturgid.cf
@@ -24,7 +24,7 @@ bundle agent stayturgid_heal {
   methods:
     "heal" usebundle => check_sshd("$(prefix)");
     "heal" usebundle => check_bootloop("$(stg)");
-    "heal" usebundle => check_stayturgid_agent("$(prefix)");
+    "heal" usebundle => check_stayturgid_agent("$(prefix)", "$(stg)");
     "heal" usebundle => check_bootloop_repair("$(prefix)", "$(home)");
 
   reports:
@@ -62,31 +62,112 @@ bundle agent check_bootloop(s) {
       "bootloop: pidfile MISSING";
 }
 
-# Liveness + restart of the Kotlin native agent (org.stayturgid.agent).
-# Depends on the device-local adb loopback (localhost:5555). We no longer
-# re-arm 5555 here (check_shell5555 was removed with the scope reduction):
-# start_adb.py owns `adb tcpip 5555` / `adb connect localhost:5555`, and
-# check_bootloop_repair (below) restarts start_adb.py when it is dead — so the
-# heal ordering re-establishes 5555 before this bundle can use it. Restart is
-# via `am start` of the exported launcher MainActivity (not start-foreground-
-# service, which shell is denied on API 34+); MainActivity.onCreate() starts
-# HostService. Detect via `dumpsys activity services`: a live started FGS shows
-# an `app=ProcessRecord{...}` line (dead/registered-only shows app=null or no
-# record).
-bundle agent check_stayturgid_agent(p) {
+# Liveness + restart of the Kotlin native agent (org.stayturgid.agent) — #86:
+# loopback/Shizuku-independent detection and restart. Previously this bundle
+# both detected and restarted the agent through the device-local adb loopback
+# (localhost:5555), which is flaky on Pixel and dead on Fire OS — a live
+# cf-runagent hail on p7a this session saw the loopback transiently down,
+# false-negativing "NOT RUNNING" while the agent was actually up. Detection no
+# longer depends on it at all.
+#
+# Liveness signal: a durable heartbeat that HostService.kt (Heartbeat.kt,
+# HeartbeatWriter) writes every 120s from a dedicated single-thread executor —
+# never the coroutine scope used for Shizuku/UserService work, so a hung
+# Shizuku binder call can never delay or block a tick. The write lands in the
+# MediaStore Downloads collection (/sdcard/Download/stayturgid-agent.heartbeat.txt
+# — the .txt is MediaStore's own doing, it enforces MIME_TYPE<->extension
+# agreement; "ts_sec=<epoch> seq=<n>"), which Termux reads as a plain file — no adb, no
+# dumpsys, no Shizuku, and no storage permission grant needed by the app
+# (MediaStore.Downloads insert() needs none on API 29+). A ContentProvider
+# (the plan's first-choice transport) was tried and dropped: Termux on the
+# real fleet has no `content` binary (only am/pm/settings — confirmed live via
+# SSH on hd8), so a `content query` probe is not reachable from this bundle;
+# MediaStore is the plan's own documented fallback and needs no new on-device
+# package.
+#
+# Freshness threshold (FRESHNESS_SEC = 420s = 7 min): 3x the 120s heartbeat
+# interval (360s, the generous end of "2-3x") + 60s margin for scheduler/Doze
+# jitter (Fire OS is the aggressive case). MUST match
+# AGENT_HEARTBEAT_FRESH_SEC in control/lib/fleet_health.py — both read the
+# same file with the same threshold so the on-device and Mac-side checks
+# cannot disagree (unify rule, #86). Worst-case detection latency for a
+# genuinely dead agent is FRESHNESS_SEC (420s) + one local boot-loop cycle
+# (<=300s, STAYTURGID_INTERVAL_SEC in start_adb.py) =~ 12 minutes; a
+# Mac-hailed cf-runagent run (Tier 3a) can catch it sooner since it runs this
+# bundle on demand.
+#
+# Restart: Termux's own `am start` of the exported launcher (MainActivity,
+# whose onCreate() starts HostService) is tried first — no loopback needed —
+# but it is best-effort only: Android 10+ background-activity-launch
+# restrictions frequently block a background Termux process from starting an
+# activity, worse after Termux has been idle/backgrounded a while and worse
+# still on Fire OS, and it fails *silently* (exit 0, nothing launches). The
+# old adb-loopback `am start` is kept as a fallback — it may still succeed
+# even though it is no longer the liveness signal.
+#
+# Reboot escalation is alert-only, on purpose: this bundle never executes a
+# reboot itself. After REBOOT_AFTER=3 consecutive checks (~15 min at the
+# 5-minute local boot-loop cadence) still find the agent not alive despite
+# both restart attempts, it writes a state file
+# ($(s)/state/agent_reboot_candidate) and nothing more.
+# control/lib/fleet_health.py surfaces that as an `agent_reboot_candidate`
+# issue, which flows into the existing human-notification path in
+# fleet_health_monitor.py — a human decides, not an unattended `adb reboot`.
+# hd8 specifically has a documented recovery-bootloop hazard on reboot
+# (docs/operations/sessions/handoff-2026-07-26-peer-start-activation.md), and
+# any device reboot generally needs a human to re-enter the PIN afterward
+# (docs/notes/lessons-learned.md) — an automatic reboot here could leave a
+# device down *harder* than the failure it was meant to fix.
+bundle agent check_stayturgid_agent(p, s) {
+  vars:
+    "heartbeat_file" string => "/sdcard/Download/stayturgid-agent.heartbeat.txt";
+    "freshness_sec"  string => "420";
+    "fail_state"     string => "$(s)/state/agent_restart_failures";
+    "reboot_marker"  string => "$(s)/state/agent_reboot_candidate";
+    "reboot_after"   string => "3";
+
   classes:
-    "agent_alive" expression => returnszero("$(p)/bin/adb -s localhost:5555 shell dumpsys activity services org.stayturgid.agent/.HostService 2>/dev/null | grep -q 'app=ProcessRecord'", "useshell");
+    # NOTE on shell syntax: CFEngine's own $(...)/${...} variable-interpolation
+    # scanner also fires inside returnszero()'s string on *shell* $(...),
+    # ${...}, and $((...)) constructs, even when their content isn't a valid
+    # CFEngine variable name — verified live on hd8 (cf-promises accepts it,
+    # but cf-agent silently never runs the shell command: no file, no error,
+    # no class set). Backticks + `expr` sidestep CFEngine's scanner entirely
+    # and were verified end-to-end on-device (alive -> stale -> counter ->
+    # reboot-candidate -> recovery). Do not "clean this up" to $(...)/$((...))
+    # without re-verifying on a real device.
+    "agent_alive" expression => returnszero(
+      "hb=$(heartbeat_file); ts=`$(p)/bin/grep -oE 'ts_sec=[0-9]+' $hb 2>/dev/null | head -1 | cut -d= -f2`; [ -z $ts ] && ts=0; now=`date +%s`; age=`expr $now - $ts`; [ $age -lt $(freshness_sec) ]",
+      "useshell");
 
   reports:
     agent_alive::
-      "stayturgid_agent: running";
+      "stayturgid_agent: running (heartbeat fresh, threshold $(freshness_sec)s)";
     !agent_alive::
-      "stayturgid_agent: NOT RUNNING — attempting restart";
+      "stayturgid_agent: NOT RUNNING (heartbeat stale or missing) — attempting restart";
 
   commands:
+    # Alive again: clear the consecutive-failure counter and any
+    # reboot-candidate marker so a past bad patch doesn't linger.
+    agent_alive::
+      "$(p)/bin/bash"
+        args => "-c 'mkdir -p $(s)/state; rm -f $(fail_state) $(reboot_marker)'",
+        contain => silent_bg;
+
+    # Not alive: try Termux's own am first (no loopback dependency; see file
+    # header for its best-effort caveat), then the adb-loopback fallback,
+    # then record the outcome and escalate if it crosses $(reboot_after).
     !agent_alive::
+      "$(p)/bin/am"
+        args => "start -n org.stayturgid.agent/.MainActivity",
+        contain => silent_bg;
+
       "$(p)/bin/adb"
         args => "-s localhost:5555 shell am start -n org.stayturgid.agent/.MainActivity",
+        contain => silent_bg;
+
+      "$(p)/bin/bash"
+        args => "-c 'mkdir -p $(s)/state; f=$(fail_state); m=$(reboot_marker); prev=`cat $f 2>/dev/null`; [ -z $prev ] && prev=0; n=`expr $prev + 1`; echo $n > $f; if [ $n -ge $(reboot_after) ]; then date +%s > $m; fi'",
         contain => silent_bg;
 }
 

--- a/docs/operations/sessions/handoff-2026-07-28-agent-liveness-86.md
+++ b/docs/operations/sessions/handoff-2026-07-28-agent-liveness-86.md
@@ -1,0 +1,216 @@
+# Handoff 2026-07-28 — #86 loopback/Shizuku-independent agent liveness + restart
+
+## Executive summary
+
+Implemented the revised #86 plan end-to-end: a durable, Shizuku-independent
+heartbeat that `HostService.kt` writes every 120s from its own dedicated
+thread; `check_stayturgid_agent` in `stayturgid.cf` now detects liveness from
+that heartbeat only (no adb loopback, no dumpsys); `fleet_health.py` reads the
+same file so the on-device and Mac-side checks cannot disagree; and a
+consecutive-failure counter that flags (never auto-executes) a reboot
+candidate after repeated restart failures.
+
+**Verified live on hd8 first, then p7a with the loopback deliberately
+disconnected** — both per the plan. On p7a specifically, confirmed
+side-by-side that the _old_ loopback-dependent check would still
+false-negative in that state while the _new_ heartbeat-based check correctly
+reports alive — i.e. reproduced the original bug and confirmed the fix.
+
+Also found and fixed a real, previously-unknown CFEngine parsing quirk along
+the way (§4) — worth reading if you touch `.cf` policy next.
+
+PR not yet opened as of writing this section — see §7 for status/link once
+pushed.
+
+---
+
+## 1. Design decisions and why
+
+**Heartbeat transport: MediaStore, not the plan's first-choice
+ContentProvider.** The revised issue plan preferred a ContentProvider queried
+via Termux `content query`. Live-checked via SSH on hd8: Termux's `$PREFIX/bin`
+has `am`, `pm`, `settings` but **no `content` binary**. A ContentProvider
+would be unreachable from the CFEngine side on the actual fleet, so I used the
+plan's own documented fallback: a MediaStore Downloads file
+(`/sdcard/Download/stayturgid-agent.heartbeat.txt` — the `.txt` is
+MediaStore's own doing, it enforces MIME_TYPE↔extension agreement and
+silently appends the extension; also verified live).
+
+**Heartbeat thread: a dedicated `ScheduledExecutorService`, not a coroutine on
+the existing `Dispatchers.Main.immediate` scope.** `HostService`'s existing
+Shizuku-touching loops run on `Dispatchers.Main.immediate`; a hung Binder call
+there blocks the single Main thread. A heartbeat coroutine sharing that
+dispatcher could be starved by the exact hang it exists to detect. The new
+`HeartbeatWriter` runs on its own daemon thread, entirely decoupled from
+Shizuku/coroutine machinery. See `Heartbeat.kt` → `HeartbeatWriter.kt`'s class
+doc.
+
+**Freshness threshold = 420s (7 min).** 3× the 120s heartbeat interval (360s,
+the generous end of the plan's "2-3x") + 60s jitter margin for Doze/scheduler
+delay (Fire OS is the aggressive case the plan calls out). This number is
+duplicated (by necessity — Kotlin/CFEngine/Python can't share a literal
+constant) in three places, all cross-referencing each other in comments:
+`HeartbeatWriter.HEARTBEAT_INTERVAL_MS`, `stayturgid.cf`'s `freshness_sec`,
+`fleet_health.py`'s `AGENT_HEARTBEAT_FRESH_SEC`. Worst-case detection latency
+for a genuinely dead agent: 420s + one local boot-loop cycle (≤300s,
+`STAYTURGID_INTERVAL_SEC`) ≈ 12 minutes; a Mac-hailed cf-runagent run can catch
+it sooner since it runs the bundle on demand.
+
+**Reboot escalation is alert-only — this bundle never executes a reboot.**
+After `reboot_after=3` consecutive not-alive checks (~15 min at the 5-minute
+boot-loop cadence) despite both restart attempts, `check_stayturgid_agent`
+writes a state file (`$(s)/state/agent_reboot_candidate`) and nothing more.
+`fleet_health.py` surfaces it as an `agent_reboot_candidate` issue tag, which
+flows into the _existing_ `notify()` desktop-alert path in
+`fleet_health_monitor.py` — a human decides. I found two independent, explicit
+reasons in this repo's own history not to auto-reboot:
+`docs/operations/sessions/handoff-2026-07-26-peer-start-activation.md` — "Do
+not `adb reboot` hd8 — recovery-bootloop risk" — and
+`docs/notes/lessons-learned.md:120` — reboot generally needs a human to
+re-enter the device PIN afterward. An unattended auto-reboot could leave a
+device down _harder_ than the failure it was meant to fix. I looked for an
+existing auto-reboot mechanism this could hook into (the revised plan says
+"confirm prolonged 'not running' is already a reboot candidate") and found
+none — `site_logging.py`'s "escalate to reboot" is a docstring example of an
+ERR-severity _log line_, not an executed action. So "reboot policy" here means
+alert, not act, by design.
+
+**Restart order: Termux `am start` first, adb-loopback `am start` second.**
+Matches the revised plan exactly. Verified live on hd8 that Termux's own `am
+start` is genuinely flaky — one attempt (via CFEngine, moments after
+backgrounding) silently did nothing (no error, no launch); an immediately
+following manual attempt (same command) succeeded. This is the documented
+Android background-activity-launch restriction, not a bug in the invocation —
+don't be surprised by it in future testing.
+
+**`fleet_health.py`: `agent_heartbeat_age` is now authoritative for
+`agent_missing`/`agent_stale`; the older `agent_age` (Shizuku-bound co-monitor
+STATUS line) is kept as telemetry only, not removed.** Removing it would also
+silently regress `shizuku`/`port`/`a11y`/`tailscale` fields, which are parsed
+from the same STATUS line and are out of this issue's scope.
+
+## 2. Files changed
+
+- `device/native-agent/app/src/main/kotlin/org/stayturgid/agent/HeartbeatWriter.kt`
+  (new) — the heartbeat writer; `HostService.kt` starts/stops it in
+  `onCreate()`/`onDestroy()`, before/alongside the existing loops.
+- `device/native-agent/app/src/test/kotlin/org/stayturgid/agent/HeartbeatWriterTest.kt`
+  (new) — pure formatting tests; the MediaStore write path itself needs a real
+  device (no Robolectric in this project) and was exercised live instead.
+- `device/termux/cfengine/policy/stayturgid.cf` — `check_stayturgid_agent`
+  rewritten (now takes `(p, s)`; the `s` param and the call site in
+  `stayturgid_heal` changed accordingly).
+- `control/lib/fleet_health.py` — `AGENT_HEARTBEAT_FRESH_SEC`; new
+  `_agent_heartbeat_age()`/`agent_reboot_candidate` probes in both
+  `HEALTH_GATHER` (SSH path) and `adb_health()` (adb fallback path);
+  `evaluate_health()`/`summarize()` updated.
+- `tests/python/test_fleet_health.py` — updated the tests that asserted
+  `agent_age` drove `agent_missing`/`agent_stale` (it no longer does; see §1)
+  to use `agent_heartbeat_age`, plus two new tests
+  (`test_evaluate_agent_reboot_candidate`,
+  `test_evaluate_agent_age_alone_no_longer_drives_staleness`).
+
+## 3. Verification performed (real devices, not simulated)
+
+1. **hd8, full cycle:** built+installed the debug variant (see §5 for why),
+   granted Shizuku, confirmed the heartbeat file appears and ticks
+   (`seq` increments every 120s). Ran the _real_ `stayturgid.cf` via
+   `cf-agent -Kf` over SSH (not a synthetic copy) and confirmed: fresh
+   heartbeat → `stayturgid_agent: running`; heartbeat forced stale → `NOT
+RUNNING`, both restart attempts fire, failure counter increments 1→2→3,
+   `agent_reboot_candidate` marker appears exactly at 3; heartbeat fresh again
+   → counter and marker both clear. Force-stopped the real process and
+   confirmed the bundle's restart path can revive it (flaky, as documented
+   above).
+2. **p7a, loopback down:** installed the same build, then `adb disconnect
+localhost:5555` from _inside_ Termux (Termux's own adb client state — does
+   not touch the Mac's adb connection to the device, which stayed up for
+   testing). With the loopback down, manually ran the **old** check command
+   (`adb -s localhost:5555 shell dumpsys ...`) and confirmed it would
+   false-negative — then ran the **new** bundle and confirmed it correctly
+   reports alive. Reconnected the loopback afterward.
+3. **`fleet_health.py` end-to-end:** ran the real, unmodified-by-hand
+   `ssh_health()` / `evaluate_health()` / `summarize()` against both live
+   devices. Both show fresh `agent_heartbeat_age` and no
+   `agent_missing`/`agent_stale`/`agent_reboot_candidate`; p7a's pre-existing,
+   unrelated `bootloop_down`/`repair_stale` issues (Python watchdog, not the
+   native agent) are unaffected — confirms no regression to other checks.
+4. **Preflights:** `just check` (includes `cf-promises` policy validation),
+   `just pytest` (594 passed, 1 skipped, unrelated), `just kt-test`, `just
+kt-format-check` all clean for the files this PR touches. `just kt-detekt`
+   has 3 pre-existing failures in `ShizukuUserService.kt` /
+   `AuthorizeReminder.kt` — unrelated to this change (verified: those files
+   are untouched by this diff) and not something I fixed — flagging for
+   whoever next touches those files, or for a dedicated cleanup.
+
+## 4. CFEngine finding: `$(...)`/`${...}`/`$((...))` inside `returnszero()` shell strings
+
+Root-caused a real bug during this session, not just in my new code: CFEngine
+3.27.1's own `$(...)`/`${...}` variable-interpolation scanner also fires
+_inside_ a `returnszero(command, "useshell")` string on **shell** command
+substitution `$(...)`, parameter expansion `${...}`, and arithmetic expansion
+`$((...))` — even when the content clearly isn't a valid CFEngine variable
+name. `cf-promises` accepts the policy (syntax-valid), but `cf-agent` silently
+never runs the affected shell command: no output file, no error, the class
+just never gets set. This is **not** about escaping `%` (I initially thought
+so, matching the pre-existing `stat -c %%Y` in `check_bootloop_repair` a few
+bundles down — doubling `%` did **not** fix it in an isolated test).
+
+Workaround, verified end-to-end on-device: use backticks for command
+substitution and `expr` for arithmetic instead — e.g. `` ts=`grep ...` ``
+instead of `ts=$(grep ...)`, `` age=`expr $now - $ts` `` instead of
+`$((now - ts))`. Plain `$(cfengine_var)` for genuine CFEngine variable
+references is unaffected (confirmed working throughout).
+
+I did **not** fix `check_bootloop_repair`'s pre-existing `repair_recent` class
+(`$(stat -c %%Y ...)`, `$(($(date +%s) - 3600))`) — it almost certainly has
+the same bug (it uses exactly these constructs), but it's untouched by this
+PR's scope and I didn't want to touch a bundle I hadn't otherwise changed.
+Flagging clearly here since whoever owns #63 (CFEngine update, later in the
+roster) or anyone else touching `.cf` policy should know about this before
+assuming a `$(...)`-based freshness check "should just work" because
+`cf-promises` accepted it.
+
+## 5. hd8/p7a device-state note (read before assuming "clean baseline")
+
+Both hd8 and p7a were running the **release** build (`org.stayturgid.agent`,
+no `.debug` suffix, `versionName=0.6.0-boot-stability`) before this session.
+The release signing keystore (`device/native-agent/agent-release.jks`,
+gitignored by design) isn't present in this isolated task worktree, so I
+could not build/install a matching signed release APK. I installed the
+**debug** variant (`org.stayturgid.agent.debug`) instead — `just agent-install`
+enforces one agent per device and removed the release build as part of that
+(this is a previously-used, supported fleet configuration per
+`docs/operations/sessions/handoff-2026-07-26-*.md`, not a novel state). Both
+devices are currently on debug with this PR's changes, Shizuku
+re-granted, agent running, heartbeat healthy, all test state files
+(`~/.stayturgid/state/*`, stray `bisect*.cf` etc.) cleaned up.
+
+**If the operator wants release back on either device**, that needs the real
+signing key (not in this worktree) and a normal `assembleRelease` + install —
+this PR does not do that.
+
+## 6. Freshness/threshold numbers, for quick reference
+
+| Constant                        | Value                                    | Where                                                                                                |
+| ------------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Heartbeat write interval        | 120s                                     | `HeartbeatWriter.HEARTBEAT_INTERVAL_MS`                                                              |
+| Freshness threshold             | 420s (3× + 60s jitter)                   | `stayturgid.cf` `freshness_sec`, `fleet_health.py` `AGENT_HEARTBEAT_FRESH_SEC` — **must stay equal** |
+| Reboot-candidate threshold      | 3 consecutive not-alive checks (~15 min) | `stayturgid.cf` `reboot_after`                                                                       |
+| Worst-case dead-agent detection | ≈12 min (420s + ≤300s boot-loop cycle)   | derived                                                                                              |
+
+## 7. Status / next steps
+
+- All code committed on `feature/agent-liveness-86` in
+  `~/src/ops-worktrees/agent-liveness-86/stayturgid`.
+- Not expected to cut a release for this unit (per brief) — PR should land
+  reviewed-ready; merge/release is a separate step.
+- Six PRs from Agent 1's overnight work (stayturgid #107-#111, site-djbclark
+  #32/#33) and two from Agent 2 (stayturgid #112, site-djbclark #34) were open
+  and unmerged when this session started; none touch native-agent/CFEngine/
+  fleet_health, so no conflict, but this PR's baseline (branched from master
+  before any of those merged) doesn't include them either.
+- Possible follow-ons (not done here, out of scope): fix
+  `check_bootloop_repair`'s likely-broken `repair_recent` freshness check
+  (§4); decide whether to restore release builds on hd8/p7a once the signing
+  key is available.

--- a/docs/operations/sessions/handoff-2026-07-28-agent-liveness-86.md
+++ b/docs/operations/sessions/handoff-2026-07-28-agent-liveness-86.md
@@ -19,7 +19,7 @@ reports alive — i.e. reproduced the original bug and confirmed the fix.
 Also found and fixed a real, previously-unknown CFEngine parsing quirk along
 the way (§4) — worth reading if you touch `.cf` policy next.
 
-PR: https://github.com/djbclark/stayturgid/pull/113 (open, not yet reviewed/merged).
+PR: #113 (open, not yet reviewed/merged).
 
 ---
 
@@ -201,10 +201,10 @@ this PR does not do that.
 ## 7. Status / next steps
 
 - All code committed and pushed on `feature/agent-liveness-86`, PR open at
-  https://github.com/djbclark/stayturgid/pull/113.
+  #113.
 - Not expected to cut a release for this unit (per brief) — PR should land
   reviewed-ready; merge/release is a separate step.
-- Six PRs from Agent 1's overnight work (stayturgid #107-#111, site-djbclark
+- Seven PRs from Agent 1's overnight work (stayturgid #107-#111, site-djbclark
   #32/#33) and two from Agent 2 (stayturgid #112, site-djbclark #34) were open
   and unmerged when this session started; none touch native-agent/CFEngine/
   fleet_health, so no conflict, but this PR's baseline (branched from master

--- a/docs/operations/sessions/handoff-2026-07-28-agent-liveness-86.md
+++ b/docs/operations/sessions/handoff-2026-07-28-agent-liveness-86.md
@@ -19,8 +19,7 @@ reports alive — i.e. reproduced the original bug and confirmed the fix.
 Also found and fixed a real, previously-unknown CFEngine parsing quirk along
 the way (§4) — worth reading if you touch `.cf` policy next.
 
-PR not yet opened as of writing this section — see §7 for status/link once
-pushed.
+PR: https://github.com/djbclark/stayturgid/pull/113 (open, not yet reviewed/merged).
 
 ---
 
@@ -201,8 +200,8 @@ this PR does not do that.
 
 ## 7. Status / next steps
 
-- All code committed on `feature/agent-liveness-86` in
-  `~/src/ops-worktrees/agent-liveness-86/stayturgid`.
+- All code committed and pushed on `feature/agent-liveness-86`, PR open at
+  https://github.com/djbclark/stayturgid/pull/113.
 - Not expected to cut a release for this unit (per brief) — PR should land
   reviewed-ready; merge/release is a separate step.
 - Six PRs from Agent 1's overnight work (stayturgid #107-#111, site-djbclark

--- a/tests/python/test_fleet_health.py
+++ b/tests/python/test_fleet_health.py
@@ -145,6 +145,8 @@ def test_summarize_includes_agent_age():
 
 
 def test_evaluate_agent_missing_is_hard_fail_after_cutover():
+    # agent_missing/agent_stale gate on agent_heartbeat_age (#86, Shizuku/loopback-independent),
+    # not the older agent_age — see AGENT_HEARTBEAT_FRESH_SEC's comment.
     report = {
         "ssh_echo": "ok",
         "sshd": "ok",
@@ -152,7 +154,7 @@ def test_evaluate_agent_missing_is_hard_fail_after_cutover():
         "shell5555": "ok",
         "watchdog_age": "100",
         "repair_age": "200",
-        "agent_age": "missing",
+        "agent_heartbeat_age": "missing",
         "a11y": "ok",
         "autojs6_a11y": "ok",
         "port": "open",
@@ -169,7 +171,7 @@ def test_evaluate_agent_stale():
         "shell5555": "ok",
         "watchdog_age": "100",
         "repair_age": "200",
-        "agent_age": str(fh.WATCHDOG_FRESH_SEC + 50),
+        "agent_heartbeat_age": str(fh.AGENT_HEARTBEAT_FRESH_SEC + 50),
         "a11y": "ok",
         "autojs6_a11y": "ok",
         "port": "open",
@@ -178,6 +180,18 @@ def test_evaluate_agent_stale():
     issues = fh.evaluate_health(report)
     assert "agent_stale" in issues
     assert "watchdog_stale" not in issues
+
+
+def test_evaluate_agent_reboot_candidate():
+    report = {"agent_heartbeat_age": "10", "agent_reboot_candidate": "yes"}
+    assert fh.evaluate_health(report) == ["agent_reboot_candidate"]
+
+
+def test_evaluate_agent_age_alone_no_longer_drives_staleness():
+    # The Shizuku-bound comonitor signal (agent_age) is retained as telemetry only — it must not,
+    # by itself, produce agent_stale/agent_missing now that agent_heartbeat_age is authoritative.
+    report = {"agent_age": "missing", "agent_heartbeat_age": "5"}
+    assert fh.evaluate_health(report) == []
 
 
 def test_evaluate_tailscale_down():
@@ -222,6 +236,7 @@ def test_monitor_notifies_after_debounce(tmp_path, monkeypatch):
                 "shell5555": "ok",
                 "watchdog_age": "99999",
                 "agent_age": "99999",
+                "agent_heartbeat_age": "99999",
                 "repair_age": "10",
                 "a11y": "ok",
                 "autojs6_a11y": "ok",
@@ -264,6 +279,7 @@ def test_monitor_agent_heal_failure_skips_cooldown(tmp_path, monkeypatch):
                 "ssh_echo": "ok",
                 "watchdog_age": "99999",
                 "agent_age": "99999",
+                "agent_heartbeat_age": "99999",
                 "repair_age": "10",
                 "sshd": "ok",
                 "bootloop": "ok",
@@ -366,6 +382,7 @@ def test_monitor_heals_stale_agent(tmp_path, monkeypatch):
                 "watchdog_age": "10",
                 "repair_age": "10",
                 "agent_age": "99999",
+                "agent_heartbeat_age": "99999",
                 "a11y": "ok",
                 "autojs6_a11y": "ok",
                 "port": "open",

--- a/tests/python/test_fleet_health.py
+++ b/tests/python/test_fleet_health.py
@@ -48,6 +48,7 @@ def test_evaluate_healthy():
         "shell5555": "ok",
         "watchdog_age": "100",
         "repair_age": "200",
+        "agent_heartbeat_age": "60",
         "a11y": "ok",
         "autojs6_a11y": "ok",
         "port": "open",
@@ -195,15 +196,18 @@ def test_evaluate_agent_age_alone_no_longer_drives_staleness():
 
 
 def test_evaluate_tailscale_down():
-    assert fh.evaluate_health({"tailscale": "down"}) == ["tailscale_down"]
+    report = {"tailscale": "down", "agent_heartbeat_age": "60"}
+    assert fh.evaluate_health(report) == ["tailscale_down"]
 
 
 def test_evaluate_tailscale_policy_down():
-    assert fh.evaluate_health({"tailscale_policy": "down"}) == ["tailscale_policy_down"]
+    report = {"tailscale_policy": "down", "agent_heartbeat_age": "60"}
+    assert fh.evaluate_health(report) == ["tailscale_policy_down"]
 
 
 def test_evaluate_tailscale_failed_states():
-    assert fh.evaluate_health({"tailscale": "FAILED", "tailscale_policy": "FAILED"}) == [
+    report = {"tailscale": "FAILED", "tailscale_policy": "FAILED", "agent_heartbeat_age": "60"}
+    assert fh.evaluate_health(report) == [
         "tailscale_down",
         "tailscale_policy_down",
     ]
@@ -348,6 +352,7 @@ def test_soft_health_snapshot_recorded(tmp_path, monkeypatch):
                 "watchdog_age": "100",
                 "repair_age": "50",
                 "agent_age": "42",
+                "agent_heartbeat_age": "42",
                 "a11y": "up",
                 "autojs6_a11y": "ok",
                 "port": "open",


### PR DESCRIPTION
## Summary
- Durable heartbeat: `HostService` writes a MediaStore Downloads file every 120s from a dedicated thread, independent of Shizuku/coroutine machinery (a hung Shizuku call can never block it).
- `check_stayturgid_agent` in `stayturgid.cf` now detects liveness from that heartbeat alone — no adb loopback, no `dumpsys` — fixing the false-negative restarts the loopback caused (flaky on Pixel, dead on Fire OS).
- `fleet_health.py` reads the same file (`AGENT_HEARTBEAT_FRESH_SEC`), so the on-device and Mac-side checks share one signal instead of two that could disagree.
- Restart: Termux's own `am start` first (best-effort, documented as flaky — verified live), adb-loopback `am start` as fallback. After 3 consecutive failures, writes an **alert-only** reboot-candidate marker — this bundle never executes a reboot itself (hd8 has a documented recovery-bootloop hazard on `adb reboot`, and reboots generally need a human to re-enter the device PIN).
- Along the way: root-caused and worked around a real CFEngine 3.27.1 quirk where shell `$(...)`/`${...}`/`$((...))` inside a `returnszero()` `useshell` string get silently swallowed by CFEngine's own variable scanner, even when they aren't valid CFEngine variables. `cf-promises` accepts the policy; `cf-agent` just never runs the command. Backticks + `expr` sidestep it — documented in the bundle and in the handoff doc (§4) for whoever touches `.cf` policy next (`check_bootloop_repair`'s `repair_recent` class likely has the same latent bug — not fixed here, flagged for a follow-up).

Full design rationale and verification detail: `docs/operations/sessions/handoff-2026-07-28-agent-liveness-86.md`.

## Test plan
- [x] `just check` clean (includes `cf-promises` CFEngine policy validation)
- [x] `just pytest` — 594 passed, 1 skipped (unrelated)
- [x] `just kt-test` / `just kt-format-check` clean for all files this PR touches (`just kt-detekt` has 3 pre-existing failures in untouched files — unrelated)
- [x] **hd8** (physical device): full alive → stale → restart-attempt → counter 1→2→3 → reboot-candidate marker → recovery cycle verified via the real `cf-agent -Kf stayturgid.cf`, not a synthetic copy. Force-stopped the real process and confirmed the bundle's restart path can revive it.
- [x] **p7a** (physical device), loopback deliberately disconnected: confirmed the *old* loopback-dependent check would still false-negative in that state, and the *new* heartbeat-based check correctly reports alive — reproduces the original bug and confirms the fix.
- [x] `fleet_health.py`'s real `ssh_health()`/`evaluate_health()`/`summarize()` run against both live devices — fresh `agent_heartbeat_age`, no spurious issues, pre-existing unrelated p7a issues (`bootloop_down`/`repair_stale`) unaffected.

Not done here (out of scope, flagged in the handoff): fixing `check_bootloop_repair`'s likely-same-bug `repair_recent` class; restoring release-signed builds on hd8/p7a (both are on the debug variant post-testing — the release signing key isn't present in this task worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a durable, connectivity-independent agent heartbeat and expose its age for liveness decisions.
  - Introduced “agent reboot candidate” reporting after repeated recovery failures.
  - Updated recovery to follow a prioritized restart sequence before escalating.
- **Bug Fixes**
  - Reduced false “missing/stale agent” alerts by basing evaluation on the durable heartbeat rather than log timestamps.
- **Documentation**
  - Added an end-to-end operational handoff guide covering the new heartbeat, thresholds, restart behavior, and verification steps.
- **Tests**
  - Expanded unit test coverage for heartbeat formatting, timing expectations, and reboot-candidate and staleness logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->