### PR TITLE
fix(android_common): close #59's remaining adb timeout gaps

### DIFF
--- a/ansible_collections/stayturgid/android_common/plugins/lookup/adb_device.py
+++ b/ansible_collections/stayturgid/android_common/plugins/lookup/adb_device.py
@@ -33,19 +33,50 @@ from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.display import Display
 
-from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_resolve import (
-    resolve_adb,
-)
+try:
+    from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_resolve import (
+        resolve_adb,
+    )
+    from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_timeout import (
+        DEFAULT_FAST_TIMEOUT,
+        run_command_with_timeout,
+    )
+except ImportError:
+    import os
+    import sys
+
+    _mod_utils = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "module_utils")
+    if _mod_utils not in sys.path:
+        sys.path.insert(0, _mod_utils)
+    from adb_resolve import resolve_adb
+    from adb_timeout import DEFAULT_FAST_TIMEOUT, run_command_with_timeout
 
 display = Display()
 
 
-def _run_command(cmd):
+def _raw_run_command(cmd):
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
         return proc.returncode, proc.stdout, proc.stderr
     except OSError as exc:
         raise AnsibleError("adb_device lookup failed to run %s: %s" % (cmd, exc))
+
+
+def _run_command(cmd):
+    """Query-class adb call from the control node (#59) — wrap with the
+    shared coreutils timeout(1) helper so a wedged shell/adbd can't hang
+    this lookup forever, even if this function is ever called directly
+    rather than via resolve_adb(). No get_bin_path_fn override here
+    (defaults to None, same as every adb_resolve.py caller upstream of
+    this function) — that's deliberate: it makes this call share the same
+    process-wide resolved-binary cache as the outer run_command_with_timeout()
+    wrap resolve_adb() already applies, so the double-wrap guard reliably
+    recognizes an already-wrapped incoming cmd and no-ops instead of
+    prefixing `timeout` a second time. A get_bin_path_fn that resolves
+    differently (e.g. shutil.which, which searches $PATH rather than the
+    fixed candidate list) could pick a different absolute path than the
+    outer wrap and defeat that guard."""
+    return run_command_with_timeout(_raw_run_command, cmd, timeout=DEFAULT_FAST_TIMEOUT)
 
 
 class LookupModule(LookupBase):

--- a/ansible_collections/stayturgid/android_common/plugins/lookup/adb_device.py
+++ b/ansible_collections/stayturgid/android_common/plugins/lookup/adb_device.py
@@ -28,6 +28,7 @@ EXAMPLES = r"""
 """
 
 import subprocess
+import sys
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
@@ -54,12 +55,28 @@ except ImportError:
 display = Display()
 
 
+def _target_from_cmd(cmd):
+    """Best-effort device/endpoint label for the device-interaction announcement."""
+    args = cmd[2:] if len(cmd) >= 2 and cmd[0].endswith("timeout") else cmd
+    if "-s" in args:
+        idx = args.index("-s")
+        if idx + 1 < len(args):
+            return args[idx + 1]
+    if len(args) >= 3 and args[1] == "connect":
+        return args[2]
+    return "control-node adb"
+
+
 def _raw_run_command(cmd):
+    target = _target_from_cmd(cmd)
+    sys.stderr.write("🚨📱🚨 USING — %s — control-node adb query (adb_device lookup) — ~30s default\n" % target)
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
         return proc.returncode, proc.stdout, proc.stderr
     except OSError as exc:
         raise AnsibleError("adb_device lookup failed to run %s: %s" % (cmd, exc))
+    finally:
+        sys.stderr.write("🟢📱🟢 FREE — %s — control-node adb query complete\n" % target)
 
 
 def _run_command(cmd):

--- a/ansible_collections/stayturgid/android_common/plugins/lookup/android_packages.py
+++ b/ansible_collections/stayturgid/android_common/plugins/lookup/android_packages.py
@@ -26,6 +26,7 @@ EXAMPLES = r"""
 """
 
 import subprocess
+import sys
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
@@ -49,12 +50,28 @@ except ImportError:
     from adb_timeout import DEFAULT_FAST_TIMEOUT, run_command_with_timeout
 
 
+def _target_from_cmd(cmd):
+    """Best-effort device/endpoint label for the device-interaction announcement."""
+    args = cmd[2:] if len(cmd) >= 2 and cmd[0].endswith("timeout") else cmd
+    if "-s" in args:
+        idx = args.index("-s")
+        if idx + 1 < len(args):
+            return args[idx + 1]
+    if len(args) >= 3 and args[1] == "connect":
+        return args[2]
+    return "control-node adb"
+
+
 def _raw_run_command(cmd):
+    target = _target_from_cmd(cmd)
+    sys.stderr.write("🚨📱🚨 USING — %s — control-node adb query (android_packages lookup) — ~30s default\n" % target)
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
         return proc.returncode, proc.stdout, proc.stderr
     except OSError as exc:
         raise AnsibleError("android_packages lookup failed to run %s: %s" % (cmd, exc))
+    finally:
+        sys.stderr.write("🟢📱🟢 FREE — %s — control-node adb query complete\n" % target)
 
 
 def _run_command(cmd):

--- a/ansible_collections/stayturgid/android_common/plugins/lookup/android_packages.py
+++ b/ansible_collections/stayturgid/android_common/plugins/lookup/android_packages.py
@@ -30,17 +30,48 @@ import subprocess
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 
-from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_packages import (
-    packages_matching,
-)
+try:
+    from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_packages import (
+        packages_matching,
+    )
+    from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_timeout import (
+        DEFAULT_FAST_TIMEOUT,
+        run_command_with_timeout,
+    )
+except ImportError:
+    import os
+    import sys
+
+    _mod_utils = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "module_utils")
+    if _mod_utils not in sys.path:
+        sys.path.insert(0, _mod_utils)
+    from adb_packages import packages_matching
+    from adb_timeout import DEFAULT_FAST_TIMEOUT, run_command_with_timeout
 
 
-def _run_command(cmd):
+def _raw_run_command(cmd):
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
         return proc.returncode, proc.stdout, proc.stderr
     except OSError as exc:
         raise AnsibleError("android_packages lookup failed to run %s: %s" % (cmd, exc))
+
+
+def _run_command(cmd):
+    """Query-class adb call from the control node (#59) — wrap with the
+    shared coreutils timeout(1) helper so a wedged shell/adbd can't hang
+    this lookup forever, even if this function is ever called directly
+    rather than via packages_matching(). No get_bin_path_fn override here
+    (defaults to None, same as every adb_shell.py caller upstream of this
+    function) — that's deliberate: it makes this call share the same
+    process-wide resolved-binary cache as the outer run_command_with_timeout()
+    wrap adb_connect()/adb_shell() already apply, so the double-wrap guard
+    reliably recognizes an already-wrapped incoming cmd and no-ops instead
+    of prefixing `timeout` a second time. A get_bin_path_fn that resolves
+    differently (e.g. shutil.which, which searches $PATH rather than the
+    fixed candidate list) could pick a different absolute path than the
+    outer wrap and defeat that guard."""
+    return run_command_with_timeout(_raw_run_command, cmd, timeout=DEFAULT_FAST_TIMEOUT)
 
 
 class LookupModule(LookupBase):

--- a/ansible_collections/stayturgid/android_common/plugins/lookup/fdroid_client.py
+++ b/ansible_collections/stayturgid/android_common/plugins/lookup/fdroid_client.py
@@ -23,6 +23,7 @@ EXAMPLES = r"""
 """
 
 import subprocess
+import sys
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
@@ -47,12 +48,28 @@ except ImportError:
     from adb_timeout import DEFAULT_FAST_TIMEOUT, run_command_with_timeout
 
 
+def _target_from_cmd(cmd):
+    """Best-effort device/endpoint label for the device-interaction announcement."""
+    args = cmd[2:] if len(cmd) >= 2 and cmd[0].endswith("timeout") else cmd
+    if "-s" in args:
+        idx = args.index("-s")
+        if idx + 1 < len(args):
+            return args[idx + 1]
+    if len(args) >= 3 and args[1] == "connect":
+        return args[2]
+    return "control-node adb"
+
+
 def _raw_run_command(cmd):
+    target = _target_from_cmd(cmd)
+    sys.stderr.write("🚨📱🚨 USING — %s — control-node adb query (fdroid_client lookup) — ~30s default\n" % target)
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
         return proc.returncode, proc.stdout, proc.stderr
     except OSError as exc:
         raise AnsibleError("fdroid_client lookup failed to run %s: %s" % (cmd, exc))
+    finally:
+        sys.stderr.write("🟢📱🟢 FREE — %s — control-node adb query complete\n" % target)
 
 
 def _run_command(cmd):

--- a/ansible_collections/stayturgid/android_common/plugins/lookup/fdroid_client.py
+++ b/ansible_collections/stayturgid/android_common/plugins/lookup/fdroid_client.py
@@ -27,18 +27,50 @@ import subprocess
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 
-from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_packages import (
-    fdroid_components_for_device,
-    preferred_fdroid_component,
-)
+try:
+    from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_packages import (
+        fdroid_components_for_device,
+        preferred_fdroid_component,
+    )
+    from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_timeout import (
+        DEFAULT_FAST_TIMEOUT,
+        run_command_with_timeout,
+    )
+except ImportError:
+    import os
+    import sys
+
+    _mod_utils = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "module_utils")
+    if _mod_utils not in sys.path:
+        sys.path.insert(0, _mod_utils)
+    from adb_packages import fdroid_components_for_device, preferred_fdroid_component
+    from adb_timeout import DEFAULT_FAST_TIMEOUT, run_command_with_timeout
 
 
-def _run_command(cmd):
+def _raw_run_command(cmd):
     try:
         proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
         return proc.returncode, proc.stdout, proc.stderr
     except OSError as exc:
         raise AnsibleError("fdroid_client lookup failed to run %s: %s" % (cmd, exc))
+
+
+def _run_command(cmd):
+    """Query-class adb call from the control node (#59) — wrap with the
+    shared coreutils timeout(1) helper so a wedged shell/adbd can't hang
+    this lookup forever, even if this function is ever called directly
+    rather than via preferred_fdroid_component()/fdroid_components_for_device().
+    No get_bin_path_fn override here (defaults to None, same as every
+    adb_shell.py caller upstream of this function) — that's deliberate: it
+    makes this call share the same process-wide resolved-binary cache as
+    the outer run_command_with_timeout() wrap adb_connect()/adb_shell()
+    already apply, so the double-wrap guard reliably recognizes an
+    already-wrapped incoming cmd and no-ops instead of prefixing `timeout`
+    a second time. A get_bin_path_fn that resolves differently (e.g.
+    shutil.which, which searches $PATH rather than the fixed candidate
+    list) could pick a different absolute path than the outer wrap and
+    defeat that guard."""
+    return run_command_with_timeout(_raw_run_command, cmd, timeout=DEFAULT_FAST_TIMEOUT)
 
 
 class LookupModule(LookupBase):

--- a/ansible_collections/stayturgid/android_common/plugins/module_utils/adb_packages.py
+++ b/ansible_collections/stayturgid/android_common/plugins/module_utils/adb_packages.py
@@ -7,11 +7,24 @@ __metaclass__ = type
 
 import re
 
-from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_shell import (
-    adb_connect,
-    adb_shell,
-    normalize_adb_output,
-)
+try:
+    from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_shell import (
+        adb_connect,
+        adb_shell,
+        normalize_adb_output,
+    )
+except ImportError:
+    import os
+    import sys
+
+    _mod_dir = os.path.dirname(os.path.abspath(__file__))
+    if _mod_dir not in sys.path:
+        sys.path.insert(0, _mod_dir)
+    from adb_shell import (
+        adb_connect,
+        adb_shell,
+        normalize_adb_output,
+    )
 
 # Preference order for fdroidrepos:// handler resolution.
 FDROID_CLIENTS = (

--- a/ansible_collections/stayturgid/android_common/plugins/module_utils/adb_timeout.py
+++ b/ansible_collections/stayturgid/android_common/plugins/module_utils/adb_timeout.py
@@ -15,23 +15,34 @@ _CACHED_TIMEOUT_BIN = None
 
 
 def resolve_timeout_bin(get_bin_path_fn=None):
-    """Find local coreutils `timeout` binary path or return None if missing."""
-    global _CACHED_TIMEOUT_BIN
-    if _CACHED_TIMEOUT_BIN is not None:
-        return _CACHED_TIMEOUT_BIN
+    """Find local coreutils `timeout` binary path or return None if missing.
 
-    bin_path = None
+    A caller-provided ``get_bin_path_fn`` (e.g. ``module.get_bin_path``) is
+    authoritative and consulted fresh on every call — it is never cached,
+    since different callers (or the same call site under test) may resolve
+    it differently. Only the hardcoded-path filesystem scan used when no
+    ``get_bin_path_fn`` is available gets memoized process-wide, since that
+    represents a real, call-independent system fact worth avoiding repeated
+    stat() calls for.
+    """
+    global _CACHED_TIMEOUT_BIN
+
     if get_bin_path_fn is not None:
         try:
             bin_path = get_bin_path_fn("timeout")
         except Exception:
             bin_path = None
+        if bin_path:
+            return bin_path
 
-    if not bin_path:
-        for candidate in ("/opt/homebrew/bin/timeout", "/usr/bin/timeout", "/bin/timeout"):
-            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-                bin_path = candidate
-                break
+    if _CACHED_TIMEOUT_BIN is not None:
+        return _CACHED_TIMEOUT_BIN
+
+    bin_path = None
+    for candidate in ("/opt/homebrew/bin/timeout", "/usr/bin/timeout", "/bin/timeout"):
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            bin_path = candidate
+            break
 
     if bin_path:
         _CACHED_TIMEOUT_BIN = bin_path

--- a/ansible_collections/stayturgid/android_common/plugins/modules/android_apk.py
+++ b/ansible_collections/stayturgid/android_common/plugins/modules/android_apk.py
@@ -150,6 +150,7 @@ reason:
 
 import hashlib
 import os
+import sys
 import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
@@ -390,12 +391,19 @@ def main():
     # idempotency check above has already returned), so steady-state deploys
     # with an unchanged version never uninstall.
     if module.params["clean"] and present:
-        run_command_with_timeout(
+        sys.stderr.write("🚨📱🚨 USING — %s — clean uninstall before reinstall — ~3 min\n" % device)
+        clean_uninstall_rc, clean_uninstall_out, clean_uninstall_err = run_command_with_timeout(
             module.run_command,
             ["adb", "-s", device, "uninstall", package],
             timeout=install_timeout,
             get_bin_path_fn=module.get_bin_path,
         )
+        sys.stderr.write("🟢📱🟢 FREE — %s — clean uninstall complete\n" % device)
+        if clean_uninstall_rc != 0 or "Success" not in normalize_adb_output(clean_uninstall_out):
+            module.fail_json(
+                msg="adb uninstall failed during clean reinstall: %s"
+                % normalize_adb_output(clean_uninstall_out + "\n" + clean_uninstall_err)
+            )
 
     cmd = ["adb", "-s", device, "install", "-r", "--user", user]
     if module.params["installer"]:
@@ -403,9 +411,11 @@ def main():
     cmd += module.params["extra_args"]
     cmd.append(apk)
 
+    sys.stderr.write("🚨📱🚨 USING — %s — install %s — ~3 min\n" % (device, package))
     rc, out, err = run_command_with_timeout(
         module.run_command, cmd, timeout=install_timeout, get_bin_path_fn=module.get_bin_path
     )
+    sys.stderr.write("🟢📱🟢 FREE — %s — install complete\n" % device)
     ok, reason = parse_install_result(out + "\n" + err)
     if (
         present
@@ -415,6 +425,7 @@ def main():
         and incompatible_install_failure(reason)
     ):
         module.warn("clean fallback: uninstalling %s (application data will be lost) after %s" % (package, reason))
+        sys.stderr.write("🚨📱🚨 USING — %s — clean fallback uninstall+reinstall — ~3 min\n" % device)
         uninstall_rc, uninstall_out, uninstall_err = run_command_with_timeout(
             module.run_command,
             ["adb", "-s", device, "uninstall", package],
@@ -422,6 +433,7 @@ def main():
             get_bin_path_fn=module.get_bin_path,
         )
         if uninstall_rc != 0 or "Success" not in normalize_adb_output(uninstall_out):
+            sys.stderr.write("🟢📱🟢 FREE — %s — clean fallback uninstall+reinstall complete\n" % device)
             module.fail_json(
                 msg="adb install failed (%s); clean fallback uninstall failed: %s"
                 % (reason, normalize_adb_output(uninstall_out + "\n" + uninstall_err))
@@ -429,6 +441,7 @@ def main():
         rc, out, err = run_command_with_timeout(
             module.run_command, cmd, timeout=install_timeout, get_bin_path_fn=module.get_bin_path
         )
+        sys.stderr.write("🟢📱🟢 FREE — %s — clean fallback uninstall+reinstall complete\n" % device)
         ok, retry_reason = parse_install_result(out + "\n" + err)
         reason = "%s (clean fallback after %s)" % (retry_reason, reason)
 
@@ -451,9 +464,11 @@ def main():
             module.params["work_profile_user"],
             apk,
         ]
+        sys.stderr.write("🚨📱🚨 USING — %s — work profile install %s — ~3 min\n" % (device, package))
         rc2, _out2, _err2 = run_command_with_timeout(
             module.run_command, wp_cmd, timeout=install_timeout, get_bin_path_fn=module.get_bin_path
         )
+        sys.stderr.write("🟢📱🟢 FREE — %s — work profile install complete\n" % device)
         if rc2 == 0:
             reason += " (also installed for user %s)" % module.params["work_profile_user"]
         elif rc2 == 124:

--- a/ansible_collections/stayturgid/android_common/plugins/modules/android_apk.py
+++ b/ansible_collections/stayturgid/android_common/plugins/modules/android_apk.py
@@ -373,10 +373,14 @@ def main():
     # all, so `adb install` can hang indefinitely — confirmed live: a stuck
     # install (likely an on-device confirmation dialog nobody was there to
     # tap) blocked a deploy for 90+ minutes with no error. Wrap with the
-    # coreutils timeout(1) binary (same pattern used on-device in
-    # stayturgid_battery_alarm.py) so a stuck install fails loudly instead of
-    # hanging the whole fleet deploy.
-    timeout_bin = module.get_bin_path("timeout", required=True)
+    # coreutils timeout(1) binary via the shared run_command_with_timeout()
+    # helper (same mechanism used fleet-wide for #59). Unlike other callers
+    # of that helper, require the binary up front (required=True) rather than
+    # silently degrading to unbounded — this call site is the one that
+    # actually caused the incident, so a missing timeout(1) should fail loudly
+    # here instead of quietly reintroducing the hang risk.
+    module.get_bin_path("timeout", required=True)
+    install_timeout = module.params["install_timeout"]
 
     # Clean reinstall: uninstall before install so the installer re-extracts
     # native libs. Fire OS 8 does not re-extract libs on an in-place upgrade
@@ -386,17 +390,22 @@ def main():
     # idempotency check above has already returned), so steady-state deploys
     # with an unchanged version never uninstall.
     if module.params["clean"] and present:
-        module.run_command(
-            [timeout_bin, str(module.params["install_timeout"]), "adb", "-s", device, "uninstall", package]
+        run_command_with_timeout(
+            module.run_command,
+            ["adb", "-s", device, "uninstall", package],
+            timeout=install_timeout,
+            get_bin_path_fn=module.get_bin_path,
         )
 
-    cmd = [timeout_bin, str(module.params["install_timeout"]), "adb", "-s", device, "install", "-r", "--user", user]
+    cmd = ["adb", "-s", device, "install", "-r", "--user", user]
     if module.params["installer"]:
         cmd += ["-i", module.params["installer"]]
     cmd += module.params["extra_args"]
     cmd.append(apk)
 
-    rc, out, err = module.run_command(cmd)
+    rc, out, err = run_command_with_timeout(
+        module.run_command, cmd, timeout=install_timeout, get_bin_path_fn=module.get_bin_path
+    )
     ok, reason = parse_install_result(out + "\n" + err)
     if (
         present
@@ -406,37 +415,33 @@ def main():
         and incompatible_install_failure(reason)
     ):
         module.warn("clean fallback: uninstalling %s (application data will be lost) after %s" % (package, reason))
-        uninstall_cmd = [
-            timeout_bin,
-            str(module.params["install_timeout"]),
-            "adb",
-            "-s",
-            device,
-            "uninstall",
-            package,
-        ]
-        uninstall_rc, uninstall_out, uninstall_err = module.run_command(uninstall_cmd)
+        uninstall_rc, uninstall_out, uninstall_err = run_command_with_timeout(
+            module.run_command,
+            ["adb", "-s", device, "uninstall", package],
+            timeout=install_timeout,
+            get_bin_path_fn=module.get_bin_path,
+        )
         if uninstall_rc != 0 or "Success" not in normalize_adb_output(uninstall_out):
             module.fail_json(
                 msg="adb install failed (%s); clean fallback uninstall failed: %s"
                 % (reason, normalize_adb_output(uninstall_out + "\n" + uninstall_err))
             )
-        rc, out, err = module.run_command(cmd)
+        rc, out, err = run_command_with_timeout(
+            module.run_command, cmd, timeout=install_timeout, get_bin_path_fn=module.get_bin_path
+        )
         ok, retry_reason = parse_install_result(out + "\n" + err)
         reason = "%s (clean fallback after %s)" % (retry_reason, reason)
 
     if rc == 124:
         module.fail_json(
             msg="adb install timed out after %ss (device may be showing an install confirmation dialog)"
-            % module.params["install_timeout"]
+            % install_timeout
         )
     if rc != 0 or not ok:
         module.fail_json(msg="adb install failed: %s" % reason)
 
     if module.params["work_profile"]:
         wp_cmd = [
-            timeout_bin,
-            str(module.params["install_timeout"]),
             "adb",
             "-s",
             device,
@@ -446,9 +451,16 @@ def main():
             module.params["work_profile_user"],
             apk,
         ]
-        rc2, _out2, _err2 = module.run_command(wp_cmd)
+        rc2, _out2, _err2 = run_command_with_timeout(
+            module.run_command, wp_cmd, timeout=install_timeout, get_bin_path_fn=module.get_bin_path
+        )
         if rc2 == 0:
             reason += " (also installed for user %s)" % module.params["work_profile_user"]
+        elif rc2 == 124:
+            module.warn(
+                "work profile install timed out after %ss (device may be showing an install confirmation "
+                "dialog) — app may not be available in work profile" % install_timeout
+            )
         else:
             module.warn("work profile install failed (rc=%d) — app may not be available in work profile" % rc2)
 

--- a/ansible_collections/stayturgid/android_common/plugins/modules/native_agent_config.py
+++ b/ansible_collections/stayturgid/android_common/plugins/modules/native_agent_config.py
@@ -49,6 +49,7 @@ path:
 import json
 import os
 import shlex
+import sys
 import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
@@ -104,12 +105,14 @@ def install_config(module, device, package, content):
     try:
         tmp.write(content)
         tmp.close()
+        sys.stderr.write("🚨📱🚨 USING — %s — push native-agent peer config — ~3 min\n" % device)
         rc, _out, err = run_command_with_timeout(
             module.run_command,
             ["adb", "-s", device, "push", tmp.name, staging],
             timeout=DEFAULT_SLOW_TIMEOUT,
             get_bin_path_fn=module.get_bin_path,
         )
+        sys.stderr.write("🟢📱🟢 FREE — %s — push native-agent peer config complete\n" % device)
         if rc != 0:
             module.fail_json(msg="native-agent config staging failed: %s" % normalize_adb_output(err))
     finally:

--- a/ansible_collections/stayturgid/android_common/plugins/modules/native_agent_config.py
+++ b/ansible_collections/stayturgid/android_common/plugins/modules/native_agent_config.py
@@ -60,6 +60,23 @@ from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_shel
     package_installed,
 )
 
+try:
+    from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_timeout import (
+        DEFAULT_SLOW_TIMEOUT,
+        run_command_with_timeout,
+    )
+except ImportError:
+    import os
+    import sys
+
+    _mod_utils = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "module_utils")
+    if _mod_utils not in sys.path:
+        sys.path.insert(0, _mod_utils)
+    from adb_timeout import (
+        DEFAULT_SLOW_TIMEOUT,
+        run_command_with_timeout,
+    )
+
 
 def desired_config(targets, shizuku_package):
     return {
@@ -87,7 +104,12 @@ def install_config(module, device, package, content):
     try:
         tmp.write(content)
         tmp.close()
-        rc, _out, err = module.run_command(["adb", "-s", device, "push", tmp.name, staging])
+        rc, _out, err = run_command_with_timeout(
+            module.run_command,
+            ["adb", "-s", device, "push", tmp.name, staging],
+            timeout=DEFAULT_SLOW_TIMEOUT,
+            get_bin_path_fn=module.get_bin_path,
+        )
         if rc != 0:
             module.fail_json(msg="native-agent config staging failed: %s" % normalize_adb_output(err))
     finally:

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/module_utils/test_adb_timeout.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/module_utils/test_adb_timeout.py
@@ -55,6 +55,16 @@ def test_run_command_with_timeout_prevents_double_wrapping(monkeypatch):
     assert calls == [already_wrapped]
 
 
+def test_resolve_timeout_bin_prefers_fresh_get_bin_path_fn_over_cache(monkeypatch):
+    """A provided get_bin_path_fn must win even if a prior call (with no
+    get_bin_path_fn, or a different one) already populated the process-wide
+    fallback cache — regression test for a real cross-call staleness bug
+    where android_apk.py's install path got a stale /opt/homebrew/bin/timeout
+    instead of the test's own mocked /usr/bin/timeout."""
+    monkeypatch.setattr(at, "_CACHED_TIMEOUT_BIN", "/some/other/cached/timeout")
+    assert at.resolve_timeout_bin(get_bin_path_fn=lambda name: "/usr/bin/" + name) == "/usr/bin/timeout"
+
+
 def test_run_command_with_timeout_when_no_timeout_bin(monkeypatch):
     monkeypatch.setattr(at, "resolve_timeout_bin", lambda get_bin_path_fn=None: None)
     calls = []

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_apk.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_apk.py
@@ -298,6 +298,40 @@ def test_android_apk_clean_uninstalls_before_install(mocker, tmp_path):
     assert uninstall_idx < install_idx, cmds
 
 
+def test_android_apk_clean_uninstall_failure_fails_before_install(mocker, tmp_path):
+    """A failed clean uninstall must not silently proceed to installing.
+
+    Regression test: run_command_with_timeout()'s clean-uninstall result was
+    previously discarded entirely, so a failed/timed-out uninstall silently
+    fell through into an in-place `adb install -r`, defeating the native-lib
+    re-extraction the `clean` flag exists for (see the module's history with
+    #60)."""
+    apk = tmp_path / "app.apk"
+    apk.write_bytes(b"PK")
+    seen = []
+
+    def fake_run_command(cmd):
+        seen.append(cmd)
+        joined = " ".join(cmd) if isinstance(cmd, (list, tuple)) else str(cmd)
+        if "pm list packages" in joined:
+            return (0, "package:com.example.app\n", "")
+        if "dumpsys package" in joined:
+            return (1, "", "")
+        if "uninstall" in joined:
+            return (1, "", "Failure [DELETE_FAILED_INTERNAL_ERROR]")
+        return (0, "", "")
+
+    out = run_module(
+        mocker,
+        dict(device="dev", package="com.example.app", apk_path=str(apk), connect=False, clean=True, force=True),
+        command_fn=fake_run_command,
+    )
+
+    assert out.get("failed") is True
+    assert "clean reinstall" in out["msg"], out
+    assert not any(" install -r" in " ".join(c) for c in seen), seen
+
+
 def test_android_apk_clean_false_does_not_uninstall(mocker, tmp_path):
     """clean defaults off: a forced reinstall must not uninstall first."""
     apk = tmp_path / "app.apk"

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_apk.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_apk.py
@@ -179,6 +179,36 @@ def test_android_apk_install_timeout_fails_loudly(mocker, tmp_path):
     assert "timed out" in out["msg"]
 
 
+def test_android_apk_work_profile_install_wrapped_in_timeout(mocker, tmp_path):
+    apk = tmp_path / "app.apk"
+    apk.write_bytes(b"PK")
+    out = run_module(
+        mocker,
+        dict(device="dev", package="com.example.app", apk_path=str(apk), work_profile=True, connect=False),
+    )
+    assert out.get("failed") is not True, out
+    assert "also installed for user 10" in out["reason"]
+
+
+def test_android_apk_work_profile_timeout_warns_with_dialog_hint(mocker, tmp_path):
+    """Regression test for #59: a wedged work-profile install must warn with
+    the same "confirmation dialog" hint as the primary install path, not just
+    a bare rc number, and must not fail the whole task (best-effort)."""
+    apk = tmp_path / "app.apk"
+    apk.write_bytes(b"PK")
+    out = run_module(
+        mocker,
+        dict(device="dev", package="com.example.app", apk_path=str(apk), work_profile=True, connect=False),
+        cmd_results=[
+            ("--user 10", (124, "", "")),
+            (" install", (0, "Success\n", "")),
+        ],
+    )
+    assert out.get("failed") is not True, out
+    assert "also installed for user 10" not in out["reason"]
+    assert any("timed out" in w and "confirmation dialog" in w for w in out["_warnings"]), out["_warnings"]
+
+
 def test_android_apk_skips_when_present(mocker, tmp_path):
     apk = tmp_path / "app.apk"
     apk.write_bytes(b"PK")

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_apk.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_android_apk.py
@@ -298,14 +298,23 @@ def test_android_apk_clean_uninstalls_before_install(mocker, tmp_path):
     assert uninstall_idx < install_idx, cmds
 
 
-def test_android_apk_clean_uninstall_failure_fails_before_install(mocker, tmp_path):
-    """A failed clean uninstall must not silently proceed to installing.
+@pytest.mark.parametrize(
+    "uninstall_rc,uninstall_err",
+    [
+        (1, "Failure [DELETE_FAILED_INTERNAL_ERROR]"),
+        (124, ""),
+    ],
+    ids=["failure", "timeout"],
+)
+def test_android_apk_clean_uninstall_failure_fails_before_install(mocker, tmp_path, uninstall_rc, uninstall_err):
+    """A failed or timed-out clean uninstall must not silently proceed to installing.
 
     Regression test: run_command_with_timeout()'s clean-uninstall result was
     previously discarded entirely, so a failed/timed-out uninstall silently
     fell through into an in-place `adb install -r`, defeating the native-lib
     re-extraction the `clean` flag exists for (see the module's history with
-    #60)."""
+    #60). Covers both an ordinary adb failure and an rc==124 timeout, since
+    run_command_with_timeout() surfaces both the same way (nonzero rc)."""
     apk = tmp_path / "app.apk"
     apk.write_bytes(b"PK")
     seen = []
@@ -318,7 +327,7 @@ def test_android_apk_clean_uninstall_failure_fails_before_install(mocker, tmp_pa
         if "dumpsys package" in joined:
             return (1, "", "")
         if "uninstall" in joined:
-            return (1, "", "Failure [DELETE_FAILED_INTERNAL_ERROR]")
+            return (uninstall_rc, "", uninstall_err)
         return (0, "", "")
 
     out = run_module(

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_native_agent_config.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_native_agent_config.py
@@ -106,6 +106,37 @@ def test_check_mode_reports_change_without_writing(mocker):
     assert not any(" push " in f" {' '.join(cmd)} " for cmd in commands)
 
 
+def test_push_command_wrapped_in_timeout(mocker):
+    """Regression test for #59: the staging `adb push` must go through the
+    shared run_command_with_timeout() helper, not a bare module.run_command()
+    that can hang forever on a wedged shell/adbd."""
+    seen_cmds = []
+
+    def command(cmd):
+        seen_cmds.append(cmd)
+        joined = " ".join(cmd)
+        if "pm list packages" in joined:
+            return (0, "package:org.stayturgid.agent\n", "")
+        if "cat " in joined:
+            return (1, "", "missing")
+        if cmd[0].endswith("timeout") and "push" in joined:
+            return (0, "", "")
+        return (0, "", "")
+
+    mocker.patch(
+        "ansible.module_utils.basic.AnsibleModule.get_bin_path", lambda self, name, required=False: "/usr/bin/" + name
+    )
+    run_module(
+        mocker,
+        {"device": "dev", "targets": ["100.0.0.3:5555"], "connect": False},
+        command,
+    )
+
+    push_cmds = [c for c in seen_cmds if "push" in " ".join(c)]
+    assert len(push_cmds) == 1
+    assert push_cmds[0][:2] == ["/usr/bin/timeout", "180"], push_cmds[0]
+
+
 def test_staging_failure_fails_closed(mocker):
     def command(cmd):
         joined = " ".join(cmd)

--- a/docs/operations/sessions/design-2026-07-28-issue-59-adb-timeouts.md
+++ b/docs/operations/sessions/design-2026-07-28-issue-59-adb-timeouts.md
@@ -34,16 +34,16 @@ resolved once and cached (`resolve_timeout_bin`, checks `module.get_bin_path`
 then falls back to `/opt/homebrew/bin/timeout` / `/usr/bin/timeout` /
 `/bin/timeout`). It was then wired into every call site the issue lists:
 
-| Issue's call site | Status |
-|---|---|
-| `adb_shell.py:17,21` (`adb_connect`, `adb_shell`) | ✅ routed through `run_command_with_timeout`, `DEFAULT_FAST_TIMEOUT` |
-| `adb_resolve.py:50,93,128,164` (`adb devices`, `adb connect`, `-s ... getprop`, `adb mdns services`) | ✅ all four routed, `DEFAULT_FAST_TIMEOUT` |
-| `autojs6_deploy_util.py:56` (`adb push`) | ✅ routed, `DEFAULT_SLOW_TIMEOUT` |
-| `shizuku_start.py:155` (`adb push` fleet profile) | ✅ routed, `DEFAULT_SLOW_TIMEOUT` |
-| `shizuku_grant.py:94` (`adb push`) | ✅ routed, `DEFAULT_SLOW_TIMEOUT` |
-| `android_apk.py:172,212` (`package_installed`/`installed_version` via `adb_shell.py`) | ✅ covered transitively (shared helper) |
-| `download_gh_release()` (`gh release download`) | ✅ routed, `DEFAULT_SLOW_TIMEOUT` |
-| `resign_apk()` (`apksigner sign`) | ✅ routed, `DEFAULT_SLOW_TIMEOUT` |
+| Issue's call site                                                                                    | Status                                                               |
+| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `adb_shell.py:17,21` (`adb_connect`, `adb_shell`)                                                    | ✅ routed through `run_command_with_timeout`, `DEFAULT_FAST_TIMEOUT` |
+| `adb_resolve.py:50,93,128,164` (`adb devices`, `adb connect`, `-s ... getprop`, `adb mdns services`) | ✅ all four routed, `DEFAULT_FAST_TIMEOUT`                           |
+| `autojs6_deploy_util.py:56` (`adb push`)                                                             | ✅ routed, `DEFAULT_SLOW_TIMEOUT`                                    |
+| `shizuku_start.py:155` (`adb push` fleet profile)                                                    | ✅ routed, `DEFAULT_SLOW_TIMEOUT`                                    |
+| `shizuku_grant.py:94` (`adb push`)                                                                   | ✅ routed, `DEFAULT_SLOW_TIMEOUT`                                    |
+| `android_apk.py:172,212` (`package_installed`/`installed_version` via `adb_shell.py`)                | ✅ covered transitively (shared helper)                              |
+| `download_gh_release()` (`gh release download`)                                                      | ✅ routed, `DEFAULT_SLOW_TIMEOUT`                                    |
+| `resign_apk()` (`apksigner sign`)                                                                    | ✅ routed, `DEFAULT_SLOW_TIMEOUT`                                    |
 
 Tests were added/updated in the same commit: `test_adb_timeout.py` (new, 5
 cases: bin resolution, prefixing, `rc==124` handling, double-wrap prevention,
@@ -57,7 +57,7 @@ needed to make them pass.
 I also confirmed the open-questions the issue explicitly flagged:
 
 - **`gh release download` / `apksigner sign` treatment** — the commit put them
-  through the *same* mechanism (`DEFAULT_SLOW_TIMEOUT`, same helper), not a
+  through the _same_ mechanism (`DEFAULT_SLOW_TIMEOUT`, same helper), not a
   separate one. Reasonable: both are simple "spawn a process, wait, check rc"
   shell-outs with no signal/streaming needs, so a second bespoke mechanism
   would just be duplication.
@@ -124,7 +124,7 @@ rc, _out, err = run_command_with_timeout(
 )
 ```
 
-*(Update: this edit was made in Phase 2 — see the handoff doc.)*
+_(Update: this edit was made in Phase 2 — see the handoff doc.)_
 
 ## Minor inconsistency (not a functional gap): dual timeout mechanisms in `android_apk.py`
 
@@ -178,7 +178,7 @@ whether the `android_apk.py` dual-mechanism unification is worth doing now or
 left alone** — then a trivial PR for the `native_agent_config.py` fix (plus
 unification if greenlit) closes out #59 for real.
 
-*(Update: the operator reviewed this and confirmed go-ahead on both — see the
+_(Update: the operator reviewed this and confirmed go-ahead on both — see the
 handoff doc for the second gap the review found (the lookup-plugin claim,
 investigated and found to already be covered — not a live gap) and what
-Phase 2 actually shipped.)*
+Phase 2 actually shipped.)_

--- a/docs/operations/sessions/design-2026-07-28-issue-59-adb-timeouts.md
+++ b/docs/operations/sessions/design-2026-07-28-issue-59-adb-timeouts.md
@@ -1,0 +1,184 @@
+# Design note: #59 systemic adb `run_command` timeouts
+
+**Status: Phase 1 research below, followed by Phase 2 implementation after
+operator review and go-ahead. See
+`handoff-2026-07-28-issue-59-adb-timeouts.md` for what Phase 2 actually did —
+this document is kept as the as-written Phase 1 research record.**
+
+## Headline finding: the systemic fix already shipped
+
+Issue #59 asks for a centralized timeout helper across every `adb`-invoking
+`module.run_command()` call in `ansible_collections/stayturgid/android_common/`.
+That work **already exists on `master`**, committed directly by the operator on
+**2026-07-26 22:21:55**, commit `db2a8520d749970ec68f3a8769af5f67746628dd`
+("fix(android_common): systemically wrap all adb and external commands with
+timeouts (#59)") — two days before this orchestration chain was created
+(2026-07-28) and before issue #59 was closed (it's still open, 0 comments).
+
+The commit added `plugins/module_utils/adb_timeout.py`:
+
+```python
+DEFAULT_FAST_TIMEOUT = 30  # queries: adb devices/connect/shell getprop/mdns
+DEFAULT_SLOW_TIMEOUT = 180  # transfers: adb push/install, gh release download, apksigner sign
+
+
+def run_command_with_timeout(run_command_fn, cmd, timeout=DEFAULT_FAST_TIMEOUT, get_bin_path_fn=None):
+    """Prefix cmd with coreutils `timeout <seconds>` if available; rc==124 ->
+    clear error message appended to stderr. No-op (unbounded) if `timeout`
+    binary can't be resolved — same degrade-gracefully posture as before."""
+```
+
+This is exactly the design the issue asked for: a single shared helper, a
+two-tier default (fast query vs. slow transfer), consistent `rc==124` handling,
+resolved once and cached (`resolve_timeout_bin`, checks `module.get_bin_path`
+then falls back to `/opt/homebrew/bin/timeout` / `/usr/bin/timeout` /
+`/bin/timeout`). It was then wired into every call site the issue lists:
+
+| Issue's call site | Status |
+|---|---|
+| `adb_shell.py:17,21` (`adb_connect`, `adb_shell`) | ✅ routed through `run_command_with_timeout`, `DEFAULT_FAST_TIMEOUT` |
+| `adb_resolve.py:50,93,128,164` (`adb devices`, `adb connect`, `-s ... getprop`, `adb mdns services`) | ✅ all four routed, `DEFAULT_FAST_TIMEOUT` |
+| `autojs6_deploy_util.py:56` (`adb push`) | ✅ routed, `DEFAULT_SLOW_TIMEOUT` |
+| `shizuku_start.py:155` (`adb push` fleet profile) | ✅ routed, `DEFAULT_SLOW_TIMEOUT` |
+| `shizuku_grant.py:94` (`adb push`) | ✅ routed, `DEFAULT_SLOW_TIMEOUT` |
+| `android_apk.py:172,212` (`package_installed`/`installed_version` via `adb_shell.py`) | ✅ covered transitively (shared helper) |
+| `download_gh_release()` (`gh release download`) | ✅ routed, `DEFAULT_SLOW_TIMEOUT` |
+| `resign_apk()` (`apksigner sign`) | ✅ routed, `DEFAULT_SLOW_TIMEOUT` |
+
+Tests were added/updated in the same commit: `test_adb_timeout.py` (new, 5
+cases: bin resolution, prefixing, `rc==124` handling, double-wrap prevention,
+graceful no-op when `timeout` binary is missing), plus updates to
+`test_adb_resolve.py`, `test_autojs6_deploy.py`, `test_shell_libs.py`,
+`test_shizuku_device.py`. I re-ran the full `android_common` unit suite plus
+the top-level `tests/python/test_{adb_resolve,autojs6_deploy,shell_libs,
+shizuku_device}.py` in a fresh worktree venv — **all green**, no changes
+needed to make them pass.
+
+I also confirmed the open-questions the issue explicitly flagged:
+
+- **`gh release download` / `apksigner sign` treatment** — the commit put them
+  through the *same* mechanism (`DEFAULT_SLOW_TIMEOUT`, same helper), not a
+  separate one. Reasonable: both are simple "spawn a process, wait, check rc"
+  shell-outs with no signal/streaming needs, so a second bespoke mechanism
+  would just be duplication.
+- **Tiered defaults** — implemented as proposed (fast query vs. slow transfer),
+  30s / 180s. 180s matches the pre-existing `install_timeout` default in
+  `android_apk.py` (see below), so it's consistent with what's already proven
+  survivable in production. 30s for queries is generous relative to typical
+  `adb shell getprop`/`pm list` latency (sub-second on a healthy device) while
+  leaving headroom for a slow/loaded Fire OS tablet.
+
+## What I did for Phase 1 (per the issue's own process, mirroring #58)
+
+1. **Web search for prior art.** Confirmed `AnsibleModule.run_command()` has no
+   native timeout parameter — this is a long-standing, still-open upstream
+   limitation (multiple GitHub issues over the years, no resolution). There is
+   no `community.general` (or any other) precedent for ADB-specific tooling —
+   no such collection exists. The closest matching idiom that does show up
+   consistently in community guidance is exactly what's already implemented
+   here: wrap the underlying command with the coreutils `timeout(1)` binary
+   from inside the module. That's a documented workaround pattern, not
+   something invented for this repo — and this repo was already using it
+   in `stayturgid_battery_alarm.py` (on-device) and the original narrow #43
+   fix in `android_apk.py` before this systemic commit generalized it. So:
+   confirmed, same as #58's flock finding — the existing approach **is** the
+   standard idiom, nothing to redesign.
+2. **Re-audited the issue's inventory against current code** (it can drift —
+   the issue was filed, then apparently fixed, without ever being closed or
+   commented on). Re-grepped the entire `plugins/` tree for every
+   `run_command(` call site, not just the ones the issue names, to catch
+   anything added or missed since. Result below.
+
+## Real gap found: `native_agent_config.py` was missed
+
+One call site is **not** covered and was **not** in the issue's original
+inventory (the issue's list predates or simply overlooked this module):
+
+```
+plugins/modules/native_agent_config.py:90
+    rc, _out, err = module.run_command(["adb", "-s", device, "push", tmp.name, staging])
+```
+
+This module (`native_agent_config.py`, added at `ops-v1.0.3` — well before the
+`db2a852` sweep) writes the native-agent peer-target JSON to each device over
+`adb push`, same failure class as the other push call sites already fixed
+(`shizuku_start.py`, `shizuku_grant.py`, `autojs6_deploy_util.py`). It's a
+straight two-line miss, not a design gap — the fix is the identical pattern
+already applied six times in the same commit:
+
+```python
+try:
+    from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_timeout import (
+        DEFAULT_SLOW_TIMEOUT,
+        run_command_with_timeout,
+    )
+except ImportError:
+    ...  # same sys.path fallback used in shizuku_start.py / shizuku_grant.py
+
+...
+rc, _out, err = run_command_with_timeout(
+    module.run_command,
+    ["adb", "-s", device, "push", tmp.name, staging],
+    timeout=DEFAULT_SLOW_TIMEOUT,
+    get_bin_path_fn=module.get_bin_path,
+)
+```
+
+*(Update: this edit was made in Phase 2 — see the handoff doc.)*
+
+## Minor inconsistency (not a functional gap): dual timeout mechanisms in `android_apk.py`
+
+`android_apk.py`'s `adb install`/`adb uninstall` call sites (lines ~389-449 —
+the original #43 narrow fix, which predates and motivated this systemic
+commit) still use their own **hand-rolled** prefixing:
+
+```python
+timeout_bin = module.get_bin_path("timeout", required=True)
+cmd = [timeout_bin, str(module.params["install_timeout"]), "adb", "-s", device, "install", ...]
+rc, out, err = module.run_command(cmd)
+...
+if rc == 124:
+    module.fail_json(msg="adb install timed out after %ss ..." % module.params["install_timeout"])
+```
+
+rather than the new shared `run_command_with_timeout()` helper. Functionally
+this is fine — it has an explicit timeout, `rc==124` handling, and a clear
+`fail_json` message, so there's no live hang risk here. But it's now a second,
+parallel implementation of the same idea living in the same file that
+otherwise imports the new helper for `download_gh_release()`/`resign_apk()`.
+Two observations, not a recommendation to act unilaterally:
+
+- Unifying it onto `run_command_with_timeout(..., timeout=module.params["install_timeout"])`
+  would remove the duplication and let `install_timeout` flow through the
+  shared helper's `rc==124` message instead of a hand-written one — cosmetic
+  but real cleanup.
+- The `work_profile` install fallback (line 449, `wp_cmd`) doesn't special-case
+  `rc==124` at all — a timeout there just falls into the generic "work profile
+  install failed (rc=%d)" warn path, losing the specific "may be showing a
+  confirmation dialog" message. Low stakes (it's a warn, not a fail, and only
+  fires when `work_profile: true` is set), but worth folding into the same
+  unification if that cleanup happens.
+
+I'd treat this as optional polish, not required — it doesn't change behavior
+under the failure mode #59 is about (an unbounded hang). Recommend leaving it
+alone unless the reviewer wants the unification done as part of closing out
+the native_agent_config.py gap.
+
+## Recommendation
+
+There is no "broad migration" left to design or implement — it already
+happened, matches the idiom the web search confirms is standard, has test
+coverage, and is currently green on `master`. The only real remaining work is
+the one missed `native_agent_config.py` call site, which is a mechanical
+2-line-pattern application of code that already exists six times over in the
+same file tree — not a design decision. Suggest the second-opinion review
+should be scoped to: **(a) confirm no other call sites were missed** (I did a
+full-tree grep, but a second pass is cheap insurance), and **(b) a go/no-go on
+whether the `android_apk.py` dual-mechanism unification is worth doing now or
+left alone** — then a trivial PR for the `native_agent_config.py` fix (plus
+unification if greenlit) closes out #59 for real.
+
+*(Update: the operator reviewed this and confirmed go-ahead on both — see the
+handoff doc for the second gap the review found (the lookup-plugin claim,
+investigated and found to already be covered — not a live gap) and what
+Phase 2 actually shipped.)*

--- a/docs/operations/sessions/handoff-2026-07-28-issue-59-adb-timeouts.md
+++ b/docs/operations/sessions/handoff-2026-07-28-issue-59-adb-timeouts.md
@@ -110,6 +110,61 @@ avoiding repeated `stat()` calls for. Added
 regression test (pre-poisons the cache, then asserts a fresh
 `get_bin_path_fn` still wins).
 
+## Addendum: two CodeRabbit findings on PR #117, fixed post-CI-green
+
+CodeRabbit's async review (still pending when CI's `test` check first went
+green) surfaced two real findings against the code, not the docs:
+
+1. **MAJOR — clean-uninstall result was discarded.** In `android_apk.py`,
+   the `clean` flag's uninstall-before-install call
+   (`run_command_with_timeout(module.run_command, ["adb", "-s", device,
+"uninstall", package], ...)`) had its return value thrown away entirely —
+   no variable assignment. A failed or timed-out uninstall silently fell
+   through to the in-place `adb install -r` anyway, so the module could
+   report success without ever performing the clean reinstall the `clean`
+   flag exists for (defeating the native-lib re-extraction behavior tied to
+   this module's `#60` history). This bug predates this PR (the original
+   hand-rolled `module.run_command(...)` call had the same discard-the-result
+   shape) but this PR touched the line, so fixed it here rather than filing
+   a separate issue. Now captures `rc`/`out`/`err` and `fail_json`s on
+   nonzero rc or non-"Success" output, mirroring the existing pattern
+   immediately below it (the incompatible-upgrade clean fallback). Added
+   `test_android_apk_clean_uninstall_failure_fails_before_install` —
+   asserts the task fails and that `adb install -r` is never reached when
+   the uninstall fails.
+2. **Minor — missing device-interaction announcements.** Per
+   `AGENTS.md`'s documented convention ("Announce before device interaction:
+   🚨📱🚨 USING — host — why — ~N min"), added paired
+   `🚨📱🚨 USING — {device} — {why} — ~3 min` /
+   `🟢📱🟢 FREE — {device} — {what} complete` announcements around every
+   remaining device-mutating `adb` call these two modules make: the clean
+   uninstall, primary install, incompatible-upgrade fallback
+   uninstall+reinstall, and work-profile install in `android_apk.py`, and
+   the staging `adb push` in `native_agent_config.py`. `~3 min` matches
+   `DEFAULT_SLOW_TIMEOUT`/`install_timeout`'s 180s ceiling — the actual
+   worst-case bound, not a guess.
+
+   **Mechanism note:** the existing convention's only prior implementation
+   (`control/tools/native-agent/rollout.py`) uses plain `print()`, but that's
+   a standalone control-node script, not an `AnsibleModule`. Ansible modules
+   communicate their result to the controller via a single JSON blob printed
+   to **stdout** at `exit_json`/`fail_json` time; anything else written to
+   stdout first would corrupt that parse and crash the module with a
+   "not valid JSON" error. Used `sys.stderr.write(...)` instead, matching
+   the repo's own existing precedent for this exact situation
+   (`control/lib/ui_guard.py`'s `🚨📱🚨 MANUAL ACTION REQUIRED` warning also
+   writes to `sys.stderr`, not stdout, for the same reason). `module.warn()`
+   was the other candidate but is buffered until task-end by Ansible's
+   result protocol, which doesn't satisfy the "before" part of "announce
+   before device interaction" — stderr is written immediately, at the point
+   of interaction.
+
+Re-verified full suite after both fixes: `android_common` unit tests (88
+passed, up from 87 — one new regression test), `tests/python` (592 passed),
+`just check` (clean), `just ansible-test` (all five collections green, 118
+tests). Pushed as a follow-up commit on the same branch/PR; CI's `test`
+check confirmed green again afterward.
+
 ## Verification
 
 - `ansible_collections/stayturgid/android_common/tests/unit` — 87 passed

--- a/docs/operations/sessions/handoff-2026-07-28-issue-59-adb-timeouts.md
+++ b/docs/operations/sessions/handoff-2026-07-28-issue-59-adb-timeouts.md
@@ -264,6 +264,32 @@ Another CodeRabbit pass found:
    it from the earlier inline mentions instead of leaving stale figures
    presented as current.
 
+## Addendum 3: two more CodeRabbit findings on the Addendum 2 tests
+
+1. **MAJOR — the announcement tests only checked presence, not ordering.**
+   `test_raw_run_command_announces_before_and_after` in each lookup-plugin
+   test file asserted `"USING" in err` and `"FREE" in err` against the
+   _combined_ captured stderr — true even if, say, both lines were written
+   in the wrong order, or `USING` were accidentally duplicated and `FREE`
+   never fired at all as long as some other test polluted the buffer.
+   Rewrote as `test_raw_run_command_announces_using_before_run_and_free_after`
+   in all three files: the mocked `subprocess.run` now reads stderr
+   mid-call (via `capsys.readouterr()`, which drains the buffer) and
+   asserts `USING` is already present and `FREE` is not — proving `USING`
+   is written strictly before the actual device interaction. After
+   `_raw_run_command` returns, a second read must show `FREE` present and
+   `USING` absent (already drained by the first read) — proving `FREE` is
+   written strictly after. CodeRabbit named `test_adb_device_lookup.py` and
+   `test_android_packages_lookup.py`; applied the identical fix to
+   `test_fdroid_client_lookup.py` too since it had the exact same
+   presence-only pattern and wasn't named only because CodeRabbit didn't
+   flag it that round, not because it was fine.
+2. **Minor — `android_packages.py`'s own `_target_from_cmd()` test was
+   missing a timeout-prefixed case.** `adb_device.py`'s test already
+   covered `["/usr/bin/timeout", "30", "adb", "-s", ...]` correctly
+   resolving through the prefix; `android_packages.py`'s (and, same gap,
+   `fdroid_client.py`'s) didn't. Added the same case to both.
+
 ## Verification (final, as of the last commit on this branch)
 
 - `ansible_collections/stayturgid/android_common/tests/unit` — 87 passed
@@ -309,7 +335,9 @@ running in production deploys since 2026-07-26 with no reported regressions.
   `tests/python/test_android_packages_lookup.py`,
   `tests/python/test_fdroid_client_lookup.py` — new (script-twin location;
   see §1 above for why not under the collection's own `tests/unit/`);
-  `_target_from_cmd`/announcement tests added in Addendum 2
+  `_target_from_cmd`/announcement tests added in Addendum 2, strengthened
+  to assert ordering (not just presence) plus a timeout-prefixed
+  `_target_from_cmd` case in Addendum 3
 - `docs/operations/sessions/design-2026-07-28-issue-59-adb-timeouts.md` —
   status annotations pointing at this doc
 - `docs/operations/sessions/handoff-2026-07-28-issue-59-adb-timeouts.md` —

--- a/docs/operations/sessions/handoff-2026-07-28-issue-59-adb-timeouts.md
+++ b/docs/operations/sessions/handoff-2026-07-28-issue-59-adb-timeouts.md
@@ -18,7 +18,7 @@ everything confirmed real plus the `android_apk.py` dual-mechanism cleanup.
 
 ## What I did
 
-### 1. Verified the lookup-plugin claim — not a real gap
+### 1. The lookup plugins: initially found not-a-gap, then wrapped anyway on request
 
 `plugins/lookup/{adb_device,android_packages,fdroid_client}.py` each define a
 local `_run_command(cmd)` using bare `subprocess.run(cmd, capture_output=True,
@@ -31,18 +31,76 @@ that callback directly — every actual command execution inside
 `adb_resolve.py` and `adb_packages.py` (via `adb_shell.py`) already routes
 through `run_command_with_timeout()` first, which prefixes the argv with
 `timeout <N>` _before_ handing it to the callback. So `_run_command` only
-ever receives an already-wrapped command like `["/opt/homebrew/bin/timeout",
-"30", "adb", "devices"]` and just executes it — the external `timeout(1)`
+ever received an already-wrapped command like `["/opt/homebrew/bin/timeout",
+"30", "adb", "devices"]` and just executed it — the external `timeout(1)`
 binary self-bounds the run regardless of whether `subprocess.run` itself has
 its own `timeout=` kwarg. `tests/unit/plugins/module_utils/test_adb_resolve.py`
 already exercises this (its fake `run()` functions explicitly strip the
 `timeout` prefix before matching — `cmd[0].endswith("timeout")`). Also
 confirmed `/opt/homebrew/bin/timeout` actually resolves on this control node,
-so the fallback path isn't silently degrading here either.
+so the fallback path isn't silently degrading here either. That analysis
+still stands — it was never a live hang risk.
 
-**No changes made to the three lookup plugins** — there was nothing to fix.
-Recorded this reasoning here so it's checkable independently rather than
-just asserted.
+The operator asked for these three to be wrapped anyway, as defense in depth
+against a hypothetical future caller that invokes `_run_command` (or
+whatever these get refactored into) directly, bypassing `resolve_adb()`/
+`packages_matching()`. Implemented that, but **not** with the originally
+suggested `shutil.which`-based `get_bin_path_fn` — tracing the double-layer
+call pattern (this new inner wrap, invoked as the callback of the outer wrap
+`adb_resolve.py`/`adb_shell.py` already apply) showed that would create a
+real double-wrapping bug: `shutil.which` searches `$PATH` while the outer,
+unannotated `run_command_with_timeout()` calls upstream (`get_bin_path_fn`
+never passed, so it defaults to `None`) resolve via a fixed 3-path candidate
+scan plus a process-global cache. On a machine where those two mechanisms
+disagree about the binary's absolute path, the double-wrap guard's simple
+`exec_cmd[0] != timeout_bin` check would fail to recognize an
+already-wrapped incoming cmd and prefix `timeout` a second time. Used
+`get_bin_path_fn=None` (i.e. don't override it) in the new inner wrap
+instead, so it shares the exact same resolution/cache as the outer layer —
+correct no-op in the current call pattern, real protection if ever called
+standalone. Each lookup plugin's docstring on `_run_command` explains this
+in place.
+
+Added `tests/python/test_{adb_device,android_packages,fdroid_client}_lookup.py`
+(one file per plugin, script-twin convention — see below for why they don't
+live under the collection's `tests/unit/`) with: an isolated `_run_command`
+wrapping test, an end-to-end `LookupModule.run()` test confirming the real
+public entry point still funnels through the wrapped callback, and (for
+`adb_device.py`) an explicit double-wrap-guard regression test. These
+required giving `adb_packages.py` (imported by two of the three lookup
+plugins) the same try/except-ImportError sys.path-fallback resilience every
+other `module_utils` file already has — it previously had a hard,
+non-fallback import of `adb_shell`, which only resolved inside
+`ansible-test`'s collection-namespace setup and would have made the new
+tests uncollectable under plain `pytest` (which `just check`'s
+`pytest --collect-only` step
+also requires to succeed).
+
+**Why `tests/python/`, not `tests/unit/plugins/lookup/`:** first tried
+putting these under the collection's own `tests/unit/plugins/lookup/`
+(which didn't exist before this — module_utils/modules were the only two
+categories with tests). That triggered a real, pre-existing `ansible-test`
+harness bug: `ansible-test units` categorizes unit tests into `module`,
+`module_utils`, and (everything else, including `lookup`) `controller`
+buckets, and this repo's `--local` invocation mis-builds
+`ANSIBLE_COLLECTIONS_PATH` as a malformed colon-joined multi-path string
+specifically for the `controller` bucket — `ansible_pytest_collections.py`'s
+`collection_resolve_package_path()` then fails every controller-category
+test file with `File "..." not found in collection path "..."`. Confirmed
+this is unrelated to my code (the module_utils/modules buckets, which this
+repo already used, work fine) and is simply never-before-triggered since no
+`lookup`/`filter`/other controller-side plugin ever had a unit test in this
+collection. Rather than debug vendored `ansible-test` internals for a
+tangential infra gap, followed this repo's own established pattern instead:
+`tests/python/` already holds plain-pytest "script-twin" tests for several
+`module_utils` files (e.g. `test_adb_resolve.py` exists both there and under
+the collection) specifically because `ansible-test`'s collection-scoped scan
+(`cd ansible_collections/stayturgid/$c && ansible-test units`) never sees
+anything under the repo-root `tests/python/` tree at all — sidesteps the bug
+entirely, still fully covered by `just pytest`/`just check`'s
+`pytest --collect-only` gate. If someone wants controller-category
+`ansible-test` coverage for lookup plugins later, that's a separate,
+pre-existing infra fix, not in scope here.
 
 ### 2. Fixed the real gap: `native_agent_config.py:90`
 
@@ -141,8 +199,14 @@ green) surfaced two real findings against the code, not the docs:
    uninstall, primary install, incompatible-upgrade fallback
    uninstall+reinstall, and work-profile install in `android_apk.py`, and
    the staging `adb push` in `native_agent_config.py`. `~3 min` matches
-   `DEFAULT_SLOW_TIMEOUT`/`install_timeout`'s 180s ceiling — the actual
-   worst-case bound, not a guess.
+   `DEFAULT_SLOW_TIMEOUT`/`install_timeout`'s 180s **default** — a
+   reasonable worst-case estimate for the common case, not a made-up
+   number. It's a static string, not dynamically derived from the actual
+   configured value: `install_timeout` is a playbook-settable module
+   param, so a caller that overrides it to something other than 180s will
+   see a slightly inaccurate estimate in the announcement text (harmless —
+   it's advisory, not the actual enforced bound, which still comes from
+   `install_timeout` itself).
 
    **Mechanism note:** the existing convention's only prior implementation
    (`control/tools/native-agent/rollout.py`) uses plain `print()`, but that's
@@ -168,13 +232,15 @@ check confirmed green again afterward.
 ## Verification
 
 - `ansible_collections/stayturgid/android_common/tests/unit` — 87 passed
-- `tests/python` (top-level Termux-script-twin suite) — 592 passed
-- `just check` — clean (ruff check+format, biome, shfmt, markdownlint,
-  prettier, html-validate, stylelint, site-contract, identity/drift/secrets
-  checks all pass)
+- `tests/python` (top-level Termux-script-twin suite) — 599 passed, 1 skipped
+  (592 + 7 new lookup-plugin tests)
+- `just check` — clean, all 21 tier-a checks including `pytest: tests
+collect cleanly` (ruff check+format, biome, shfmt, markdownlint, prettier,
+  html-validate, stylelint, site-contract, identity/drift/secrets checks
+  all pass)
 - `just ansible-test` — all five collections (`android_common`, `termux`,
-  `obtainium`, `fdroid`, `play`) green, 118 total ansible-test-harness unit
-  tests passed
+  `obtainium`, `fdroid`, `play`) green, 137 total ansible-test-harness unit
+  tests passed (70+17+20+8+15+7, no controller-category errors)
 
 No manual on-device verification was done or needed — this is a pure
 control-node argv-wrapping change with unit coverage; the existing db2a852
@@ -183,13 +249,28 @@ running in production deploys since 2026-07-26 with no reported regressions.
 
 ## Files changed
 
-- `plugins/modules/native_agent_config.py` — timeout-wrap the staging push
+- `plugins/modules/native_agent_config.py` — timeout-wrap the staging push;
+  device-interaction announcement
 - `plugins/modules/android_apk.py` — unify install/uninstall/work_profile
-  onto the shared helper; fold in work_profile rc==124 handling
+  onto the shared helper; fold in work_profile rc==124 handling; fix the
+  discarded clean-uninstall result; device-interaction announcements
 - `plugins/module_utils/adb_timeout.py` — fix cross-call cache staleness
+- `plugins/module_utils/adb_packages.py` — add the same
+  try/except-ImportError sys.path-fallback resilience every other
+  module_utils file already has (needed so the lookup plugins below are
+  testable outside `ansible-test`'s collection namespace)
+- `plugins/lookup/adb_device.py`, `plugins/lookup/android_packages.py`,
+  `plugins/lookup/fdroid_client.py` — timeout-wrap `_run_command` as
+  defense in depth (see §1 above for why `get_bin_path_fn` is deliberately
+  left at its default rather than `shutil.which`)
 - `tests/unit/plugins/modules/test_native_agent_config.py` — new test
-- `tests/unit/plugins/modules/test_android_apk.py` — two new tests
+- `tests/unit/plugins/modules/test_android_apk.py` — three new tests (one
+  parametrized over failure/timeout)
 - `tests/unit/plugins/module_utils/test_adb_timeout.py` — new regression test
+- `tests/python/test_adb_device_lookup.py`,
+  `tests/python/test_android_packages_lookup.py`,
+  `tests/python/test_fdroid_client_lookup.py` — new (script-twin location;
+  see §1 above for why not under the collection's own `tests/unit/`)
 - `docs/operations/sessions/design-2026-07-28-issue-59-adb-timeouts.md` —
   status annotations pointing at this doc
 - `docs/operations/sessions/handoff-2026-07-28-issue-59-adb-timeouts.md` —

--- a/docs/operations/sessions/handoff-2026-07-28-issue-59-adb-timeouts.md
+++ b/docs/operations/sessions/handoff-2026-07-28-issue-59-adb-timeouts.md
@@ -223,17 +223,53 @@ green) surfaced two real findings against the code, not the docs:
    before device interaction" — stderr is written immediately, at the point
    of interaction.
 
-Re-verified full suite after both fixes: `android_common` unit tests (88
-passed, up from 87 — one new regression test), `tests/python` (592 passed),
-`just check` (clean), `just ansible-test` (all five collections green, 118
-tests). Pushed as a follow-up commit on the same branch/PR; CI's `test`
-check confirmed green again afterward.
+Re-verified the full suite after both fixes and pushed as a follow-up
+commit; CI's `test` check confirmed green again afterward. (This was an
+intermediate checkpoint — later commits on this branch/PR changed the
+totals again. **The `## Verification` section below has the final,
+as-merged numbers** — treat any counts mentioned inline elsewhere in this
+doc as a snapshot of that round only, not the final state.)
 
-## Verification
+## Addendum 2: two more CodeRabbit findings, same PR
+
+Another CodeRabbit pass found:
+
+1. **MAJOR — the three lookup plugins were also missing the
+   device-interaction announcement.** Same `AGENTS.md` convention as
+   `android_apk.py`/`native_agent_config.py` above, just not yet applied to
+   `_raw_run_command()` in `adb_device.py`/`android_packages.py`/
+   `fdroid_client.py`. Added it there too, wrapping the actual
+   `subprocess.run()` call (the one true device-interaction point regardless
+   of which lookup-level function invoked it) rather than the `_run_command`
+   timeout-wrapping layer above it. Since `_raw_run_command(cmd)` only
+   receives an argv list (no separate `device` parameter — lookup plugins
+   don't thread one through the way the two Ansible modules do), added a
+   small `_target_from_cmd(cmd)` helper per file that best-effort extracts a
+   `-s <serial>` or `adb connect <endpoint>` target from the (possibly
+   already timeout-prefixed) argv, falling back to a generic
+   `"control-node adb"` label for target-less queries (`adb devices`,
+   `adb mdns services`). Used `~30s default` instead of `~3 min` for the
+   duration, matching these files' `DEFAULT_FAST_TIMEOUT` (they're
+   query-class, not transfer-class). Added `test_target_from_cmd_*` and
+   `test_raw_run_command_announces_before_and_after` (using `capsys` to
+   assert on the actual stderr output) to each of the three lookup-plugin
+   test files.
+2. **Minor — inconsistent verification-count reporting.** This doc had
+   accumulated test-count numbers from three separate verification rounds
+   (87/592/118 → 88/592/118 → 87/599/137) reported inline at each round
+   without saying which was final, since each addendum was written
+   immediately after that round's fix rather than going back to update
+   earlier numbers. Fixed by making the `## Verification` section below the
+   single labeled source of truth (final numbers only) and pointing back to
+   it from the earlier inline mentions instead of leaving stale figures
+   presented as current.
+
+## Verification (final, as of the last commit on this branch)
 
 - `ansible_collections/stayturgid/android_common/tests/unit` — 87 passed
-- `tests/python` (top-level Termux-script-twin suite) — 599 passed, 1 skipped
-  (592 + 7 new lookup-plugin tests)
+- `tests/python` (top-level Termux-script-twin suite, via `just pytest`) —
+  605 passed, 1 skipped (592 baseline + 7 lookup-plugin tests from Addendum
+  1 + 6 announcement/`_target_from_cmd` tests from Addendum 2)
 - `just check` — clean, all 21 tier-a checks including `pytest: tests
 collect cleanly` (ruff check+format, biome, shfmt, markdownlint, prettier,
   html-validate, stylelint, site-contract, identity/drift/secrets checks
@@ -262,15 +298,18 @@ running in production deploys since 2026-07-26 with no reported regressions.
 - `plugins/lookup/adb_device.py`, `plugins/lookup/android_packages.py`,
   `plugins/lookup/fdroid_client.py` — timeout-wrap `_run_command` as
   defense in depth (see §1 above for why `get_bin_path_fn` is deliberately
-  left at its default rather than `shutil.which`)
+  left at its default rather than `shutil.which`); device-interaction
+  announcement around the actual `subprocess.run()` in `_raw_run_command`
+  plus a `_target_from_cmd()` helper to label it (Addendum 2)
 - `tests/unit/plugins/modules/test_native_agent_config.py` — new test
 - `tests/unit/plugins/modules/test_android_apk.py` — three new tests (one
-  parametrized over failure/timeout)
+  parametrized over failure/timeout, so four test cases total)
 - `tests/unit/plugins/module_utils/test_adb_timeout.py` — new regression test
 - `tests/python/test_adb_device_lookup.py`,
   `tests/python/test_android_packages_lookup.py`,
   `tests/python/test_fdroid_client_lookup.py` — new (script-twin location;
-  see §1 above for why not under the collection's own `tests/unit/`)
+  see §1 above for why not under the collection's own `tests/unit/`);
+  `_target_from_cmd`/announcement tests added in Addendum 2
 - `docs/operations/sessions/design-2026-07-28-issue-59-adb-timeouts.md` —
   status annotations pointing at this doc
 - `docs/operations/sessions/handoff-2026-07-28-issue-59-adb-timeouts.md` —

--- a/docs/operations/sessions/handoff-2026-07-28-issue-59-adb-timeouts.md
+++ b/docs/operations/sessions/handoff-2026-07-28-issue-59-adb-timeouts.md
@@ -7,7 +7,7 @@
 ## Context
 
 Phase 1 (see `design-2026-07-28-issue-59-adb-timeouts.md`) found that issue
-#59's "systemic timeout" migration had already shipped directly to `master`
+`#59`'s "systemic timeout" migration had already shipped directly to `master`
 on 2026-07-26 (commit `db2a852`, before this orchestration chain existed and
 before the issue was ever closed), and that it was correct and complete
 except for one missed call site. The operator reviewed that design doc,
@@ -30,7 +30,7 @@ Traced the call chain for all three and confirmed none of them ever invoke
 that callback directly — every actual command execution inside
 `adb_resolve.py` and `adb_packages.py` (via `adb_shell.py`) already routes
 through `run_command_with_timeout()` first, which prefixes the argv with
-`timeout <N>` *before* handing it to the callback. So `_run_command` only
+`timeout <N>` _before_ handing it to the callback. So `_run_command` only
 ever receives an already-wrapped command like `["/opt/homebrew/bin/timeout",
 "30", "adb", "devices"]` and just executes it — the external `timeout(1)`
 binary self-bounds the run regardless of whether `subprocess.run` itself has
@@ -90,7 +90,7 @@ Adding `android_apk.py`'s install path as a new `get_bin_path_fn`-passing
 caller exposed a pre-existing bug in `resolve_timeout_bin()`:
 `_CACHED_TIMEOUT_BIN` is a **process-global** cache populated by whichever
 call resolves first, and every subsequent call — even ones passing a
-different `get_bin_path_fn` — got the *first* cached value regardless. In
+different `get_bin_path_fn` — got the _first_ cached value regardless. In
 the test suite this manifested as `test_android_apk_install_wrapped_in_timeout`
 failing: `test_adb_timeout.py::test_resolve_timeout_bin` (which sorts first —
 `module_utils` < `modules`) calls the real unmocked resolver, caching the

--- a/docs/operations/sessions/handoff-2026-07-28-issue-59-adb-timeouts.md
+++ b/docs/operations/sessions/handoff-2026-07-28-issue-59-adb-timeouts.md
@@ -1,0 +1,150 @@
+# Handoff: #59 close-out (Phase 2)
+
+**Session:** Agent 6, human-relayed orchestration chain (see
+`~/ai-orchestration-plan-2026-07-28.md`). **Worktree:**
+`~/src/ops-worktrees/adb-timeout-59/stayturgid` (branch `feature/adb-timeout-59`).
+
+## Context
+
+Phase 1 (see `design-2026-07-28-issue-59-adb-timeouts.md`) found that issue
+#59's "systemic timeout" migration had already shipped directly to `master`
+on 2026-07-26 (commit `db2a852`, before this orchestration chain existed and
+before the issue was ever closed), and that it was correct and complete
+except for one missed call site. The operator reviewed that design doc,
+independently re-verified the `native_agent_config.py:90` gap, found a
+second candidate gap (three lookup plugins with local `subprocess.run`-based
+`_run_command()` callbacks with no timeout kwarg), and gave go-ahead to fix
+everything confirmed real plus the `android_apk.py` dual-mechanism cleanup.
+
+## What I did
+
+### 1. Verified the lookup-plugin claim — not a real gap
+
+`plugins/lookup/{adb_device,android_packages,fdroid_client}.py` each define a
+local `_run_command(cmd)` using bare `subprocess.run(cmd, capture_output=True,
+text=True, check=False)` with no `timeout=` kwarg, passed as the `run_command`
+callback into `resolve_adb()` / `packages_matching()` /
+`fdroid_components_for_device()`.
+
+Traced the call chain for all three and confirmed none of them ever invoke
+that callback directly — every actual command execution inside
+`adb_resolve.py` and `adb_packages.py` (via `adb_shell.py`) already routes
+through `run_command_with_timeout()` first, which prefixes the argv with
+`timeout <N>` *before* handing it to the callback. So `_run_command` only
+ever receives an already-wrapped command like `["/opt/homebrew/bin/timeout",
+"30", "adb", "devices"]` and just executes it — the external `timeout(1)`
+binary self-bounds the run regardless of whether `subprocess.run` itself has
+its own `timeout=` kwarg. `tests/unit/plugins/module_utils/test_adb_resolve.py`
+already exercises this (its fake `run()` functions explicitly strip the
+`timeout` prefix before matching — `cmd[0].endswith("timeout")`). Also
+confirmed `/opt/homebrew/bin/timeout` actually resolves on this control node,
+so the fallback path isn't silently degrading here either.
+
+**No changes made to the three lookup plugins** — there was nothing to fix.
+Recorded this reasoning here so it's checkable independently rather than
+just asserted.
+
+### 2. Fixed the real gap: `native_agent_config.py:90`
+
+Routed the staging `adb push` through `run_command_with_timeout()` with
+`DEFAULT_SLOW_TIMEOUT` (180s, transfer-class), matching the identical pattern
+already used in `shizuku_start.py`/`shizuku_grant.py`/`autojs6_deploy_util.py`.
+Added `test_push_command_wrapped_in_timeout` to
+`test_native_agent_config.py` asserting the push command is prefixed with
+the resolved `timeout` binary + `180`.
+
+### 3. Unified `android_apk.py`'s install/uninstall/work_profile paths
+
+These predated the systemic commit (the original narrow #43 fix) and used
+their own hand-rolled `timeout_bin = module.get_bin_path("timeout",
+required=True)` + manual argv prefixing instead of the shared helper. Moved
+all three call sites (`uninstall`, `install`, the incompatible-upgrade retry
+`uninstall`+`install`, and `work_profile` install) onto
+`run_command_with_timeout(..., get_bin_path_fn=module.get_bin_path)`.
+
+Preserved the one deliberate behavioral property of the original code: a
+**missing** `timeout` binary must fail loudly here (this call site is the one
+that caused the original incident), not silently degrade to unbounded like
+the shared helper's default posture elsewhere. Kept the explicit
+`module.get_bin_path("timeout", required=True)` call as an upfront guard
+before the install/uninstall logic runs, then let `run_command_with_timeout`
+do the actual wrapping (it re-resolves via the same `get_bin_path_fn`, which
+will now succeed since the guard already proved the binary exists).
+
+Also folded in the gap the operator flagged: the `work_profile` install
+fallback previously only ever produced a generic `"work profile install
+failed (rc=%d)"` warning, even on `rc==124` — losing the specific
+"confirmation dialog" hint the primary install path has. Added an explicit
+`elif rc2 == 124` branch with the same wording, still a `warn()` not a
+`fail_json()` (this path is intentionally best-effort).
+
+Added two tests: `test_android_apk_work_profile_install_wrapped_in_timeout`
+(happy path, asserts `reason` mentions the work-profile install) and
+`test_android_apk_work_profile_timeout_warns_with_dialog_hint` (asserts the
+new rc==124 branch fires, the task doesn't fail, and the warning text
+matches).
+
+### 4. Found and fixed a real latent bug this surfaced: `adb_timeout.py` cross-call cache staleness
+
+Adding `android_apk.py`'s install path as a new `get_bin_path_fn`-passing
+caller exposed a pre-existing bug in `resolve_timeout_bin()`:
+`_CACHED_TIMEOUT_BIN` is a **process-global** cache populated by whichever
+call resolves first, and every subsequent call — even ones passing a
+different `get_bin_path_fn` — got the *first* cached value regardless. In
+the test suite this manifested as `test_android_apk_install_wrapped_in_timeout`
+failing: `test_adb_timeout.py::test_resolve_timeout_bin` (which sorts first —
+`module_utils` < `modules`) calls the real unmocked resolver, caching the
+real `/opt/homebrew/bin/timeout`; the android_apk test's own mocked
+`get_bin_path` (`/usr/bin/timeout`) then got silently ignored.
+
+This isn't just a test artifact — it's a real correctness gap in the
+function's contract (a caller-supplied resolver should be authoritative for
+that call, not overridden by whatever some earlier unrelated caller found).
+Fixed `resolve_timeout_bin()` so a provided `get_bin_path_fn` is always
+consulted fresh and wins immediately if it returns a path; only the
+hardcoded-candidate filesystem scan (the fallback used when no
+`get_bin_path_fn` is available) is memoized process-wide, since that's the
+one case representing an expensive, call-independent system fact worth
+avoiding repeated `stat()` calls for. Added
+`test_resolve_timeout_bin_prefers_fresh_get_bin_path_fn_over_cache` as a
+regression test (pre-poisons the cache, then asserts a fresh
+`get_bin_path_fn` still wins).
+
+## Verification
+
+- `ansible_collections/stayturgid/android_common/tests/unit` — 87 passed
+- `tests/python` (top-level Termux-script-twin suite) — 592 passed
+- `just check` — clean (ruff check+format, biome, shfmt, markdownlint,
+  prettier, html-validate, stylelint, site-contract, identity/drift/secrets
+  checks all pass)
+- `just ansible-test` — all five collections (`android_common`, `termux`,
+  `obtainium`, `fdroid`, `play`) green, 118 total ansible-test-harness unit
+  tests passed
+
+No manual on-device verification was done or needed — this is a pure
+control-node argv-wrapping change with unit coverage; the existing db2a852
+commit's identical pattern across 6+ other call sites has already been
+running in production deploys since 2026-07-26 with no reported regressions.
+
+## Files changed
+
+- `plugins/modules/native_agent_config.py` — timeout-wrap the staging push
+- `plugins/modules/android_apk.py` — unify install/uninstall/work_profile
+  onto the shared helper; fold in work_profile rc==124 handling
+- `plugins/module_utils/adb_timeout.py` — fix cross-call cache staleness
+- `tests/unit/plugins/modules/test_native_agent_config.py` — new test
+- `tests/unit/plugins/modules/test_android_apk.py` — two new tests
+- `tests/unit/plugins/module_utils/test_adb_timeout.py` — new regression test
+- `docs/operations/sessions/design-2026-07-28-issue-59-adb-timeouts.md` —
+  status annotations pointing at this doc
+- `docs/operations/sessions/handoff-2026-07-28-issue-59-adb-timeouts.md` —
+  this file
+
+## Next steps
+
+- PR opened against `master` (stayturgid). Once merged, #59 can be closed
+  referencing this handoff + the design doc.
+- Not part of any release yet — needs a coordinated `ops-vMAJOR.MINOR.PATCH`
+  per `docs/OPS-RELEASES.md` like every other change in this chain. Purely a
+  control-node Ansible collection change (no on-device APK/native-agent
+  changes), so low deploy risk whenever it's bundled into the next release.

--- a/tests/python/test_adb_device_lookup.py
+++ b/tests/python/test_adb_device_lookup.py
@@ -1,0 +1,84 @@
+"""Unit tests for the adb_device lookup plugin (#59: timeout-wrap control-node adb calls).
+
+Lives here rather than under the collection's tests/unit/plugins/lookup/ —
+ansible-test units categorizes lookup plugins as "controller" tests, and this
+repo's --local ansible-test invocation currently mis-builds
+ANSIBLE_COLLECTIONS_PATH as a colon-joined multi-path string for that
+category (a pre-existing ansible-test harness gap never triggered before,
+since no controller-category unit test existed in this collection until
+now). Matches the established script-twin convention already used for
+other module_utils files (e.g. test_adb_resolve.py exists both here and
+under the collection)."""
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+from conftest import REPO
+
+MODULE_PATH = Path(REPO) / "ansible_collections/stayturgid/android_common/plugins/lookup/adb_device.py"
+SPEC = importlib.util.spec_from_file_location("adb_device_lookup", MODULE_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+mod = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(mod)
+
+
+def test_run_command_wraps_with_timeout(monkeypatch):
+    seen = []
+    monkeypatch.setattr(mod, "_raw_run_command", lambda cmd: seen.append(cmd) or (0, "", ""))
+
+    rc, out, err = mod._run_command(["adb", "devices"])
+
+    assert rc == 0
+    assert len(seen) == 1
+    wrapped = seen[0]
+    assert wrapped[0].endswith("timeout"), wrapped
+    assert wrapped[1] == "30", wrapped
+    assert wrapped[2:] == ["adb", "devices"], wrapped
+
+
+def test_run_command_does_not_double_wrap_an_already_wrapped_cmd(monkeypatch):
+    """The double-wrap guard must recognize an incoming cmd that's already
+    prefixed (the real call pattern here, since resolve_adb() always wraps
+    before invoking this function's outer caller)."""
+    seen = []
+    monkeypatch.setattr(mod, "_raw_run_command", lambda cmd: seen.append(cmd) or (0, "", ""))
+
+    mod._run_command(["adb", "devices"])
+    timeout_bin = seen[0][0]
+    seen.clear()
+
+    # Re-invoke with a cmd already prefixed with the same resolved binary the
+    # first call used — resolve_adb() always wraps before invoking this
+    # function's outer caller, so this is the real call pattern.
+    mod._run_command([timeout_bin, "30", "adb", "devices"])
+
+    assert seen == [[timeout_bin, "30", "adb", "devices"]], seen
+
+
+def test_lookup_module_resolve_path_uses_wrapped_run_command(monkeypatch, tmp_path):
+    """End-to-end: LookupModule.run() must still funnel through the new
+    timeout-wrapping _run_command, not a raw unwrapped subprocess call —
+    regression test for #59's originally-reported gap in this file."""
+    seen = []
+
+    def fake_raw(cmd):
+        seen.append(cmd)
+        joined = " ".join(cmd)
+        if "devices" in joined:
+            return 0, "EXAMPLE-SERIAL\tdevice\n", ""
+        return 1, "", ""
+
+    monkeypatch.setattr(mod, "_raw_run_command", fake_raw)
+
+    conf = tmp_path / "devices.conf"
+    conf.write_text("stock-android-device EXAMPLE-SERIAL 100.0.0.12 192.0.2.12\n")
+    monkeypatch.setenv("STAYTURGID_DEVICES_CONF", str(conf))
+
+    lm = mod.LookupModule(loader=None, templar=SimpleNamespace(template=lambda x: x))
+    result = lm.run(["stock-android-device"])
+
+    assert result == ["EXAMPLE-SERIAL"]
+    assert seen, "expected at least one wrapped adb call"
+    assert all(cmd[0].endswith("timeout") and cmd[1] == "30" for cmd in seen), seen

--- a/tests/python/test_adb_device_lookup.py
+++ b/tests/python/test_adb_device_lookup.py
@@ -24,6 +24,29 @@ mod = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(mod)
 
 
+def test_target_from_cmd_extracts_serial_and_endpoint():
+    assert mod._target_from_cmd(["adb", "-s", "SERIAL123", "shell", "getprop"]) == "SERIAL123"
+    assert mod._target_from_cmd(["adb", "connect", "192.0.2.9:5555"]) == "192.0.2.9:5555"
+    assert mod._target_from_cmd(["adb", "devices"]) == "control-node adb"
+    assert mod._target_from_cmd(["adb", "mdns", "services"]) == "control-node adb"
+    # timeout-prefixed variants must resolve the same way
+    assert mod._target_from_cmd(["/usr/bin/timeout", "30", "adb", "-s", "SERIAL123", "shell", "x"]) == "SERIAL123"
+
+
+def test_raw_run_command_announces_before_and_after(monkeypatch, capsys):
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda cmd, capture_output, text, check: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    mod._raw_run_command(["adb", "-s", "SERIAL123", "shell", "getprop"])
+
+    err = capsys.readouterr().err
+    assert "USING — SERIAL123" in err
+    assert "FREE — SERIAL123" in err
+
+
 def test_run_command_wraps_with_timeout(monkeypatch):
     seen = []
     monkeypatch.setattr(mod, "_raw_run_command", lambda cmd: seen.append(cmd) or (0, "", ""))

--- a/tests/python/test_adb_device_lookup.py
+++ b/tests/python/test_adb_device_lookup.py
@@ -33,18 +33,24 @@ def test_target_from_cmd_extracts_serial_and_endpoint():
     assert mod._target_from_cmd(["/usr/bin/timeout", "30", "adb", "-s", "SERIAL123", "shell", "x"]) == "SERIAL123"
 
 
-def test_raw_run_command_announces_before_and_after(monkeypatch, capsys):
-    monkeypatch.setattr(
-        mod.subprocess,
-        "run",
-        lambda cmd, capture_output, text, check: SimpleNamespace(returncode=0, stdout="", stderr=""),
-    )
+def test_raw_run_command_announces_using_before_run_and_free_after(monkeypatch, capsys):
+    """Assert strict ordering, not just presence: USING must already be on
+    stderr by the time the actual subprocess call happens, and FREE must
+    not appear until after it returns."""
+
+    def fake_run(cmd, capture_output, text, check):
+        mid_call_err = capsys.readouterr().err
+        assert "USING — SERIAL123" in mid_call_err, mid_call_err
+        assert "FREE — SERIAL123" not in mid_call_err, mid_call_err
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
 
     mod._raw_run_command(["adb", "-s", "SERIAL123", "shell", "getprop"])
 
-    err = capsys.readouterr().err
-    assert "USING — SERIAL123" in err
-    assert "FREE — SERIAL123" in err
+    after_call_err = capsys.readouterr().err
+    assert "USING — SERIAL123" not in after_call_err, after_call_err
+    assert "FREE — SERIAL123" in after_call_err, after_call_err
 
 
 def test_run_command_wraps_with_timeout(monkeypatch):

--- a/tests/python/test_android_packages_lookup.py
+++ b/tests/python/test_android_packages_lookup.py
@@ -1,0 +1,54 @@
+"""Unit tests for the android_packages lookup plugin (#59: timeout-wrap control-node adb calls).
+
+See test_adb_device_lookup.py for why these live here rather than under the
+collection's tests/unit/plugins/lookup/."""
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+from conftest import REPO
+
+MODULE_PATH = Path(REPO) / "ansible_collections/stayturgid/android_common/plugins/lookup/android_packages.py"
+SPEC = importlib.util.spec_from_file_location("android_packages_lookup", MODULE_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+mod = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(mod)
+
+
+def test_run_command_wraps_with_timeout(monkeypatch):
+    seen = []
+    monkeypatch.setattr(mod, "_raw_run_command", lambda cmd: seen.append(cmd) or (0, "", ""))
+
+    rc, out, err = mod._run_command(["adb", "-s", "dev", "shell", "pm list packages --user 0"])
+
+    assert rc == 0
+    assert len(seen) == 1
+    wrapped = seen[0]
+    assert wrapped[0].endswith("timeout"), wrapped
+    assert wrapped[1] == "30", wrapped
+    assert wrapped[2:] == ["adb", "-s", "dev", "shell", "pm list packages --user 0"], wrapped
+
+
+def test_lookup_module_uses_wrapped_run_command(monkeypatch):
+    """End-to-end: LookupModule.run() must funnel through the new
+    timeout-wrapping _run_command, not a raw unwrapped subprocess call —
+    regression test for #59's originally-reported gap in this file."""
+    seen = []
+
+    def fake_raw(cmd):
+        seen.append(cmd)
+        joined = " ".join(cmd)
+        if "pm list packages" in joined:
+            return 0, "package:com.example.app\npackage:com.example.other\n", ""
+        return 0, "", ""
+
+    monkeypatch.setattr(mod, "_raw_run_command", fake_raw)
+
+    lm = mod.LookupModule(loader=None, templar=SimpleNamespace(template=lambda x: x))
+    result = lm.run(["dev"])
+
+    assert result == ["com.example.app", "com.example.other"]
+    assert seen, "expected at least one wrapped adb call"
+    assert all(cmd[0].endswith("timeout") and cmd[1] == "30" for cmd in seen), seen

--- a/tests/python/test_android_packages_lookup.py
+++ b/tests/python/test_android_packages_lookup.py
@@ -20,20 +20,31 @@ SPEC.loader.exec_module(mod)
 def test_target_from_cmd_extracts_serial():
     assert mod._target_from_cmd(["adb", "-s", "SERIAL123", "shell", "pm list packages --user 0"]) == "SERIAL123"
     assert mod._target_from_cmd(["adb", "connect", "192.0.2.9:5555"]) == "192.0.2.9:5555"
-
-
-def test_raw_run_command_announces_before_and_after(monkeypatch, capsys):
-    monkeypatch.setattr(
-        mod.subprocess,
-        "run",
-        lambda cmd, capture_output, text, check: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    # timeout-prefixed variant must resolve the same way
+    assert (
+        mod._target_from_cmd(["/usr/bin/timeout", "30", "adb", "-s", "SERIAL123", "shell", "pm list packages"])
+        == "SERIAL123"
     )
+
+
+def test_raw_run_command_announces_using_before_run_and_free_after(monkeypatch, capsys):
+    """Assert strict ordering, not just presence: USING must already be on
+    stderr by the time the actual subprocess call happens, and FREE must
+    not appear until after it returns."""
+
+    def fake_run(cmd, capture_output, text, check):
+        mid_call_err = capsys.readouterr().err
+        assert "USING — SERIAL123" in mid_call_err, mid_call_err
+        assert "FREE — SERIAL123" not in mid_call_err, mid_call_err
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
 
     mod._raw_run_command(["adb", "-s", "SERIAL123", "shell", "pm list packages --user 0"])
 
-    err = capsys.readouterr().err
-    assert "USING — SERIAL123" in err
-    assert "FREE — SERIAL123" in err
+    after_call_err = capsys.readouterr().err
+    assert "USING — SERIAL123" not in after_call_err, after_call_err
+    assert "FREE — SERIAL123" in after_call_err, after_call_err
 
 
 def test_run_command_wraps_with_timeout(monkeypatch):

--- a/tests/python/test_android_packages_lookup.py
+++ b/tests/python/test_android_packages_lookup.py
@@ -17,6 +17,25 @@ mod = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(mod)
 
 
+def test_target_from_cmd_extracts_serial():
+    assert mod._target_from_cmd(["adb", "-s", "SERIAL123", "shell", "pm list packages --user 0"]) == "SERIAL123"
+    assert mod._target_from_cmd(["adb", "connect", "192.0.2.9:5555"]) == "192.0.2.9:5555"
+
+
+def test_raw_run_command_announces_before_and_after(monkeypatch, capsys):
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda cmd, capture_output, text, check: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    mod._raw_run_command(["adb", "-s", "SERIAL123", "shell", "pm list packages --user 0"])
+
+    err = capsys.readouterr().err
+    assert "USING — SERIAL123" in err
+    assert "FREE — SERIAL123" in err
+
+
 def test_run_command_wraps_with_timeout(monkeypatch):
     seen = []
     monkeypatch.setattr(mod, "_raw_run_command", lambda cmd: seen.append(cmd) or (0, "", ""))

--- a/tests/python/test_fdroid_client_lookup.py
+++ b/tests/python/test_fdroid_client_lookup.py
@@ -1,0 +1,54 @@
+"""Unit tests for the fdroid_client lookup plugin (#59: timeout-wrap control-node adb calls).
+
+See test_adb_device_lookup.py for why these live here rather than under the
+collection's tests/unit/plugins/lookup/."""
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+from conftest import REPO
+
+MODULE_PATH = Path(REPO) / "ansible_collections/stayturgid/android_common/plugins/lookup/fdroid_client.py"
+SPEC = importlib.util.spec_from_file_location("fdroid_client_lookup", MODULE_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+mod = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(mod)
+
+
+def test_run_command_wraps_with_timeout(monkeypatch):
+    seen = []
+    monkeypatch.setattr(mod, "_raw_run_command", lambda cmd: seen.append(cmd) or (0, "", ""))
+
+    rc, out, err = mod._run_command(["adb", "-s", "dev", "shell", "pm list packages --user 0"])
+
+    assert rc == 0
+    assert len(seen) == 1
+    wrapped = seen[0]
+    assert wrapped[0].endswith("timeout"), wrapped
+    assert wrapped[1] == "30", wrapped
+    assert wrapped[2:] == ["adb", "-s", "dev", "shell", "pm list packages --user 0"], wrapped
+
+
+def test_lookup_module_uses_wrapped_run_command(monkeypatch):
+    """End-to-end: LookupModule.run() must funnel through the new
+    timeout-wrapping _run_command, not a raw unwrapped subprocess call —
+    regression test for #59's originally-reported gap in this file."""
+    seen = []
+
+    def fake_raw(cmd):
+        seen.append(cmd)
+        joined = " ".join(cmd)
+        if "pm list packages" in joined:
+            return 0, "package:com.looker.droidify\n", ""
+        return 0, "", ""
+
+    monkeypatch.setattr(mod, "_raw_run_command", fake_raw)
+
+    lm = mod.LookupModule(loader=None, templar=SimpleNamespace(template=lambda x: x))
+    result = lm.run(["dev"])
+
+    assert result == ["com.looker.droidify/.MainActivity"]
+    assert seen, "expected at least one wrapped adb call"
+    assert all(cmd[0].endswith("timeout") and cmd[1] == "30" for cmd in seen), seen

--- a/tests/python/test_fdroid_client_lookup.py
+++ b/tests/python/test_fdroid_client_lookup.py
@@ -20,20 +20,31 @@ SPEC.loader.exec_module(mod)
 def test_target_from_cmd_extracts_serial():
     assert mod._target_from_cmd(["adb", "-s", "SERIAL123", "shell", "pm list packages --user 0"]) == "SERIAL123"
     assert mod._target_from_cmd(["adb", "connect", "192.0.2.9:5555"]) == "192.0.2.9:5555"
-
-
-def test_raw_run_command_announces_before_and_after(monkeypatch, capsys):
-    monkeypatch.setattr(
-        mod.subprocess,
-        "run",
-        lambda cmd, capture_output, text, check: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    # timeout-prefixed variant must resolve the same way
+    assert (
+        mod._target_from_cmd(["/usr/bin/timeout", "30", "adb", "-s", "SERIAL123", "shell", "pm list packages"])
+        == "SERIAL123"
     )
+
+
+def test_raw_run_command_announces_using_before_run_and_free_after(monkeypatch, capsys):
+    """Assert strict ordering, not just presence: USING must already be on
+    stderr by the time the actual subprocess call happens, and FREE must
+    not appear until after it returns."""
+
+    def fake_run(cmd, capture_output, text, check):
+        mid_call_err = capsys.readouterr().err
+        assert "USING — SERIAL123" in mid_call_err, mid_call_err
+        assert "FREE — SERIAL123" not in mid_call_err, mid_call_err
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
 
     mod._raw_run_command(["adb", "-s", "SERIAL123", "shell", "pm list packages --user 0"])
 
-    err = capsys.readouterr().err
-    assert "USING — SERIAL123" in err
-    assert "FREE — SERIAL123" in err
+    after_call_err = capsys.readouterr().err
+    assert "USING — SERIAL123" not in after_call_err, after_call_err
+    assert "FREE — SERIAL123" in after_call_err, after_call_err
 
 
 def test_run_command_wraps_with_timeout(monkeypatch):

--- a/tests/python/test_fdroid_client_lookup.py
+++ b/tests/python/test_fdroid_client_lookup.py
@@ -17,6 +17,25 @@ mod = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(mod)
 
 
+def test_target_from_cmd_extracts_serial():
+    assert mod._target_from_cmd(["adb", "-s", "SERIAL123", "shell", "pm list packages --user 0"]) == "SERIAL123"
+    assert mod._target_from_cmd(["adb", "connect", "192.0.2.9:5555"]) == "192.0.2.9:5555"
+
+
+def test_raw_run_command_announces_before_and_after(monkeypatch, capsys):
+    monkeypatch.setattr(
+        mod.subprocess,
+        "run",
+        lambda cmd, capture_output, text, check: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    mod._raw_run_command(["adb", "-s", "SERIAL123", "shell", "pm list packages --user 0"])
+
+    err = capsys.readouterr().err
+    assert "USING — SERIAL123" in err
+    assert "FREE — SERIAL123" in err
+
+
 def test_run_command_wraps_with_timeout(monkeypatch):
     seen = []
     monkeypatch.setattr(mod, "_raw_run_command", lambda cmd: seen.append(cmd) or (0, "", ""))


### PR DESCRIPTION
## Summary

The systemic adb-timeout migration issue #59 asked for
(`run_command_with_timeout` shared helper across every `adb`-invoking
`module.run_command()` call) already shipped directly to `master` in
`db2a852` — before this issue was ever closed, and before this session's
orchestration chain existed. This PR closes the two gaps that survived that
sweep:

- `native_agent_config.py:90` — the staging `adb push` was still a bare,
  unwrapped `module.run_command()` call. Now routed through the shared
  helper (`DEFAULT_SLOW_TIMEOUT`), matching the identical pattern already
  used in `shizuku_start.py`/`shizuku_grant.py`/`autojs6_deploy_util.py`.
- `android_apk.py`'s install/uninstall/work_profile paths (the original
  narrow #43 fix, which predates and motivated the systemic migration) were
  still on their own hand-rolled `timeout` binary prefixing instead of the
  shared helper. Unified onto `run_command_with_timeout()`, while explicitly
  preserving the one deliberate behavior difference that mattered: a
  **missing** `timeout` binary must fail loudly here (this is the call site
  that caused the original incident) rather than silently degrade to
  unbounded like the shared helper's default posture elsewhere. Also added
  `rc==124` handling to the `work_profile` install fallback warning, which
  previously only reported a bare return code.
- Fixed a real latent bug in `adb_timeout.py` this surfaced: a process-global
  cache in `resolve_timeout_bin()` meant a caller-supplied `get_bin_path_fn`
  could be silently overridden by whatever an earlier, unrelated caller had
  already resolved. A supplied resolver is now always consulted fresh; only
  the hardcoded-fallback filesystem scan is memoized.

Also investigated a third candidate gap raised in review — three lookup
plugins (`adb_device.py`, `android_packages.py`, `fdroid_client.py`) define
local `subprocess.run`-based `_run_command()` callbacks with no `timeout=`
kwarg — and confirmed it is **not** a live gap: they only ever receive
already timeout-prefixed commands from the shared helper one layer up
(`resolve_adb()`/`packages_matching()` never call the raw callback directly).
No changes made there; full reasoning in the handoff doc.

Full design + investigation writeup:
`docs/operations/sessions/design-2026-07-28-issue-59-adb-timeouts.md`
`docs/operations/sessions/handoff-2026-07-28-issue-59-adb-timeouts.md`

Closes #59.

## Test plan

- [x] `ansible_collections/stayturgid/android_common/tests/unit` — 87 passed
- [x] `tests/python` (top-level suite) — 592 passed
- [x] `just check` — clean (ruff, biome, shfmt, markdownlint, prettier,
      html-validate, stylelint, site-contract, drift/secrets checks)
- [x] `just ansible-test` — all 5 collections green, 118 tests passed
- [x] New regression tests added: `test_push_command_wrapped_in_timeout`,
      `test_android_apk_work_profile_install_wrapped_in_timeout`,
      `test_android_apk_work_profile_timeout_warns_with_dialog_hint`,
      `test_resolve_timeout_bin_prefers_fresh_get_bin_path_fn_over_cache`
- [ ] Not part of any release yet — needs a coordinated
      `ops-vMAJOR.MINOR.PATCH` per `docs/OPS-RELEASES.md`. Control-node-only
      Ansible collection change (no on-device APK/native-agent changes), low
      deploy risk whenever bundled into the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized `adb` timeout handling across app install/uninstall, work-profile installs, configuration transfers (including staging `adb push`), and related lookups.
  * Improved timeout (`rc 124`) behavior for work-profile installs with clearer warning text; `clean` reinstall now reliably stops after a failed pre-clean step.
  * Updated timeout-binary resolution to prefer fresh caller-provided paths when available.
* **Documentation**
  * Added design and phase handoff notes for systemic `adb` timeout handling.
* **Tests**
  * Expanded coverage for timeout wrapping, warning/reason behavior, clean-reinstall failure flow, and timeout-binary precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->