### PR TITLE
fix(control): resolve real Mac adb transport for peer-start target reminder (#66)

### DIFF
--- a/control/lib/adb_cli.py
+++ b/control/lib/adb_cli.py
@@ -45,6 +45,10 @@ def resolve_target(alias: str) -> str:
     return dev.resolve_adb(alias)
 
 
+def alias_for_host(host: str) -> str | None:
+    return dev.alias_for_host(host)
+
+
 def resolve_ssh(alias: str) -> str:
     return dev.resolve_ssh_host(alias)
 

--- a/control/lib/stayturgid_device.py
+++ b/control/lib/stayturgid_device.py
@@ -120,6 +120,22 @@ def device_row(alias, conf_path=None):
     return None
 
 
+def alias_for_host(host, conf_path=None):
+    """Reverse-lookup: the devices.conf alias whose tailscale_ip or lan_ip is ``host``.
+
+    Some callers only have a device's network address in hand (e.g. a Fire-OS
+    peer-start target's Tailscale IP, which is what the *peer* device uses to
+    reach it) and need the alias to find the Mac's own preferred adb transport
+    for that same physical device via [resolve_adb] — usually USB, since the
+    Mac is frequently not Tailscale-reachable to the target even when a peer
+    is. Returns None for hosts not in devices.conf (unknown target).
+    """
+    for name, _usb, ts_ip, lan, *_label in iter_devices_conf(conf_path):
+        if host in (ts_ip, lan):
+            return name
+    return None
+
+
 def resolve_adb(alias, conf_path=None):
     """USB when online, else first reachable wireless endpoint (LAN then Tailscale).
 

--- a/control/tools/native-agent/provision_peer.py
+++ b/control/tools/native-agent/provision_peer.py
@@ -117,12 +117,24 @@ def set_target_reminder(target: str) -> None:
     """Best-effort: drop the 'approve the Allow dialog' marker on a target device
     so its own agent nags the operator standing at it. The peer clears the marker
     automatically over the authorized connection once peer-start succeeds.
+
+    ``target`` is the Tailscale ``host:port`` the *peer* device uses to reach it
+    (matches the on-device ``PeerConfig.targets`` schema) — the Mac itself is
+    frequently only USB-serial-reachable to that same physical device. Reverse-
+    lookup the devices.conf alias for this host so we resolve via whatever adb
+    transport the Mac actually has (USB when online, else LAN/Tailscale),
+    instead of assuming the peer's Tailscale endpoint is Mac-adb-reachable too.
     """
-    resolved_target = adb.resolve_target(target) if target else target
-    try:
-        adb.run([adb.adb_bin(), "connect", resolved_target], timeout=15)
-    except Exception:  # noqa: BLE001
-        pass
+    host = target.split(":", 1)[0] if target else target
+    alias = adb.alias_for_host(host) if host else None
+    resolved_target = adb.resolve_target(alias) if alias else target
+    if resolved_target and ":" in resolved_target:
+        # Only a network endpoint needs an explicit `adb connect`; a resolved
+        # USB serial is already a live adb transport.
+        try:
+            adb.run([adb.adb_bin(), "connect", resolved_target], timeout=15)
+        except Exception:  # noqa: BLE001
+            pass
     ok = False
     for pkg in AGENT_PKGS:
         r = adb.adb(

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/AuthorizeReminder.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/AuthorizeReminder.kt
@@ -39,6 +39,7 @@ object AuthorizeReminder {
      */
     fun clearCommand(): String =
         AGENT_PACKAGES.joinToString("; ") { pkg ->
-            "run-as $pkg rm -f files/$FILE_NAME 2>/dev/null; rm -f /sdcard/Android/data/$pkg/files/$FILE_NAME 2>/dev/null"
+            val external = "/sdcard/Android/data/$pkg/files/$FILE_NAME"
+            "run-as $pkg rm -f files/$FILE_NAME 2>/dev/null; rm -f $external 2>/dev/null"
         }
 }

--- a/docs/operations/sessions/handoff-2026-07-28-issue-66-peer-marker-issue-64-tailscale-gate.md
+++ b/docs/operations/sessions/handoff-2026-07-28-issue-66-peer-marker-issue-64-tailscale-gate.md
@@ -56,7 +56,7 @@ call as a red herring.
 ### 1. Fixed the residual `#66` gap
 
 - **`control/lib/stayturgid_device.py`**: added `alias_for_host(host,
-  conf_path=None)` — reverse-lookup a `devices.conf` alias by its
+conf_path=None)` — reverse-lookup a `devices.conf` alias by its
   `tailscale_ip` or `lan_ip` (the existing `device_row`/`iter_devices_conf`
   only look up forward, by alias name).
 - **`control/lib/adb_cli.py`**: forwarded it as `alias_for_host()`, matching
@@ -107,8 +107,7 @@ shellOut(arrayOf("am", "start", "-n", TAILSCALE_COMPONENT), 8)
 ```
 
 `isTailscaleTunnelUp()` reads `/proc/net/dev` directly inside
-`ComonitorProbes`, which runs in the Shizuku `UserService` process (UID
-2000) — the class's own doc comment confirms this, and it's the same
+`ComonitorProbes`, which runs in the Shizuku `UserService` process (UID 2000) — the class's own doc comment confirms this, and it's the same
 context the co-monitor already uses correctly (per the issue's own
 observation that the native agent "reads the tunnel interface correctly,"
 unlike Termux's app-uid read). No `EACCES` risk here, so the gate itself is
@@ -160,9 +159,9 @@ trusting that stale note:
 
 - `~/.local/bin/pytest` (project `.venv-test`, via `just test-venv` then
   `just pytest`): **612 passed, 1 skipped** (pre-existing skip, unrelated).
-- `just check`: clean (ruff, biome, shfmt, markdownlint, prettier* — *node
-  modules not installed in this worktree, pre-existing skip unrelated to
-  this change, same as other agents in this chain have seen).
+- `just check`: clean (ruff, biome, shfmt, markdownlint, prettier,
+  html-validate, stylelint, validate-identity — ran `bun install` in this
+  worktree first since node_modules wasn't present).
 - `just kt-format-check`: clean.
 - `just kt-test`: `BUILD SUCCESSFUL`, 154 tasks.
 - `just kt-detekt`: clean (0 findings — includes fixing the one

--- a/docs/operations/sessions/handoff-2026-07-28-issue-66-peer-marker-issue-64-tailscale-gate.md
+++ b/docs/operations/sessions/handoff-2026-07-28-issue-66-peer-marker-issue-64-tailscale-gate.md
@@ -1,0 +1,204 @@
+# Handoff: #66 peer-start marker unification + #64 repairTailscale GUI-foreground gate
+
+**Session:** Agent 8, human-relayed orchestration chain (see
+`~/ai-orchestration-plan-2026-07-28.md`). **Worktree:**
+`~/src/ops-worktrees/peer-marker-66-tailscale-64/stayturgid` (branch
+`feature/peer-marker-66-tailscale-64`).
+
+## Headline finding: both issues were already mostly fixed directly on `master`
+
+Same pattern this chain has now hit five times (`#59`, `#60`, `#65`, and now
+`#66`/`#64`): commit `81baa49` ("fix(agent): suppress Tailscale GUI launch,
+reap stale UserServices, unify Fire OS target reminder (#64, #65, #66)"),
+authored by the operator on 2026-07-26 21:30:56 -0400, already implements
+the great majority of both issues' asks — about 15 hours after the
+operator's own issue comments describing the bugs. Neither issue was closed
+or updated after that commit landed. Agent 7 (`#65`'s unit) noticed the
+bundling and explicitly flagged one loose end in this exact code for
+whoever picked up `#66`/`#64` next (that was me — see below).
+
+### What `81baa49` already did for `#66`
+
+- `AuthorizeReminder.kt`: `isPresent`/`clear`/`clearCommand` all now check
+  internal `filesDir` first (via `run-as`) with an external-dir fallback —
+  exactly the `PeerConfig`-mirroring unification the issue asked for. Works
+  on Fire OS and OneUI uniformly.
+- `provision_peer.py`'s `set_target_reminder()`: rewrote the write path to
+  `run-as <pkg> touch files/authorize_reminder` with an external-dir
+  fallback, fixing the Fire-OS `Permission denied` half of the bug.
+
+### The one residual gap (real, confirmed by testing — not just reading)
+
+The issue's second ask — "fix `set_target_reminder()` to use whichever adb
+transport the Mac actually has for that specific target (USB serial or
+Tailscale), not assume one" — was **not actually fixed** by `81baa49`,
+despite looking like it. The commit added a `adb.resolve_target(target)`
+call, but `target` here is the Fire-OS device's **Tailscale** `host:port`
+(matches the on-device `PeerConfig.targets` schema, e.g. hd8's
+`100.124.55.39:5555`) — not a `devices.conf` **alias name** like `"hd8"`.
+`resolve_adb()`/`device_row()` match by alias name only, so calling it with
+a raw IP:port is a silent no-op (confirmed live):
+
+```
+>>> stayturgid_device.resolve_adb("100.124.55.39:5555")
+'100.124.55.39:5555'          # unchanged — no alias literally named that
+>>> stayturgid_device.resolve_adb("hd8")
+'GN43T503430603PS'            # the actual USB serial, only reachable via the alias
+```
+
+So the Mac still unconditionally attempted `adb connect <tailscale-ip>:5555`
+even when the Mac only has USB-serial access to that physical device — the
+exact bug the issue described, just with the giveaway `resolve_target()`
+call as a red herring.
+
+## What I did this unit
+
+### 1. Fixed the residual `#66` gap
+
+- **`control/lib/stayturgid_device.py`**: added `alias_for_host(host,
+  conf_path=None)` — reverse-lookup a `devices.conf` alias by its
+  `tailscale_ip` or `lan_ip` (the existing `device_row`/`iter_devices_conf`
+  only look up forward, by alias name).
+- **`control/lib/adb_cli.py`**: forwarded it as `alias_for_host()`, matching
+  the existing `resolve_target`/`resolve_ssh` forwarding pattern.
+- **`control/tools/native-agent/provision_peer.py`**:
+  `set_target_reminder()` now splits the port off `target`, reverse-looks-up
+  the devices.conf alias for that host, and — only if found — resolves via
+  `adb.resolve_target(alias)` (USB-preferred) instead of the dead
+  pass-through call. Also skips the `adb connect` step entirely when the
+  resolved target is a bare USB serial (no colon) — `adb connect` is a
+  network-transport command and doesn't apply to a serial that's already a
+  live adb transport. Falls back to the raw target unchanged for hosts not
+  in `devices.conf` (ad-hoc/one-off targets), preserving prior behavior
+  there.
+- Tests added: `test_stayturgid_device_conf.py::test_alias_for_host_reverse_lookup`,
+  `test_adb_cli.py::test_alias_for_host_forwards_to_stayturgid_device`, and
+  two new tests in `test_provision_peer.py` that exercise
+  `set_target_reminder()` end-to-end (mocked `adb.*`) proving: (a) a known
+  target resolves to its USB serial and issues shell commands against that
+  serial with **no** `adb connect` call, and (b) an unknown target still
+  falls back to the old best-effort raw-target behavior.
+
+### 2. Fixed the pre-existing `kt-detekt` finding Agent 7 flagged for this unit
+
+`AuthorizeReminder.kt:42` (`MaximumLineLength`) — pre-existing from
+`81baa49`, in this issue's own file, explicitly left for whoever picked up
+`#66`/`#64` (see Agent 7's handoff,
+`handoff-2026-07-28-issue-65-shizuku-userservice-leak.md`, §"One
+known-and-deliberately-untouched remaining kt-detekt finding"). Fixed by
+extracting the external-path string to a local `val` instead of inlining it
+in the `joinToString` lambda — same string, same behavior, just under the
+line-length limit. `just kt-detekt` is now fully clean (0 findings, not
+just this issue's slice).
+
+### 3. Verified `#64`'s native-agent gate needs no code changes
+
+`CatastrophicRepair.repairTailscale()` (now at lines 186-193, shifted from
+the issue's `:177` reference since `81baa49` landed) already has the exact
+gate the issue asked for:
+
+```kotlin
+if (ComonitorProbes.isTailscaleTunnelUp()) {
+    val detail = "tailscale tunnel up; control-plane probe flaky (GUI launch suppressed)"
+    appendLog("[agent] $detail")
+    return Result(policyOk, detail)
+}
+shellOut(arrayOf("am", "start", "-n", TAILSCALE_COMPONENT), 8)
+```
+
+`isTailscaleTunnelUp()` reads `/proc/net/dev` directly inside
+`ComonitorProbes`, which runs in the Shizuku `UserService` process (UID
+2000) — the class's own doc comment confirms this, and it's the same
+context the co-monitor already uses correctly (per the issue's own
+observation that the native agent "reads the tunnel interface correctly,"
+unlike Termux's app-uid read). No `EACCES` risk here, so the gate itself is
+correct as shipped. No unit tests existed for `CatastrophicRepair.kt` or
+`ComonitorProbes.kt` before or after this unit — both are thin,
+`ProcessBuilder`/`File`-IO-heavy wrappers with no pure logic to extract in
+the style of `AuthorizeReminderTest.kt`/`ShizukuUserServiceTest.kt`
+(unlike `#65`'s `reapStaleUserServices()`, there's no obvious pure decision
+function buried in `repairTailscale()` to pull out); adding real coverage
+would need dependency-injecting the shell-out layer, which is a much larger
+change than this narrow verification unit warranted. Flagging as a gap for
+whoever next touches this file with a larger budget.
+
+### 4. Verified `#64`'s Termux-side fleet rollout is complete (not guessed)
+
+The issue's "keeping this open" list included "fleet-wide deploy of the
+fixed script — the Pixel peer was offline and the Fire host uses the
+Mac-adb path at last check, may have changed." Checked live rather than
+trusting that stale note:
+
+- `device/termux/py/stayturgid_repair.py` is deployed via the
+  `termux_userland` Ansible role ("Deploy Python runtime scripts to
+  `~/.stayturgid/bin`"), so it goes out with every `just deploy`.
+- Commit `12c0b61` (the actual `_tailscale_runtime_up()` fix) is an ancestor
+  of the `ops-v1.0.13` release commit (`ddad7e2`) — confirmed via
+  `git merge-base --is-ancestor`.
+- **Live-verified all three fleet devices are now directly SSH-reachable**
+  (s24, p7a, hd8 — including hd8's Termux over Tailscale, not just the
+  Mac-adb path the issue's note described as the prior state) and their
+  deployed `stayturgid_repair.py` **byte-for-byte matches** this repo's
+  current blob (`git hash-object` comparison, not just a `grep` for the
+  function name):
+
+  ```
+  repo blob:      713a9fb1384672cf14441706a6877177c200dd48
+  s24 live blob:  713a9fb1384672cf14441706a6877177c200dd48  MATCH
+  p7a live blob:  713a9fb1384672cf14441706a6877177c200dd48  MATCH
+  hd8 live blob:  713a9fb1384672cf14441706a6877177c200dd48  MATCH
+  ```
+
+- **No redeploy needed or attempted** — the fleet is already fully current.
+  p7a being reachable at all is itself new information (it was offline as
+  of Agent 1's handoff a few hours earlier in this same chain, and is still
+  flagged `stayturgid_fleet_status: offline` in site-djbclark inventory
+  pending `#103`/`#104` — that flag concerns a different liveness signal,
+  not adb/SSH reachability, and is out of scope here).
+
+## Verification
+
+- `~/.local/bin/pytest` (project `.venv-test`, via `just test-venv` then
+  `just pytest`): **612 passed, 1 skipped** (pre-existing skip, unrelated).
+- `just check`: clean (ruff, biome, shfmt, markdownlint, prettier* — *node
+  modules not installed in this worktree, pre-existing skip unrelated to
+  this change, same as other agents in this chain have seen).
+- `just kt-format-check`: clean.
+- `just kt-test`: `BUILD SUCCESSFUL`, 154 tasks.
+- `just kt-detekt`: clean (0 findings — includes fixing the one
+  pre-existing finding Agent 7 flagged for this unit).
+- Live fleet verification for `#64`(a): see §4 above.
+
+## Files changed
+
+- `control/lib/stayturgid_device.py` — new `alias_for_host()` reverse
+  lookup.
+- `control/lib/adb_cli.py` — forward `alias_for_host()`.
+- `control/tools/native-agent/provision_peer.py` — `set_target_reminder()`
+  now resolves the Mac's actual adb transport via reverse alias lookup
+  instead of a dead pass-through call.
+- `device/native-agent/app/src/main/kotlin/org/stayturgid/agent/AuthorizeReminder.kt`
+  — pre-existing `kt-detekt` line-length fix (no behavior change).
+- `tests/python/test_stayturgid_device_conf.py`,
+  `tests/python/test_adb_cli.py`, `tests/python/test_provision_peer.py` —
+  new tests for the above.
+- This handoff doc.
+
+## Next steps / recommendations
+
+- PR opened against `master` for `#66` (all code changes in this unit are
+  scoped to `#66`'s own file — `#64` needed no code changes, see below).
+  Needs a coordinated `ops-vMAJOR.MINOR.PATCH` release like everything else
+  in this chain before it reaches the fleet.
+- **`#64`: recommend closing**, referencing commit `81baa49` (the gate) and
+  this handoff's §4 (fleet rollout confirmed complete on all three
+  devices) — both items the operator's comment listed as "keeping this
+  open for" are now resolved. Posting a closing comment with this evidence
+  as part of this unit (no PR needed since no code changed for `#64`).
+- **`#66`: recommend closing once this PR merges** — both original asks
+  (unify the marker mechanism, fix the Mac-adb-transport assumption) are
+  now genuinely fixed and tested.
+- If a larger unit ever touches `CatastrophicRepair.kt`/`ComonitorProbes.kt`
+  again, worth extracting a pure decision core (as `#65`'s unit did for
+  `ShizukuUserService.kt`) so `repairTailscale()`'s branching logic gets
+  real unit coverage instead of relying on manual/live verification.

--- a/tests/python/test_adb_cli.py
+++ b/tests/python/test_adb_cli.py
@@ -50,3 +50,15 @@ def test_sync_catalog_paths_exist():
     for which, (json_path, dest_name) in sync.CATALOGS.items():
         assert json_path.is_file(), which
         assert dest_name.startswith("stayturgid-obtainium-")
+
+
+def test_alias_for_host_forwards_to_stayturgid_device(monkeypatch):
+    seen = {}
+
+    def fake_alias_for_host(host):
+        seen["host"] = host
+        return "hd8"
+
+    monkeypatch.setattr(ac.dev, "alias_for_host", fake_alias_for_host)
+    assert ac.alias_for_host("100.124.55.39") == "hd8"
+    assert seen["host"] == "100.124.55.39"

--- a/tests/python/test_provision_peer.py
+++ b/tests/python/test_provision_peer.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 from pathlib import Path
+from unittest.mock import Mock
 
 MODULE_PATH = Path(__file__).resolve().parents[2] / "control" / "tools" / "native-agent" / "provision_peer.py"
 SPEC = importlib.util.spec_from_file_location("provision_peer", MODULE_PATH)
@@ -38,3 +39,48 @@ def test_explicit_package_override_does_not_fall_through(monkeypatch):
 
     assert provision_peer._resolve_pkg("device") is None
     assert seen == ["com.example.agent"]
+
+
+def test_set_target_reminder_uses_mac_adb_transport_not_peer_tailscale_ip(monkeypatch):
+    """#66: the Mac is frequently USB-only for a target whose peer reaches it over
+    Tailscale — set_target_reminder must reverse-resolve to the Mac's own adb
+    transport (USB serial here) for the shell commands, not the raw peer-facing
+    Tailscale host:port, and must not `adb connect` a USB serial."""
+    monkeypatch.setattr(provision_peer.adb, "alias_for_host", lambda host: "hd8" if host == "100.124.55.39" else None)
+    monkeypatch.setattr(provision_peer.adb, "resolve_target", lambda alias: "USBSERIAL123" if alias == "hd8" else alias)
+    connect_calls = []
+    monkeypatch.setattr(provision_peer.adb, "run", lambda cmd, **kw: connect_calls.append(cmd))
+    shell_targets = []
+
+    def fake_adb(serial, *args, **kwargs):
+        shell_targets.append(serial)
+        return Mock(stdout="OK")
+
+    monkeypatch.setattr(provision_peer.adb, "adb", fake_adb)
+
+    provision_peer.set_target_reminder("100.124.55.39:5555")
+
+    assert connect_calls == []  # USB serial never needs `adb connect`
+    assert shell_targets == ["USBSERIAL123", "USBSERIAL123"]  # one per AGENT_PKGS entry
+
+
+def test_set_target_reminder_falls_back_to_raw_target_when_host_unknown(monkeypatch):
+    """A target not in devices.conf (no reverse-lookup alias) still gets a
+    best-effort `adb connect` + shell against the raw host:port, matching the
+    pre-existing behavior for ad-hoc targets."""
+    monkeypatch.setattr(provision_peer.adb, "alias_for_host", lambda host: None)
+    monkeypatch.setattr(provision_peer.adb, "resolve_target", lambda alias: alias)
+    connect_calls = []
+    monkeypatch.setattr(provision_peer.adb, "run", lambda cmd, **kw: connect_calls.append(cmd))
+    shell_targets = []
+
+    def fake_adb(serial, *args, **kwargs):
+        shell_targets.append(serial)
+        return Mock(stdout="OK")
+
+    monkeypatch.setattr(provision_peer.adb, "adb", fake_adb)
+
+    provision_peer.set_target_reminder("203.0.113.5:5555")
+
+    assert connect_calls and connect_calls[0][-1] == "203.0.113.5:5555"
+    assert shell_targets == ["203.0.113.5:5555", "203.0.113.5:5555"]

--- a/tests/python/test_stayturgid_device_conf.py
+++ b/tests/python/test_stayturgid_device_conf.py
@@ -21,3 +21,12 @@ def test_iter_devices_conf_and_monitor_hosts(tmp_path):
     assert mon == [("oneui-device", "100.1", "192.1"), ("stock-android-device", "100.2", "-")]
     assert sd.device_row("oneui-device", str(conf)) == ("USB1", "100.1", "192.1")
     assert sd.device_row("nope", str(conf)) is None
+
+
+def test_alias_for_host_reverse_lookup(tmp_path):
+    conf = tmp_path / "devices.conf"
+    conf.write_text("# c\noneui-device USB1 100.1 192.1\nstock-android-device USB2 100.2\n")
+    assert sd.alias_for_host("100.1", str(conf)) == "oneui-device"
+    assert sd.alias_for_host("192.1", str(conf)) == "oneui-device"
+    assert sd.alias_for_host("100.2", str(conf)) == "stock-android-device"
+    assert sd.alias_for_host("9.9.9.9", str(conf)) is None


### PR DESCRIPTION
## Summary

- Fixes the residual half of #66: `provision_peer.py:set_target_reminder()` looked fixed after commit `81baa49` (added an `adb.resolve_target(target)` call), but `target` is the Fire-OS device's **Tailscale** `host:port` — not a `devices.conf` alias name — so the resolve call was a confirmed-live no-op. The Mac kept assuming Tailscale reachability to a device it may only have USB-serial access to.
- Adds `alias_for_host()` reverse lookup (`control/lib/stayturgid_device.py` + `control/lib/adb_cli.py` forwarding) so `set_target_reminder()` now resolves via whatever adb transport the Mac actually has for that physical device (USB-preferred, matching `resolve_adb`'s existing preference order), and skips the network-only `adb connect` step when the resolved target is a bare USB serial.
- `81baa49` already shipped the other half of #66 (run-as + external-dir fallback for both writing and clearing the marker, mirroring `PeerConfig`) — verified correct, no changes needed there.
- Also fixes a pre-existing `kt-detekt` `MaximumLineLength` finding in `AuthorizeReminder.kt` (same `81baa49` commit, explicitly flagged for this issue by a prior agent's `#65` handoff doc) — no behavior change.
- `#64` (repairTailscale GUI-foreground gate) needed **no code changes** — already correctly implemented in `81baa49` and verified; see the handoff doc for the full evidence trail including live fleet verification that the Termux-side fix is deployed fleet-wide. Closing #64 directly via issue comment, no PR needed.

Full writeup: `docs/operations/sessions/handoff-2026-07-28-issue-66-peer-marker-issue-64-tailscale-gate.md`.

## Test plan

- [x] `just pytest` (project `.venv-test`): 612 passed, 1 pre-existing skip
- [x] `just check`: clean (ruff, biome, shfmt, markdownlint, prettier, html-validate, stylelint, validate-identity)
- [x] `just kt-format-check`: clean
- [x] `just kt-test`: `BUILD SUCCESSFUL`
- [x] `just kt-detekt`: clean (0 findings)
- [x] Manually verified `alias_for_host("100.124.55.39")` → `"hd8"` → `resolve_adb("hd8")` → USB serial, live against this Mac's `devices.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)