### PR TITLE
fix: self-heal own-mode secrets env for site-serverapps

### DIFF
--- a/control/site_contract/serverapps.py
+++ b/control/site_contract/serverapps.py
@@ -64,6 +64,35 @@ KNOWN_APPS = (
 )
 OUR_CONFIG_PREFIXES = (Path.home() / ".config" / "stayturgid",)
 
+# Own-mode secrets that ansible roles read via lookup('env', ...) (e.g.
+# serverapp_openobserve, serverapp_vector). Not committed, not in secretspec —
+# self-healed here so a fresh shell/agent session doesn't need to remember to
+# `source` it before running site-serverapps.
+OWN_MODE_SECRETS_ENV_FILE = Path.home() / ".config" / "stayturgid" / "observability.env"
+
+
+def _load_own_mode_secrets_env(path: Path = OWN_MODE_SECRETS_ENV_FILE) -> dict[str, str]:
+    """Parse simple KEY=VALUE lines from an own-mode secrets file.
+
+    Never overrides a variable already present in the environment, so an
+    operator who did explicitly export something (e.g. for a one-off
+    override) still wins. Missing file is not an error — own-mode apps that
+    don't need these vars run fine without it.
+    """
+    if not path.is_file():
+        return {}
+    loaded: dict[str, str] = {}
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            loaded[key] = value
+    return loaded
+
 
 class ServerAppsError(Exception):
     """Precondition, execution, or user-content refusal for site-serverapps."""
@@ -2064,7 +2093,11 @@ def _run_ansible_role(plan: ServerAppsPlan, app: AppPlan, *, dry_run: bool) -> N
             check=False,
             capture_output=True,
             text=True,
-            env={**os.environ, "ANSIBLE_ROLES_PATH": str(plan.product_root / "ansible" / "roles")},
+            env={
+                **os.environ,
+                **_load_own_mode_secrets_env(),
+                "ANSIBLE_ROLES_PATH": str(plan.product_root / "ansible" / "roles"),
+            },
         )
     except OSError as exc:
         raise ServerAppsError(f"failed to run ansible-playbook: {exc}") from exc

--- a/tests/python/test_serverapps.py
+++ b/tests/python/test_serverapps.py
@@ -99,6 +99,40 @@ def _write_site_map(dest: Path, body: str) -> None:
     (dest / "site-map.yml").write_text(body, encoding="utf-8")
 
 
+# --- own-mode secrets env loader --------------------------------------------
+
+
+def test_load_own_mode_secrets_env_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert sa._load_own_mode_secrets_env(tmp_path / "nope.env") == {}
+
+
+def test_load_own_mode_secrets_env_parses_key_value_lines(tmp_path: Path) -> None:
+    env_file = tmp_path / "observability.env"
+    env_file.write_text(
+        "# comment\n"
+        "\n"
+        "OPENOBSERVE_ROOT_EMAIL=someone@example.com\n"
+        'OPENOBSERVE_ROOT_PASSWORD="quoted-value"\n'
+        "not-a-valid-line\n",
+        encoding="utf-8",
+    )
+    loaded = sa._load_own_mode_secrets_env(env_file)
+    assert loaded == {
+        "OPENOBSERVE_ROOT_EMAIL": "someone@example.com",
+        "OPENOBSERVE_ROOT_PASSWORD": "quoted-value",
+    }
+
+
+def test_load_own_mode_secrets_env_does_not_override_existing_env(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setenv("OPENOBSERVE_ROOT_EMAIL", "already-set@example.com")
+    env_file = tmp_path / "observability.env"
+    env_file.write_text("OPENOBSERVE_ROOT_EMAIL=from-file@example.com\n", encoding="utf-8")
+    loaded = sa._load_own_mode_secrets_env(env_file)
+    assert "OPENOBSERVE_ROOT_EMAIL" not in loaded
+
+
 # --- mode resolution -------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- `serverapp_openobserve`/`serverapp_vector` ansible roles read `OPENOBSERVE_ROOT_EMAIL`/`OPENOBSERVE_ROOT_PASSWORD` via `lookup('env', ...)`, but nothing auto-loaded `~/.config/stayturgid/observability.env` (own-mode, ignored, not in secretspec) into the process running `just site-serverapps` — required a human to remember to `source` it first.
- `_run_ansible_role()` now loads that env file directly (self-healing), without overriding an already-exported variable.
- Follow-up from issue #44's credential reset — closing the "one-off fix" gap the operator flagged.

## Test plan
- [x] `.venv-test/bin/python -m pytest tests/python/test_serverapps.py -q` — 47/47 pass, including 3 new tests for `_load_own_mode_secrets_env` (missing file, key=value parsing incl. quoted values/comments, does-not-override-existing-env)
- [x] Verified live: `just site-serverapps` ran the real openobserve/vector roles successfully with the env file present and *not* manually sourced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for supplying own-mode Ansible runs with secrets from a local environment file.
  * Existing environment variables take precedence over values in the secrets file.
  * Supports standard `KEY=VALUE` entries, quoted values, comments, and blank lines.

* **Bug Fixes**
  * Invalid or missing secrets files are handled safely without interrupting execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->