### PR TITLE
fix(agent): gate CatastrophicRepair's loopback ADB on privilegedShellExpected (#60)

### DIFF
--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/CatastrophicRepair.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/CatastrophicRepair.kt
@@ -31,7 +31,14 @@ object CatastrophicRepair {
             if (ComonitorProbes.probe().port == "open") {
                 return Result(true, "already open")
             }
-            steps += "shell_wireless"
+            // Fire OS adbd drops this step's loopback connect (#60); labeled distinctly
+            // from a real failure so agent.log doesn't read as a mystery repeated failure.
+            steps +=
+                if (DeviceProfile.isPrivilegedShellExpected()) {
+                    "shell_wireless"
+                } else {
+                    "shell_wireless_skip"
+                }
             if (tryShellWirelessRepair()) {
                 appendLog("[agent] catastrophic shell wireless OK")
                 return Result(true, steps.joinToString("+") + ":ok")
@@ -109,6 +116,13 @@ object CatastrophicRepair {
     }
 
     fun tryShellWirelessRepair(): Boolean {
+        if (!DeviceProfile.isPrivilegedShellExpected()) {
+            // Fire OS adbd drops this exact loopback connect (#60) — same gate Termux
+            // already applies via `privilegedShellExpected` in device.json. Skip the
+            // doomed attempt rather than eat the connect timeout every cycle.
+            Log.i(TAG, "tryShellWirelessRepair skipped — privilegedShellExpected=false")
+            return false
+        }
         ensureSetting("global", "development_settings_enabled", "1")
         ensureSetting("global", "adb_enabled", "1")
         ensureSetting("global", "adb_wifi_enabled", "1")

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/CatastrophicRepair.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/CatastrophicRepair.kt
@@ -31,26 +31,27 @@ object CatastrophicRepair {
             if (ComonitorProbes.probe().port == "open") {
                 return Result(true, "already open")
             }
-            // Fire OS adbd drops this step's loopback connect (#60); labeled distinctly
-            // from a real failure so agent.log doesn't read as a mystery repeated failure.
-            steps +=
-                if (DeviceProfile.isPrivilegedShellExpected()) {
-                    "shell_wireless"
-                } else {
-                    "shell_wireless_skip"
-                }
-            if (tryShellWirelessRepair()) {
+            // Fire OS adbd drops this step's loopback connect (#60). Snapshot the flag once
+            // so the recorded step label and the actual attempt can't disagree if the
+            // profile changes mid-repair, and so a downstream "shell status unknown" outcome
+            // can distinguish an intentional skip from a genuine unknown/failure.
+            val shellExpected = DeviceProfile.isPrivilegedShellExpected()
+            steps += if (shellExpected) "shell_wireless" else "shell_wireless_skip"
+            if (tryShellWirelessRepair(shellExpected)) {
                 appendLog("[agent] catastrophic shell wireless OK")
                 return Result(true, steps.joinToString("+") + ":ok")
             }
             steps += "headless_start"
             if (headlessStart()) {
                 appendLog("[agent] catastrophic HEADLESS_START sent; rechecking shell")
-                if (tryShellWirelessRepair()) {
+                if (tryShellWirelessRepair(shellExpected)) {
                     return Result(true, steps.joinToString("+") + ":ok")
                 }
                 if (serverRunning()) {
-                    return Result(true, steps.joinToString("+") + ":server_up_shell_unknown")
+                    return Result(
+                        true,
+                        steps.joinToString("+") + ":" + serverUpDetail(shellExpected),
+                    )
                 }
             }
             appendLog("[agent] catastrophic FAILED steps=${steps.joinToString("+")}")
@@ -61,6 +62,13 @@ object CatastrophicRepair {
             return Result(false, "error:${t.message}")
         }
     }
+
+    /**
+     * Distinguishes an intentional Fire-OS skip (shell status was never expected to be known) from
+     * a genuine unknown after a real wireless-repair attempt.
+     */
+    private fun serverUpDetail(shellExpected: Boolean): String =
+        if (shellExpected) "server_up_shell_unknown" else "server_up_shell_skip"
 
     fun serverRunning(): Boolean {
         val bc =
@@ -115,8 +123,11 @@ object CatastrophicRepair {
         }
     }
 
-    fun tryShellWirelessRepair(): Boolean {
-        if (!DeviceProfile.isPrivilegedShellExpected()) {
+    fun tryShellWirelessRepair(): Boolean =
+        tryShellWirelessRepair(DeviceProfile.isPrivilegedShellExpected())
+
+    fun tryShellWirelessRepair(shellExpected: Boolean): Boolean {
+        if (!shellExpected) {
             // Fire OS adbd drops this exact loopback connect (#60) — same gate Termux
             // already applies via `privilegedShellExpected` in device.json. Skip the
             // doomed attempt rather than eat the connect timeout every cycle.

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/DeviceProfile.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/DeviceProfile.kt
@@ -1,0 +1,40 @@
+package org.stayturgid.agent
+
+import android.util.Log
+import java.io.File
+
+/**
+ * Reads the fleet-provisioned on-device profile (`device.json`) that Termux/Ansible already consume
+ * (`stayturgid_repair.py`, `stayturgid_shell.py`) so the Kotlin side can honor the same
+ * `privilegedShellExpected` flag instead of guessing.
+ *
+ * Fire OS's `adbd` drops any ADB connection whose peer is local to the device (#60) — Termux's own
+ * `localhost:5555` scripts are already gated off there via this flag (`privilegedShellExpected:
+ * false` in the device's `device.json`). [CatastrophicRepair]'s wireless-shell repair step performs
+ * the exact same loopback connect and needs the same gate.
+ *
+ * Regex extraction of a single known boolean field, not full JSON parsing — `org.json.JSONObject`
+ * is an unconfigurable Android stub under plain JVM unit tests (matches the no-Android-deps
+ * philosophy [PeerStartCommands] already documents for its own testable pure functions).
+ */
+object DeviceProfile {
+    private const val TAG = "StayTurgidDeviceProfile"
+    private const val PROFILE_PATH = "/sdcard/stayturgid/state/device.json"
+    private val PRIVILEGED_SHELL_EXPECTED_FIELD =
+        Regex(""""privilegedShellExpected"\s*:\s*(true|false)""")
+
+    /** True unless the device's profile explicitly says otherwise (matches the Python default). */
+    fun isPrivilegedShellExpected(): Boolean =
+        try {
+            val file = File(PROFILE_PATH)
+            if (file.canRead()) parsePrivilegedShellExpected(file.readText()) else true
+        } catch (e: java.io.IOException) {
+            Log.w(TAG, "device profile read failed: ${e.message}")
+            true
+        }
+
+    /** Pure parse, kept separate from file I/O so it is unit-testable off-device. */
+    fun parsePrivilegedShellExpected(json: String): Boolean =
+        PRIVILEGED_SHELL_EXPECTED_FIELD.find(json)?.groupValues?.get(1)?.toBooleanStrictOrNull()
+            ?: true
+}

--- a/device/native-agent/app/src/test/kotlin/org/stayturgid/agent/DeviceProfileTest.kt
+++ b/device/native-agent/app/src/test/kotlin/org/stayturgid/agent/DeviceProfileTest.kt
@@ -1,0 +1,30 @@
+package org.stayturgid.agent
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/** Pure parse tests — mirrors device.json's `privilegedShellExpected` semantics from #60. */
+class DeviceProfileTest {
+    @Test
+    fun explicitFalseIsRespected() {
+        val json = """{"id":"hd8","privilegedShellExpected":false}"""
+        assertFalse(DeviceProfile.parsePrivilegedShellExpected(json))
+    }
+
+    @Test
+    fun explicitTrueIsRespected() {
+        val json = """{"id":"s24","privilegedShellExpected":true}"""
+        assertTrue(DeviceProfile.parsePrivilegedShellExpected(json))
+    }
+
+    @Test
+    fun missingFieldDefaultsToTrue() {
+        assertTrue(DeviceProfile.parsePrivilegedShellExpected("""{"id":"s24"}"""))
+    }
+
+    @Test
+    fun emptyObjectDefaultsToTrue() {
+        assertTrue(DeviceProfile.parsePrivilegedShellExpected("{}"))
+    }
+}

--- a/docs/operations/sessions/handoff-2026-07-28-issue-60-shizuku-eof-scope-check.md
+++ b/docs/operations/sessions/handoff-2026-07-28-issue-60-shizuku-eof-scope-check.md
@@ -5,13 +5,13 @@
 
 ## Task
 
-#60's own last comment deprioritized it in favor of #86, noting it "remains
-relevant only for the agent's own Shizuku-gated privileged actions, not for
-detecting/restarting the agent." Since then #86 (heartbeat/Shizuku-independent
-liveness, PR #113) and #61 (external-ADB peer-start, merged to master via
-`7ad421a`/`10a346a`, live-verified in PR #115) both landed. This session's job:
-determine whether any genuinely open work remains under #60 for the
-"privileged actions" angle.
+Issue `#60`'s own last comment deprioritized it in favor of `#86`, noting it
+"remains relevant only for the agent's own Shizuku-gated privileged actions,
+not for detecting/restarting the agent." Since then `#86`
+(heartbeat/Shizuku-independent liveness, PR `#113`) and `#61` (external-ADB
+peer-start, merged to master via `7ad421a`/`10a346a`, live-verified in PR
+`#115`) both landed. This session's job: determine whether any genuinely open
+work remains under `#60` for the "privileged actions" angle.
 
 ## What was checked
 
@@ -22,13 +22,13 @@ is up:
   through `Shizuku.bindUserService()` (Android Binder IPC), never ADB. Once
   the peer-start loop (`HostService.startPeerStartLoop()`, screen-independent,
   every 20 min) has the Fire-OS target's Shizuku daemon running, these never
-  touch loopback ADB at all. **Confirmed unaffected by #60.**
+  touch loopback ADB at all. **Confirmed unaffected by `#60`.**
 - `ShizukuUserService.repairCatastrophic()` → `CatastrophicRepair.repair()` —
   this one **does** touch loopback ADB: `tryShellWirelessRepair()` runs
-  `adb connect 127.0.0.1:5555` from *inside* the already-running Shizuku
+  `adb connect 127.0.0.1:5555` from _inside_ the already-running Shizuku
   UserService process, to open/verify Android's own ADB-over-network debug
   port (5555) for Termux's `localhost:5555`-based scripts. This is the same
-  operation class the #60 root-cause investigation identified — an on-device
+  operation class the `#60` root-cause investigation identified — an on-device
   process connecting to `adbd` over loopback — so it would hit the identical
   drop on Fire OS.
 - `CatastrophicRepair.repairTailscale()` / `ensureAdbBaseline()` — no ADB
@@ -43,12 +43,12 @@ connection from this Mac):
   Termux's own `stayturgid_repair.py`/`stayturgid_shell.py` are **already**
   correctly gated off from ever attempting `localhost:5555` on Fire OS
   (`privileged_shell_expected()` checks this exact flag; predates this
-  session, not something #86/#61 needed to touch).
+  session, not something `#86`/`#61` needed to touch).
 - hd8's live `agent.log` shows `port=open shell=yes` continuously for the
   last several days — meaning `ComonitorProbes.probe().port == "open"`
   (listening on a non-loopback address) has been true throughout, so
   `CatastrophicRepair.repair()`'s early-return (`if port == "open": return
-  already-open`) means the loopback-touching step is **not currently
+already-open`) means the loopback-touching step is **not currently
   executing** on hd8. It would only fire in the narrow window right after a
   reboot, before any external/peer ADB connection reopens the port — and
   `tryShellWirelessRepair()`'s own doc comment already acknowledges Fire OS
@@ -57,7 +57,7 @@ connection from this Mac):
 So this was a **real but narrow, already-mostly-dormant gap**: an
 unconditional loopback-ADB attempt inside a Shizuku-gated privileged action,
 with no Fire-OS awareness, unlike the equivalent (and already-correct) Python
-side. Not touched by #86 or #61 (neither PR modifies `CatastrophicRepair.kt`).
+side. Not touched by `#86` or `#61` (neither PR modifies `CatastrophicRepair.kt`).
 
 ## Fix applied
 
@@ -68,7 +68,7 @@ side. Not touched by #86 or #61 (neither PR modifies `CatastrophicRepair.kt`).
   function can't use it directly; same reasoning `PeerStartCommands`
   documents for its own dependency-free pure functions).
 - Gated `CatastrophicRepair.tryShellWirelessRepair()`'s loopback `adb connect
-  127.0.0.1:5555` step behind `DeviceProfile.isPrivilegedShellExpected()` —
+127.0.0.1:5555` step behind `DeviceProfile.isPrivilegedShellExpected()` —
   skips cleanly (logged, not a silent no-op) on Fire OS instead of eating the
   doomed connect/timeout every ~20 min post-reboot cycle. `repair()`'s step
   log now distinguishes `shell_wireless_skip` from a real `shell_wireless`
@@ -84,9 +84,9 @@ side. Not touched by #86 or #61 (neither PR modifies `CatastrophicRepair.kt`).
   changed/added files. `kt-detekt` still reports its **3 pre-existing,
   unrelated** failures in untouched files (`ShizukuUserService.kt`
   `NestedBlockDepth` + `SpreadOperator`, `AuthorizeReminder.kt`
-  `MaximumLineLength`) — same ones Agent 3's #113 PR already noted; not
-  touched here. `just kt-format-check` on `master` as-is *also* fails on
-  `ShizukuUserService.kt` (pre-existing drift from `81baa49`, #64/#65/#66) —
+  `MaximumLineLength`) — same ones Agent 3's `#113` PR already noted; not
+  touched here. `just kt-format-check` on `master` as-is _also_ fails on
+  `ShizukuUserService.kt` (pre-existing drift from `81baa49`, `#64`/`#65`/`#66`) —
   left as-is, out of this PR's scope.
 - Did **not** reboot hd8 to force-exercise the skip path live — hd8 has a
   documented recovery-bootloop hazard on `adb reboot`
@@ -96,12 +96,12 @@ side. Not touched by #86 or #61 (neither PR modifies `CatastrophicRepair.kt`).
   `agent.log` shows `shell_wireless_skip` instead of a `shell_wireless`
   failure in the post-boot cycle.
 
-## Outcome / recommendation for #60
+## Outcome / recommendation for `#60`
 
 Not a clean "nothing left" — there was a real, narrow gap, now fixed and
 merged into this PR. With this fix, every Shizuku-gated privileged action
 either (a) runs over Binder IPC once the peer-start-started daemon is up
 (never touches ADB), or (b) is the one loopback-touching best-effort repair
 step, which now correctly no-ops on Fire OS instead of attempting a doomed
-connect. Recommend **closing #60** once this PR merges, with a comment
+connect. Recommend **closing `#60`** once this PR merges, with a comment
 summarizing this evidence — posted separately to the issue.

--- a/docs/operations/sessions/handoff-2026-07-28-issue-60-shizuku-eof-scope-check.md
+++ b/docs/operations/sessions/handoff-2026-07-28-issue-60-shizuku-eof-scope-check.md
@@ -1,0 +1,107 @@
+# Handoff: #60 hd8 Shizuku EOFException — scope check + residual fix
+
+2026-07-28, Agent 5 of the ops-suite orchestration chain
+(`~/ai-orchestration-plan-2026-07-28.md`).
+
+## Task
+
+#60's own last comment deprioritized it in favor of #86, noting it "remains
+relevant only for the agent's own Shizuku-gated privileged actions, not for
+detecting/restarting the agent." Since then #86 (heartbeat/Shizuku-independent
+liveness, PR #113) and #61 (external-ADB peer-start, merged to master via
+`7ad421a`/`10a346a`, live-verified in PR #115) both landed. This session's job:
+determine whether any genuinely open work remains under #60 for the
+"privileged actions" angle.
+
+## What was checked
+
+Read every privileged-action code path the native-agent APK runs once Shizuku
+is up:
+
+- `HostService.ensureBound()` / `pingAwake()` / `runComonitor()` — all go
+  through `Shizuku.bindUserService()` (Android Binder IPC), never ADB. Once
+  the peer-start loop (`HostService.startPeerStartLoop()`, screen-independent,
+  every 20 min) has the Fire-OS target's Shizuku daemon running, these never
+  touch loopback ADB at all. **Confirmed unaffected by #60.**
+- `ShizukuUserService.repairCatastrophic()` → `CatastrophicRepair.repair()` —
+  this one **does** touch loopback ADB: `tryShellWirelessRepair()` runs
+  `adb connect 127.0.0.1:5555` from *inside* the already-running Shizuku
+  UserService process, to open/verify Android's own ADB-over-network debug
+  port (5555) for Termux's `localhost:5555`-based scripts. This is the same
+  operation class the #60 root-cause investigation identified — an on-device
+  process connecting to `adbd` over loopback — so it would hit the identical
+  drop on Fire OS.
+- `CatastrophicRepair.repairTailscale()` / `ensureAdbBaseline()` — no ADB
+  loopback involved (settings puts + `am broadcast`/`am start`). Unaffected.
+
+## Is the loopback step in `repairCatastrophic()` actually live?
+
+Checked hd8 directly (`adb -s 100.124.55.39:5555 shell`, live Tailscale
+connection from this Mac):
+
+- `device.json` on hd8 already has `"privilegedShellExpected": false` —
+  Termux's own `stayturgid_repair.py`/`stayturgid_shell.py` are **already**
+  correctly gated off from ever attempting `localhost:5555` on Fire OS
+  (`privileged_shell_expected()` checks this exact flag; predates this
+  session, not something #86/#61 needed to touch).
+- hd8's live `agent.log` shows `port=open shell=yes` continuously for the
+  last several days — meaning `ComonitorProbes.probe().port == "open"`
+  (listening on a non-loopback address) has been true throughout, so
+  `CatastrophicRepair.repair()`'s early-return (`if port == "open": return
+  already-open`) means the loopback-touching step is **not currently
+  executing** on hd8. It would only fire in the narrow window right after a
+  reboot, before any external/peer ADB connection reopens the port — and
+  `tryShellWirelessRepair()`'s own doc comment already acknowledges Fire OS
+  can't self-heal this without an external connection.
+
+So this was a **real but narrow, already-mostly-dormant gap**: an
+unconditional loopback-ADB attempt inside a Shizuku-gated privileged action,
+with no Fire-OS awareness, unlike the equivalent (and already-correct) Python
+side. Not touched by #86 or #61 (neither PR modifies `CatastrophicRepair.kt`).
+
+## Fix applied
+
+- Added `DeviceProfile.kt`: reads the same `privilegedShellExpected` field
+  from `/sdcard/stayturgid/state/device.json` that Termux already reads,
+  via a small regex extraction (not `org.json.JSONObject` — that class is an
+  unimplemented Android stub under plain-JVM unit tests, so a testable pure
+  function can't use it directly; same reasoning `PeerStartCommands`
+  documents for its own dependency-free pure functions).
+- Gated `CatastrophicRepair.tryShellWirelessRepair()`'s loopback `adb connect
+  127.0.0.1:5555` step behind `DeviceProfile.isPrivilegedShellExpected()` —
+  skips cleanly (logged, not a silent no-op) on Fire OS instead of eating the
+  doomed connect/timeout every ~20 min post-reboot cycle. `repair()`'s step
+  log now distinguishes `shell_wireless_skip` from a real `shell_wireless`
+  attempt, so `agent.log` doesn't read as a mystery repeated failure.
+  `headlessStart()` (Shizuku's own restart nudge, no ADB involved) still
+  runs regardless — unaffected.
+- Added `DeviceProfileTest.kt` (4 cases: explicit true/false, missing field,
+  empty object).
+
+## Verification
+
+- `just kt-format-check`, `just kt-detekt`, `just kt-test` all clean for the
+  changed/added files. `kt-detekt` still reports its **3 pre-existing,
+  unrelated** failures in untouched files (`ShizukuUserService.kt`
+  `NestedBlockDepth` + `SpreadOperator`, `AuthorizeReminder.kt`
+  `MaximumLineLength`) — same ones Agent 3's #113 PR already noted; not
+  touched here. `just kt-format-check` on `master` as-is *also* fails on
+  `ShizukuUserService.kt` (pre-existing drift from `81baa49`, #64/#65/#66) —
+  left as-is, out of this PR's scope.
+- Did **not** reboot hd8 to force-exercise the skip path live — hd8 has a
+  documented recovery-bootloop hazard on `adb reboot`
+  (`memory/project_fireos8_adb_wireless_debugging.md` /
+  handoff-2026-07-25 session notes). The next time hd8 reboots naturally
+  (or an operator does it deliberately with recovery-menu awareness), confirm
+  `agent.log` shows `shell_wireless_skip` instead of a `shell_wireless`
+  failure in the post-boot cycle.
+
+## Outcome / recommendation for #60
+
+Not a clean "nothing left" — there was a real, narrow gap, now fixed and
+merged into this PR. With this fix, every Shizuku-gated privileged action
+either (a) runs over Binder IPC once the peer-start-started daemon is up
+(never touches ADB), or (b) is the one loopback-touching best-effort repair
+step, which now correctly no-ops on Fire OS instead of attempting a doomed
+connect. Recommend **closing #60** once this PR merges, with a comment
+summarizing this evidence — posted separately to the issue.


### PR DESCRIPTION
## Summary
- Scope check for #60 requested by the orchestration plan: with #86 (heartbeat liveness, PR #113) and #61 (peer-start, merged + verified in PR #115) both landed, is there any genuine open work left for "the agent's own Shizuku-gated privileged actions"?
- Answer: mostly no, but found one real narrow gap — `CatastrophicRepair.tryShellWirelessRepair()` unconditionally runs `adb connect 127.0.0.1:5555` *inside* the already-running Shizuku UserService to open Android's own ADB debug port for Termux. That's the same loopback-connect pattern #60's root-cause investigation found Fire OS's `adbd` drops. Neither #86 nor #61 touched this file.
- Termux's own equivalent scripts (`stayturgid_repair.py`, `stayturgid_shell.py`) are already correctly gated off this on Fire OS via `device.json`'s `privilegedShellExpected: false` (confirmed live on hd8). This PR brings the Kotlin side in line with the same flag.
- Confirmed via hd8's live `agent.log` that this path is mostly dormant today (port has stayed externally "open" for days), so this is a narrow, low-blast-radius fix — not a live-breaking bug — but a real, unconditional loopback attempt that would otherwise repeat every ~20 min in the window right after a reboot before an external/peer connection reopens the port.
- Full investigation + evidence: `docs/operations/sessions/handoff-2026-07-28-issue-60-shizuku-eof-scope-check.md`.

## Test plan
- [x] `just kt-format-check`, `just kt-detekt`, `just kt-test` all clean for changed/added files (detekt's 3 remaining failures are pre-existing/unrelated, in untouched files — same ones Agent 3's #113 already flagged)
- [x] `just markdownlint` clean on the handoff doc
- [x] Live-checked hd8 over adb/Tailscale (no reboot — hd8 has a documented recovery-bootloop hazard on `adb reboot`) to confirm `device.json`'s `privilegedShellExpected` flag and current `port=open` steady state
- [ ] Live verification of the actual skip path needs a natural/careful hd8 reboot (not forced here) — noted in the handoff doc

Recommend closing #60 once this merges; posting a closing summary to the issue separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reading a device profile flag to determine whether privileged shell behavior is expected, and using it to guide repair logic.
* **Bug Fixes**
  * Prevented shell wireless repair steps when the profile indicates privileged shell access is not expected.
  * Added clearer reporting for intentionally skipped repair steps and improved consistency of server-detail messaging.
  * Defaulted to enabled behavior when the device profile file is missing or unreadable.
* **Tests**
  * Added unit tests covering parsing of the `privilegedShellExpected` flag for explicit, missing, and empty values.
* **Documentation**
  * Added an operations handoff documenting the privileged-action scope verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->