### PR TITLE
Remove Ollama from landing service discovery

### DIFF
--- a/control/landing/discover.py
+++ b/control/landing/discover.py
@@ -49,7 +49,6 @@ KNOWN_SERVICES: list[dict] = [
     {"url": "https://mac.example.ts.net/opencode/", "label": "OpenCode Web (HTTPS)", "group": "mac"},
     {"url": "https://mac.example.ts.net/dashboard/", "label": "Fleet Dashboard (HTTPS)", "group": "mac"},
     {"url": "https://mac.example.ts.net/stats/", "label": "Fleet Stats (HTTPS)", "group": "mac"},
-    {"url": "https://mac.example.ts.net/ollama/", "label": "Ollama LLM API (HTTPS)", "group": "mac"},
     {"url": "https://mac.example.ts.net/litellm/", "label": "LiteLLM Proxy (HTTPS)", "group": "mac"},
     {"url": "http://localhost:6736/v1/limits", "label": "OpenUsage Limits API", "group": "mac"},
     {"url": "ssh://mac.example.ts.net:22", "label": "SSH Server (sshd)", "group": "mac"},

--- a/control/landing/services.json
+++ b/control/landing/services.json
@@ -9,7 +9,6 @@
     {"group": "mac", "label": "OpenCode Web (HTTPS)", "url": "https://mac.example.ts.net/opencode/"},
     {"group": "mac", "label": "Fleet Dashboard (HTTPS)", "url": "https://mac.example.ts.net/dashboard/"},
     {"group": "mac", "label": "Fleet Stats (HTTPS)", "url": "https://mac.example.ts.net/stats/"},
-    {"group": "mac", "label": "Ollama LLM API (HTTPS)", "url": "https://mac.example.ts.net/ollama/"},
     {"group": "mac", "label": "LiteLLM Proxy (HTTPS)", "url": "https://mac.example.ts.net/litellm/"},
     {"group": "mac", "label": "OpenUsage Limits API", "url": "http://localhost:6736/v1/limits"},
     {"group": "mac", "label": "SSH Server (sshd)", "url": "ssh://mac.example.ts.net:22"},


### PR DESCRIPTION
## Summary
- Remove Ollama HTTPS entries from landing `discover.py` and `services.json`

Pairs with the site-djbclark registry/Caddy cleanup after uninstalling local Ollama.

## Test plan
- [ ] Landing discovery no longer lists Ollama
- [ ] No remaining `/ollama/` advertisements in control/landing


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the obsolete Ollama LLM API entry from the service discovery catalog.
  * The service will no longer appear as a preloaded or statically listed discovery option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->