### PR TITLE
Declare DeepSeek and OpenRouter Hermes API keys in secretspec

### DIFF
--- a/SITE-CONTRACT.md
+++ b/SITE-CONTRACT.md
@@ -269,6 +269,8 @@ FIRERPA_CERTIFICATE = { description = "Path to the FIRERPA service certificate a
 GITHUB_TOKEN = { description = "GitHub personal access token for gh CLI auth", required = false }
 ANSIBLE_GALAXY_TOKEN = { description = "Ansible Galaxy API token", required = false }
 OPENCODE_ZEN_API_KEY = { description = "OpenCode Zen API key for the Hermes provider", required = false }
+DEEPSEEK_API_KEY = { description = "DeepSeek API key for the Hermes native DeepSeek provider", required = false }
+OPENROUTER_API_KEY = { description = "OpenRouter API key for the Hermes OpenRouter provider", required = false }
 SSH_TERMUX_KEY = { description = "Path to the Termux SSH private key", required = false, default = "~/.ssh/termux_key" }
 SSH_CA_KEY = { description = "Path to the SSH CA private key", required = false, default = "~/.ssh/stayturgid_ca" }
 FLEET_ADBKEY = { description = "Path to the fleet ADB private key", required = false, default = "~/.config/stayturgid/adbkey" }

--- a/control/site_contract/templates/secretspec.toml.j2
+++ b/control/site_contract/templates/secretspec.toml.j2
@@ -16,6 +16,8 @@ FIRERPA_CERTIFICATE = { description = "Path to the FIRERPA service certificate a
 GITHUB_TOKEN = { description = "GitHub personal access token for gh CLI auth", required = false }
 ANSIBLE_GALAXY_TOKEN = { description = "Ansible Galaxy API token", required = false }
 OPENCODE_ZEN_API_KEY = { description = "OpenCode Zen API key for the Hermes provider", required = false }
+DEEPSEEK_API_KEY = { description = "DeepSeek API key for the Hermes native DeepSeek provider", required = false }
+OPENROUTER_API_KEY = { description = "OpenRouter API key for the Hermes OpenRouter provider", required = false }
 SSH_TERMUX_KEY = { description = "Path to the Termux SSH private key", required = false, default = "~/.ssh/termux_key" }
 SSH_CA_KEY = { description = "Path to the SSH CA private key", required = false, default = "~/.ssh/stayturgid_ca" }
 FLEET_ADBKEY = { description = "Path to the fleet ADB private key", required = false, default = "~/.config/stayturgid/adbkey" }

--- a/secretspec.toml
+++ b/secretspec.toml
@@ -34,6 +34,8 @@ ANSIBLE_GALAXY_TOKEN = { description = "Ansible Galaxy API token for publishing 
 
 # ── OpenCode / LLM Providers (configured via /connect in TUI) ──
 OPENCODE_ZEN_API_KEY = { description = "OpenCode Zen API key for the Hermes LLM provider. Configured via `hermes auth add opencode-zen`", required = false }
+DEEPSEEK_API_KEY = { description = "DeepSeek API key for the Hermes native DeepSeek provider. Configured via `hermes auth add deepseek`", required = false }
+OPENROUTER_API_KEY = { description = "OpenRouter API key for the Hermes OpenRouter provider. Configured via `hermes auth add openrouter`", required = false }
 
 # ── Paths to key files (used by ansible/control scripts) ──
 SSH_TERMUX_KEY = { description = "Path to Termux SSH private key (~/.ssh/termux_key)", required = false, default = "~/.ssh/termux_key" }


### PR DESCRIPTION
## Summary
- Add `DEEPSEEK_API_KEY` and `OPENROUTER_API_KEY` declarations to `secretspec.toml`, the site-contract template, and `SITE-CONTRACT.md`
- Values live in the secretspec provider / Hermes `.env` (not in git); `OPENCODE_ZEN_API_KEY` was already declared

## Test plan
- [x] `secretspec check` shows both keys present in the task worktree
- [x] Hermes one-shot chat works with `--provider deepseek`, `openrouter`, and `opencode-zen`


Made with [Cursor](https://cursor.com)