### PR TITLE
docs(k1): resolve #18 scoping doc's cross-process logging contract gap

### DIFF
--- a/docs/operations/sessions/design-2026-07-29-issue-18-scoping.md
+++ b/docs/operations/sessions/design-2026-07-29-issue-18-scoping.md
@@ -127,6 +127,36 @@ Ordered by dependency, not by priority — §3.1 gates several others.
    native-agent-writable path), plus log levels. **No other sub-item below
    should ship its "enhanced logging" pieces before this lands** — there's
    nowhere for that data to go yet.
+
+   **Cross-process handoff contract (the specific path/permission question
+   a future implementer must resolve first):** native-agent (its own Android
+   UID) and Termux's `otelcol-contrib` (a different UID) can't share
+   internal `filesDir` — that's exactly why `watchdog.jsonl` (written by the
+   now-retired AutoJs6, a third, different UID) was readable by Termux at
+   all: it went through `stayturgid_sd_root` (default `/sdcard/stayturgid`,
+   shared external storage, no app-scoped permission boundary). Two options
+   for native-agent's JSONL emitter, in order of precedent-fit:
+   - **Preferred:** write to native-agent's own external-files-dir
+     (`/sdcard/Android/data/<pkg>/files/logs/agent.jsonl`) — the same
+     external/internal-fallback pattern `AuthorizeReminder.kt` already uses
+     (PR #125) and that this repo's Termux-side tooling already knows how to
+     read cross-UID (`run-as`/direct external-dir reads, same precedent).
+     Needs a new `filelog/agent` receiver entry in `otel-config.yaml.j2`
+     pointed at that exact path — no new Android permission grant beyond
+     what native-agent already holds.
+   - **Alternative:** write directly to `stayturgid_sd_root`
+     (`/sdcard/stayturgid/logs/agent.jsonl`), matching AutoJs6's old
+     mechanism exactly — but this needs broader external-storage write
+     access than native-agent's app-scoped dir currently requires, which
+     modern Android gates behind `MANAGE_EXTERNAL_STORAGE` or a
+     Storage-Access-Framework grant. Only worth it if something else
+     already needs that broader permission; don't request it solely for
+     this.
+
+   Whichever path is chosen, it must be nailed down as a concrete decision
+   (not left open) before implementation starts — this is the one piece of
+   this sub-item that blocks everything downstream of it.
+
 2. **Efficiency-mode formalization** (Small). Mostly already implemented:
    `AgentSchedule`'s per-device stagger + screen-on-gated ping loop already
    _are_ efficiency behavior. This is closer to naming/documenting the


### PR DESCRIPTION
## Summary
- PR #131 (issue #18 scoping doc) got a legitimate CodeRabbit "Major" finding after merge: sub-item #3.1's native-agent structured-logging proposal didn't specify the actual cross-process (cross-UID) file handoff path between native-agent and Termux's `otelcol-contrib`.
- Filled in the concrete answer using this repo's own precedent: native-agent's external-files-dir (same pattern `AuthorizeReminder.kt` already uses, PR #125) rather than the broader `stayturgid_sd_root` shared-storage path AutoJs6's now-retired `watchdog.jsonl` used, which would need a broader storage permission native-agent doesn't currently hold.

## Test plan
- [x] `just check` — clean (`RESULT: PASS (code)`)
- [x] `prettier --check` clean after `--write`

🤖 Generated with [Claude Code](https://claude.com/claude-code)