### PR TITLE
fix(agent): log unexpected pidof exit codes in runPidof (CodeRabbit follow-up on #124)

### DIFF
--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/ShizukuUserService.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/ShizukuUserService.kt
@@ -227,9 +227,17 @@ class ShizukuUserService : IStayTurgidService.Stub {
         val p = ProcessBuilder("pidof", "$pkg:userservice").redirectErrorStream(true).start()
         if (!p.waitFor(2, TimeUnit.SECONDS)) {
             p.destroyForcibly()
+            Log.w(TAG, "pidof timed out for $pkg")
             return ""
         }
-        return p.inputStream.bufferedReader().use { it.readText().trim() }
+        val out = p.inputStream.bufferedReader().use { it.readText().trim() }
+        // Android/toybox pidof exits 0 (match found) or 1 (no match) as routine,
+        // expected outcomes. Anything else is a real failure worth logging so a
+        // broken pidof doesn't silently skip stale-service cleanup.
+        if (p.exitValue() != 0 && p.exitValue() != 1) {
+            Log.w(TAG, "pidof exited ${p.exitValue()} for $pkg: $out")
+        }
+        return out
     }
 
     private fun killPids(pids: List<Int>) {


### PR DESCRIPTION
## Summary

Small follow-up to #124 (itself a follow-up to #120, #65) — one more
CodeRabbit finding landed on #124 after it had already been merged by the
time I addressed it, so carrying it forward the same way.

`runPidof()` read `pidof`'s output regardless of exit code, silently
treating any non-zero exit the same as "no match found." Android/toybox
`pidof` exits `0` (match found) or `1` (no match) as routine, expected
outcomes — anything else now gets logged so a genuinely broken `pidof`
doesn't silently skip stale-service cleanup. Output is still returned
either way (lenient, matches the existing best-effort `catch (t:
Throwable)` in `reapStaleUserServices()`).

## Test plan

- [x] `just kt-format-check` — clean
- [x] `just kt-test` — clean
- [x] `just kt-detekt` — no new findings
- [x] `just check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)