### PR TITLE
Speed up fleet deploy runs (#57): profile_tasks, --devices-only, collection-install caching

### DIFF
--- a/control/bin/deploy_fleet.py
+++ b/control/bin/deploy_fleet.py
@@ -5,14 +5,16 @@ Canonical entry (from repo root)::
 
   ANSIBLE_CONFIG=ansible/ansible.cfg ansible-playbook ansible/playbooks/site.yml
 
-This wrapper installs collections and **always** re-runs control_node/site.yml after
+This wrapper installs collections and, by default, re-runs control_node/site.yml after
 the fleet site playbook. Ansible ``--limit`` is device hosts only, so localhost
 (control node) would otherwise be skipped — Mac agents/launchd must still refresh.
+Pass ``--devices-only`` (#57) to skip that second pass when iterating on one device.
 
 Usage:
   deploy_fleet.py [host ...]              # full site deploy
   deploy_fleet.py --scope fdroid oneui-device      # F-Droid roles only
   deploy_fleet.py --scope play oneui-device        # Play roles + Aurora UI
+  deploy_fleet.py --devices-only oneui-device      # skip the redundant Mac control_node pass
   CHECK=1 deploy_fleet.py oneui-device             # ansible --check --diff (no post-UI / validate asserts)
 
 Scopes map to ansible-playbook --tags on site.yml (see site.yml header).
@@ -21,6 +23,7 @@ Scopes map to ansible-playbook --tags on site.yml (see site.yml header).
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import shutil
@@ -129,8 +132,28 @@ def require_ansible() -> None:
         sys.exit(1)
 
 
+def _requirements_hash() -> str:
+    return hashlib.sha256(REQUIREMENTS.read_bytes()).hexdigest()
+
+
+def _collections_up_to_date(collections_path: Path, stamp: Path, current_hash: str) -> bool:
+    if not (collections_path / "ansible_collections").is_dir():
+        return False
+    try:
+        return stamp.read_text().strip() == current_hash
+    except OSError:
+        return False
+
+
 def install_collections() -> None:
     context = resolve_ansible_context(REPO_ROOT)
+    current_hash = _requirements_hash()
+    stamp = context.collections_path / ".requirements-hash"
+    # #57: ansible-galaxy pays real dependency-resolution/filesystem-check cost
+    # on every invocation — skip it when requirements.yml hasn't changed since
+    # the last successful install.
+    if _collections_up_to_date(context.collections_path, stamp, current_hash):
+        return
     subprocess.run(
         [
             "ansible-galaxy",
@@ -145,6 +168,8 @@ def install_collections() -> None:
         stdout=subprocess.DEVNULL,
         cwd=REPO_ROOT,
     )
+    stamp.parent.mkdir(parents=True, exist_ok=True)
+    stamp.write_text(current_hash)
 
 
 def warn_prerequisites(scope: Scope) -> None:
@@ -214,7 +239,7 @@ def deploy_mac(*, check: bool, tags: str = "mac", verbose: int = 0) -> int:
     )
 
 
-def deploy(scope: Scope, hosts: list[str], *, check: bool, verbose: int = 0) -> int:
+def deploy(scope: Scope, hosts: list[str], *, check: bool, verbose: int = 0, devices_only: bool = False) -> int:
     require_ansible()
     context = resolve_ansible_context(REPO_ROOT)
     require_inventory(context)
@@ -242,6 +267,10 @@ def deploy(scope: Scope, hosts: list[str], *, check: bool, verbose: int = 0) -> 
         # agent role includes privileged /etc configuration, and its normal deploy is
         # independent of the device host check below.
         if check:
+            return rc
+        if devices_only:
+            # #57: the caller only wants the device playbook (e.g. iterating on
+            # one device) — skip the second ansible-playbook launch entirely.
             return rc
         # Always refresh Mac control node on real deploys: deploy_fleet always passes a
         # device --limit, so site.yml's control_node import never selects localhost.
@@ -273,6 +302,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--check", action="store_true", help="Ansible dry run (--check --diff); also honors CHECK=1")
     parser.add_argument(
+        "--devices-only",
+        action="store_true",
+        help="Skip the control_node/site.yml Mac pass (#57) — for iterating on one device only",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         action="count",
@@ -288,7 +322,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     try:
-        rc = deploy(scope, args.hosts, check=check_mode(args.check), verbose=verbose)
+        rc = deploy(scope, args.hosts, check=check_mode(args.check), verbose=verbose, devices_only=args.devices_only)
     except FleetLockHeld as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 3

--- a/control/bin/termux_pkg_nightly.py
+++ b/control/bin/termux_pkg_nightly.py
@@ -27,7 +27,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from control.lib.ansible_context import AnsibleConfigError, require_inventory, resolve_ansible_context
+from control.lib.ansible_context import AnsibleConfigError, require_inventory, resolve_ansible_context, resolved_env
 from control.lib.fleet_deploy_lock import FleetLockHeld, fleet_lock
 
 PLAYBOOK = REPO_ROOT / "ansible" / "playbooks" / "fleet" / "termux-pkg-upgrade.yml"
@@ -96,9 +96,9 @@ def main(argv: list[str] | None = None) -> int:
     if check:
         cmd.extend(["--check", "--diff"])
 
-    env = os.environ.copy()
-    env["ANSIBLE_CONFIG"] = str(context.config)
-    env["STAYTURGID_ROOT"] = str(REPO_ROOT)
+    # resolved_env() also supplies ANSIBLE_ROLES_PATH/ANSIBLE_COLLECTIONS_PATH —
+    # without them ansible-playbook can't resolve stayturgid.termux.termux_pkg.
+    env = resolved_env(REPO_ROOT)
     # launchd has a minimal PATH; prefer Homebrew ansible.
     homebrew = "/opt/homebrew/bin:/usr/local/bin"
     env["PATH"] = homebrew + ":" + env.get("PATH", "/usr/bin:/bin")

--- a/control/lib/ansible_context.py
+++ b/control/lib/ansible_context.py
@@ -187,6 +187,12 @@ def resolved_env(repo_root: Path, environ: Mapping[str, str] | None = None) -> d
     env["ANSIBLE_COLLECTIONS_PATH"] = os.pathsep.join(
         dict.fromkeys(path for path in (*product_collections, *configured_collections.split(os.pathsep)) if path)
     )
+    # Real per-task timing (#57) regardless of which site's ansible.cfg is
+    # selected — ansible.posix is already a required collection dependency.
+    configured_callbacks = env.get("ANSIBLE_CALLBACKS_ENABLED", "")
+    env["ANSIBLE_CALLBACKS_ENABLED"] = ",".join(
+        dict.fromkeys(name for name in ("ansible.posix.profile_tasks", *configured_callbacks.split(",")) if name)
+    )
     return env
 
 

--- a/docs/operations/sessions/handoff-2026-07-29-issue-57-fleet-deploy-speed.md
+++ b/docs/operations/sessions/handoff-2026-07-29-issue-57-fleet-deploy-speed.md
@@ -42,9 +42,11 @@ Per the issue's `deploy_fleet.py:245` citation: `--limit <device>` never
 matches `localhost`, so `deploy()` always launched a second
 `ansible-playbook` process for `control_node/site.yml` even on a
 single-device run. `--devices-only` skips that second launch. Exposed via
-`just deploy devices_only=1 hosts=s24` too (env-var-style, matching the
-existing `hosts=`/`scope=` convention in the top-level `justfile` +
-`just/fleet.just`). `deploy-check` untouched — check mode already returns
+`just --set devices_only 1 --set hosts s24 deploy` too (`just`'s variable
+overrides go before the recipe name, not after — matching the existing
+`hosts=`/`scope=` convention in the top-level `justfile` + `just/fleet.just`,
+which are shell/`just`-level variables read via `env_var_or_default`, not
+recipe parameters). `deploy-check` untouched — check mode already returns
 before the Mac pass runs, so the flag would be a no-op there.
 
 ### 3. `ansible-galaxy collection install` caching (`control/bin/deploy_fleet.py`)

--- a/docs/operations/sessions/handoff-2026-07-29-issue-57-fleet-deploy-speed.md
+++ b/docs/operations/sessions/handoff-2026-07-29-issue-57-fleet-deploy-speed.md
@@ -1,0 +1,245 @@
+# Handoff: #57 fleet deploy speed (measure-first, per the issue's own order)
+
+**Session:** Agent 11, human-relayed orchestration chain (see
+`~/ai-orchestration-plan-2026-07-28.md`). **Worktree:**
+`~/src/ops-worktrees/fleet-deploy-speed-57/stayturgid` (branch
+`feature/fleet-deploy-speed-57`).
+
+## Context
+
+Issue #57 filed a deploy-speed analysis with an explicit suggested order:
+measure first with `ansible.posix.profile_tasks`, then only act on items the
+data actually supports. Followed that order exactly. Two of the five items
+were cheap/safe/unconditional and just got implemented; the other two
+(`strategy: free`, `termux-pkg-upgrade.yml`'s `serial: 1`) got real timing
+data collected via a live fleet deploy across s24/hd8/p7a, and the data
+argued against changing them — documented below rather than changed
+speculatively.
+
+## What shipped
+
+### 1. `ansible.posix.profile_tasks` wired in globally (`control/lib/ansible_context.py`)
+
+Added to `resolved_env()` — the single choke point already shared by every
+fleet entry point (`deploy_fleet.py`, `deploy_termux.py`,
+`termux_pkg_nightly.py`, `ansible_exec.py`, `firerpa_health_monitor.py`,
+`verify_drift.py`) — rather than to the repo's own `ansible/ansible.cfg` or
+the site overlay's `ansible.cfg`. Real production deploys read
+`~/ops/site-djbclark/ansible.cfg` (a separate repo, a deploy-only checkout
+per this session's `~/CLAUDE.md` policy — no worktree for it exists in this
+task, and none was needed), not this repo's own `ansible.cfg`. Putting it in
+`resolved_env()` means real per-task timing is on for every fleet entry
+point regardless of which site's `ansible.cfg` is selected, with no
+cross-repo change. Merges with any caller-set `ANSIBLE_CALLBACKS_ENABLED`
+instead of clobbering it (same `dict.fromkeys` pattern already used for
+`ANSIBLE_ROLES_PATH`/`ANSIBLE_COLLECTIONS_PATH` in the same function).
+`ansible.posix` is already a required collection dependency
+(`ansible/requirements.yml`) — no new dependency.
+
+### 2. `--devices-only` flag (`control/bin/deploy_fleet.py`)
+
+Per the issue's `deploy_fleet.py:245` citation: `--limit <device>` never
+matches `localhost`, so `deploy()` always launched a second
+`ansible-playbook` process for `control_node/site.yml` even on a
+single-device run. `--devices-only` skips that second launch. Exposed via
+`just deploy devices_only=1 hosts=s24` too (env-var-style, matching the
+existing `hosts=`/`scope=` convention in the top-level `justfile` +
+`just/fleet.just`). `deploy-check` untouched — check mode already returns
+before the Mac pass runs, so the flag would be a no-op there.
+
+### 3. `ansible-galaxy collection install` caching (`control/bin/deploy_fleet.py`)
+
+Hash `ansible/requirements.yml` (sha256), stamp it at
+`<collections_path>/.requirements-hash` after a successful install, skip the
+subprocess entirely when the stamp matches **and** `<collections_path>/ansible_collections/`
+still exists (so a manually-wiped collections dir can't silently pass a
+stale-but-matching stamp). `.ansible/collections/` is already gitignored, so
+the stamp never gets committed. Measured on this machine: cold
+(forced-reinstall) `install_collections()` call = 0.588s; warm-cache skip =
+0.002s. Small in absolute terms but it's pure fixed tax paid on every single
+deploy invocation, including tiny `--limit oneui-device --devices-only`
+iterate-on-one-device runs where it was proportionally the biggest single
+cost after the fix above.
+
+### 4. Real bug found + fixed: `termux_pkg_nightly.py` was broken in production
+
+While setting up to gather `serial: 1` timing data (item 5 below) via
+`CHECK=1 python3 control/bin/termux_pkg_nightly.py`, hit:
+
+```
+[ERROR]: couldn't resolve module/action 'stayturgid.termux.termux_pkg'.
+```
+
+Checked `~/.config/stayturgid/logs/termux-pkg-nightly.log` (the real nightly
+launchd job's log, not just this session's run) — **this has been failing
+with `rc=4` on every single invocation since 2026-07-28 00:04**, i.e. the
+nightly package-upgrade job has been silently no-op-ing in production for
+about a day and a half. Root cause: `termux_pkg_nightly.py` built its own
+subprocess `env` by hand (`os.environ.copy()` + manually setting
+`ANSIBLE_CONFIG`/`STAYTURGID_ROOT`) instead of calling the shared
+`resolved_env()` helper every other entry point uses — so it never got
+`ANSIBLE_ROLES_PATH`/`ANSIBLE_COLLECTIONS_PATH`, and `ansible-playbook`
+couldn't resolve the `stayturgid.termux` collection (which lives directly
+under this repo checkout, discoverable only via that env var). Fixed by
+switching to `resolved_env(REPO_ROOT)` (same one-line pattern
+`deploy_termux.py` already uses), keeping the existing launchd-minimal-PATH
+prefix logic layered on top. Re-ran the same dry-run afterward — clean,
+`rc=0`, all three hosts converge correctly (see timing data below). Updated
+`tests/python/test_termux_pkg_nightly.py`'s existing
+`test_nightly_runner_uses_resolved_site_config` to mock `resolved_env`
+directly (matching how `test_deploy_fleet.py` mocks `install_collections`/
+`run_playbook` wholesale rather than letting real env-resolution logic run
+during a unit test) instead of relying on the mocked `resolve_ansible_context`
+to propagate through — the previous test happened to pass only because
+nothing exercised the broken code path.
+
+**This was orthogonal to #57 but blocked verifying item 5**, and is a small,
+obviously-correct, well-tested fix, so I fixed it rather than working around
+it.
+
+## Live fleet deploy — real timing data (per issue's step 1)
+
+All three devices (s24, hd8, p7a) confirmed reachable via both USB and
+Tailscale at the start of this session; inventory shows all three as active
+`stayturgid` group members (no `stayturgid_fleet_status: offline` flag —
+p7a's earlier offline flag from Agent 1's session has since been resolved).
+
+Ran a real, non-check `python3 control/bin/deploy_fleet.py` (full fleet,
+default scope) with `profile_tasks` active. Device-play (site.yml minus the
+Mac pass) total: **11m16s** (`0:11:16.494`), `failed=0` on all three hosts.
+Top task costs from the `TASKS RECAP`:
+
+```
+Deploy Python runtime scripts to ~/.stayturgid/bin -- 81.90s
+Verify the repair script runs ------ 43.04s
+Run stayturgid-repair and parse STATUS ----- 42.24s
+Deploy battery color assets -------- 33.91s
+Install fleet SSH private keys on device -- 24.26s
+Deploy shared libs to ~/.stayturgid/lib -- 23.92s
+```
+
+Then, to isolate per-host cost (profile_tasks alone only gives per-task
+aggregate time, not a per-host breakdown), ran three separate real
+`--devices-only <host>` passes back to back against the now-converged fleet
+(near-idempotent, `changed≈0` runs — safe, not a repeat of the earlier
+mutating deploy):
+
+| Host | Real time (full device play, solo) |
+|------|-------------------------------------|
+| s24  | 318.58s (~5m19s) |
+| p7a  | 421.64s (~7m02s) |
+| hd8  | 492.38s (~8m12s) |
+
+Confirms the issue's suspicion — hd8 (Fire OS) is the slowest device — but
+also shows **p7a is meaningfully slower than s24 too** (32% slower), not
+just hd8 alone. Sum of solo times = 1232.6s vs. the actual combined
+3-host `linear` run at 676s — `linear` already runs each task across hosts
+concurrently (it's not literally sequential per-host; the barrier is
+per-task, not per-host), so the real ceiling `strategy: free` could
+theoretically reclaim is bounded by `676s - 492s ≈ 184s` (~27%), since
+hd8's own 492s of real work is a hard floor no ansible strategy can avoid.
+
+## Why `strategy: free` was NOT implemented (item 4) — real correctness risk, not just readability
+
+The issue's own hedge was right, but the actual reason turned out to be
+stronger than "log readability": grepped every device-targeting play/role
+for `run_once`/`hostvars[` and found **real cross-host data dependencies**
+that rely on `linear`'s per-task synchronization barrier for correctness:
+
+- `ansible_collections/stayturgid/termux/roles/termux_userland/tasks/ssh_keys.yml:149` —
+  `hostvars[item].stayturgid_device_ssh_pubkey` when installing the fleet
+  SSH mesh `authorized_keys` on every host, looped over
+  `groups[stayturgid_ssh_mesh_group]`. Needs every other host's pubkey fact
+  to already be set by the time this host reaches this task.
+- `ansible_collections/stayturgid/termux/roles/termux_userland/tasks/main.yml:100,112` —
+  `run_once: true` + `delegate_to: localhost` CFEngine policy build; a later
+  task (`Deploy CFEngine Build artifact to device`) on **every** host copies
+  the artifact this task builds.
+- `.../tasks/otelcol.yml:9,19,30,49` — four `run_once: true` +
+  `delegate_to: localhost` health/cache-verification checks (Vector, OTLP,
+  OpenObserve, otelcol-contrib archive cache) gating the per-host otelcol
+  deploy tasks that follow.
+- `.../tasks/fleet_adbkey.yml:11,21` — `run_once: true` fleet ADB key stat,
+  read by every host afterward.
+
+Under `linear`, all hosts synchronize at every task boundary, so any
+`run_once` task's side effect (a built artifact, a verified cache, a stat
+result) is guaranteed available to every host by the time it reaches later
+tasks that depend on it, and every host's own facts are guaranteed visible
+via `hostvars[]` to every other host in the same play. `strategy: free`
+removes that barrier entirely — hosts race ahead independently. Ansible's
+own docs flag `run_once` under `free` as unreliable (no guarantee it runs
+exactly once before dependents need its result, and a fast host can reach a
+`hostvars[other_host]`-dependent task before that other host has set the
+fact). Concretely: under `free`, a fast s24 could reach the SSH mesh task
+before hd8's own pubkey fact is set, silently skip installing hd8's key
+(the `when: hostvars[item]... is defined` guard just evaluates false — no
+error, no warning), and leave the SSH mesh quietly incomplete. Same failure
+shape for the CFEngine artifact (file not found or stale) and the otelcol
+health gates.
+
+Given the timing data only supports a bounded ~27% ceiling anyway, and the
+correctness risk is real (not hypothetical) and touches three independent
+subsystems inside a role shared by every device-targeting play, this is not
+a "worth the log-readability tradeoff" decision — it's a "don't do this
+without a real refactor" decision. Left `strategy` unset (linear, the
+default) everywhere. If this is revisited later, the CFEngine
+build/otelcol-verification/ADB-key-stat `run_once` tasks would need to move
+to a small `serial`-safe pre-play (or `hosts: localhost` play) ahead of the
+device-targeting play, and the SSH mesh task would need the pubkey facts
+gathered in an earlier, still-`linear` play before any `free` play runs —
+nontrivial restructuring, not a one-line `strategy: free` addition.
+
+## Why `termux-pkg-upgrade.yml`'s `serial: 1` was left unchanged (item 5)
+
+`termux-pkg-upgrade.yml` is **not** part of the normal `site.yml`/`just
+deploy` chain — it's a separate playbook run only via nightly launchd
+(`com.stayturgid.termux-pkg-nightly`) or `just termux-pkg-upgrade`, so the
+step-1 timing data above doesn't cover it at all. Ran a safe, non-mutating
+`CHECK=1 python3 control/bin/termux_pkg_nightly.py` (all three hosts) after
+fixing the bug above: total wall time **27.05s**, `serial: 1` (s24 → p7a →
+hd8 sequentially, ~9-12s each including mirror-pin + package-index-check
+round trips over SSH). Removing `serial: 1` would save roughly two of those
+per-host slices (~18s, since 3 hosts would run concurrently instead of
+sequentially) for this dry-run case — real, but modest in absolute terms
+for a job nobody waits on interactively.
+
+Left unchanged: this is an **unattended nightly job** (currently running at
+04:15 local per the log), not something in `just deploy`'s interactive path,
+so shaving ~18s off it has no user-facing latency benefit. The issue's own
+hedge — "possibly intentional (bandwidth/safety)" — is the more important
+consideration: `serial: 1` means if a mirror hiccup or partial
+`apt-get full-upgrade` corrupts package state, it happens to one device at a
+time with the other two still in a known-good state, rather than all three
+simultaneously. Given the modest speed upside and the real, if unquantified,
+blast-radius downside for an unattended fleet-wide package mutation, kept
+the current default. The var (`stayturgid_termux_pkg_upgrade_serial`) is
+already overridable per-host/group if this default is ever reconsidered.
+
+## Verification
+
+```
+cd ~/src/ops-worktrees/fleet-deploy-speed-57/stayturgid
+just worktree-setup   # fresh worktree — .venv-test, node_modules, .ansible/collections
+just check            # clean
+just test             # clean (all pytest/ansible-test/shell-unit suites)
+```
+
+Live (real devices, not a dry run):
+```
+python3 control/bin/deploy_fleet.py                    # full fleet, confirmed failed=0 on s24/hd8/p7a
+python3 control/bin/deploy_fleet.py --devices-only s24  # confirmed no second control_node/site.yml launch
+CHECK=1 python3 control/bin/termux_pkg_nightly.py       # confirmed rc=0 after the bugfix, was rc=4 before
+```
+
+## Not done / left open
+
+- `strategy: free` and `termux-pkg-upgrade.yml`'s `serial: 1` — evaluated
+  with real data, deliberately not changed (see above). Any future attempt
+  at `free` needs the `run_once`/`hostvars[]` restructuring described above
+  first, not just flipping the setting.
+- No further profiling/tuning attempted beyond what's above — the two
+  cheap/safe items (`--devices-only`, collection-install caching) are the
+  real, unconditional wins from this issue; the other two needed the
+  correctness/blast-radius analysis this handoff documents instead of a
+  code change.

--- a/docs/operations/sessions/handoff-2026-07-29-issue-57-fleet-deploy-speed.md
+++ b/docs/operations/sessions/handoff-2026-07-29-issue-57-fleet-deploy-speed.md
@@ -125,10 +125,10 @@ aggregate time, not a per-host breakdown), ran three separate real
 mutating deploy):
 
 | Host | Real time (full device play, solo) |
-|------|-------------------------------------|
-| s24  | 318.58s (~5m19s) |
-| p7a  | 421.64s (~7m02s) |
-| hd8  | 492.38s (~8m12s) |
+| ---- | ---------------------------------- |
+| s24  | 318.58s (~5m19s)                   |
+| p7a  | 421.64s (~7m02s)                   |
+| hd8  | 492.38s (~8m12s)                   |
 
 Confirms the issue's suspicion — hd8 (Fire OS) is the slowest device — but
 also shows **p7a is meaningfully slower than s24 too** (32% slower), not
@@ -226,6 +226,7 @@ just test             # clean (all pytest/ansible-test/shell-unit suites)
 ```
 
 Live (real devices, not a dry run):
+
 ```
 python3 control/bin/deploy_fleet.py                    # full fleet, confirmed failed=0 on s24/hd8/p7a
 python3 control/bin/deploy_fleet.py --devices-only s24  # confirmed no second control_node/site.yml launch

--- a/just/fleet.just
+++ b/just/fleet.just
@@ -5,7 +5,7 @@
 
 # ---------- Deploy ----------
 _deploy_impl:
-    python3 control/bin/deploy_fleet.py {{ deploy_args }} {{ deploy_scope_arg }}
+    python3 control/bin/deploy_fleet.py {{ deploy_args }} {{ deploy_scope_arg }} {{ deploy_devices_only_arg }}
 
 deploy-legacy:
     @just _deploy_impl

--- a/justfile
+++ b/justfile
@@ -3,6 +3,7 @@
 # Variables (optional on most recipes):
 #   hosts=oneui-device       Limit to one or more inventory hosts: just deploy hosts=oneui-device fireos-device
 #   scope=full      Deploy scope: full | fdroid | play | app-stores
+#   devices_only=1  Skip the Mac control_node pass (#57) — for iterating on one device
 #
 # Quick start:
 #   just help           → show this listing
@@ -18,9 +19,11 @@ ansible_playbook := "python3 control/bin/ansible_exec.py ansible-playbook"
 
 hosts := env_var_or_default("hosts", "")
 scope := env_var_or_default("scope", "full")
+devices_only := env_var_or_default("devices_only", "")
 
 deploy_args := env_var_or_default("deploy_args", if hosts == "" { "" } else { hosts })
 deploy_scope_arg := env_var_or_default("deploy_scope_arg", if scope == "full" { "" } else { "--scope " + scope })
+deploy_devices_only_arg := env_var_or_default("deploy_devices_only_arg", if devices_only == "" { "" } else { "--devices-only" })
 limit_flag := env_var_or_default("limit_flag", if hosts == "" { "" } else { "-l " + hosts })
 
 mac_site := "ansible/playbooks/control_node/site.yml"

--- a/tests/python/test_ansible_context.py
+++ b/tests/python/test_ansible_context.py
@@ -266,3 +266,48 @@ def test_resolved_env_preserves_additional_ansible_search_paths(tmp_path):
 
     assert env["ANSIBLE_ROLES_PATH"] == f"{tmp_path / 'ansible' / 'roles'}:/site/roles"
     assert env["ANSIBLE_COLLECTIONS_PATH"] == (f"{tmp_path / '.ansible' / 'collections'}:{tmp_path}:/site/collections")
+
+
+def test_resolved_env_enables_profile_tasks_callback(tmp_path):
+    """#57: real per-task timing must be on regardless of the selected site config."""
+    site = tmp_path / "site"
+    site.mkdir()
+    config = write_config(site)
+    (site / "inventory").mkdir()
+    (site / "inventory" / "hosts.yml").write_text("all: {}\n", encoding="utf-8")
+
+    env = ac.resolved_env(tmp_path, {"ANSIBLE_CONFIG": str(config)})
+
+    assert env["ANSIBLE_CALLBACKS_ENABLED"] == "ansible.posix.profile_tasks"
+
+
+def test_resolved_env_preserves_additional_callbacks(tmp_path):
+    """A caller-configured callback list keeps its entries alongside profile_tasks."""
+    site = tmp_path / "site"
+    site.mkdir()
+    config = write_config(site)
+    (site / "inventory").mkdir()
+    (site / "inventory" / "hosts.yml").write_text("all: {}\n", encoding="utf-8")
+
+    env = ac.resolved_env(
+        tmp_path,
+        {"ANSIBLE_CONFIG": str(config), "ANSIBLE_CALLBACKS_ENABLED": "community.general.diy"},
+    )
+
+    assert env["ANSIBLE_CALLBACKS_ENABLED"] == "ansible.posix.profile_tasks,community.general.diy"
+
+
+def test_resolved_env_does_not_duplicate_profile_tasks(tmp_path):
+    """If a site already enables profile_tasks explicitly, don't list it twice."""
+    site = tmp_path / "site"
+    site.mkdir()
+    config = write_config(site)
+    (site / "inventory").mkdir()
+    (site / "inventory" / "hosts.yml").write_text("all: {}\n", encoding="utf-8")
+
+    env = ac.resolved_env(
+        tmp_path,
+        {"ANSIBLE_CONFIG": str(config), "ANSIBLE_CALLBACKS_ENABLED": "ansible.posix.profile_tasks"},
+    )
+
+    assert env["ANSIBLE_CALLBACKS_ENABLED"] == "ansible.posix.profile_tasks"

--- a/tests/python/test_deploy_fleet.py
+++ b/tests/python/test_deploy_fleet.py
@@ -107,6 +107,55 @@ def test_resolve_hosts_explicit():
     assert df.resolve_hosts(["oneui-device"]) == ["oneui-device"]
 
 
+class _FakeContext:
+    def __init__(self, collections_path):
+        self.collections_path = collections_path
+
+
+def _stub_install_collections_context(monkeypatch, tmp_path):
+    monkeypatch.setattr(df, "resolve_ansible_context", lambda root: _FakeContext(tmp_path))
+
+
+def test_install_collections_runs_when_no_stamp(monkeypatch, tmp_path):
+    calls = []
+    _stub_install_collections_context(monkeypatch, tmp_path)
+    monkeypatch.setattr(df.subprocess, "run", lambda *a, **k: calls.append(a))
+    df.install_collections()
+    assert len(calls) == 1
+    assert (tmp_path / ".requirements-hash").read_text().strip() == df._requirements_hash()
+
+
+def test_install_collections_skips_when_hash_matches_and_installed(monkeypatch, tmp_path):
+    calls = []
+    _stub_install_collections_context(monkeypatch, tmp_path)
+    monkeypatch.setattr(df.subprocess, "run", lambda *a, **k: calls.append(a))
+    (tmp_path / "ansible_collections").mkdir()
+    (tmp_path / ".requirements-hash").write_text(df._requirements_hash())
+    df.install_collections()
+    assert calls == []
+
+
+def test_install_collections_reruns_when_hash_stale(monkeypatch, tmp_path):
+    calls = []
+    _stub_install_collections_context(monkeypatch, tmp_path)
+    monkeypatch.setattr(df.subprocess, "run", lambda *a, **k: calls.append(a))
+    (tmp_path / "ansible_collections").mkdir()
+    (tmp_path / ".requirements-hash").write_text("stale-hash")
+    df.install_collections()
+    assert len(calls) == 1
+    assert (tmp_path / ".requirements-hash").read_text().strip() == df._requirements_hash()
+
+
+def test_install_collections_reruns_when_collections_dir_missing(monkeypatch, tmp_path):
+    """Hash matching a stamp doesn't matter if the collections were removed."""
+    calls = []
+    _stub_install_collections_context(monkeypatch, tmp_path)
+    monkeypatch.setattr(df.subprocess, "run", lambda *a, **k: calls.append(a))
+    (tmp_path / ".requirements-hash").write_text(df._requirements_hash())
+    df.install_collections()
+    assert len(calls) == 1
+
+
 def _stub_deploy_deps(monkeypatch, calls, *, playbook_rc=0):
     monkeypatch.setattr(df, "require_ansible", lambda: None)
     monkeypatch.setattr(df, "warn_prerequisites", lambda scope: None)
@@ -142,6 +191,27 @@ def test_deploy_always_runs_mac_even_without_host_limit(monkeypatch):
     assert rc == 0
     assert ("playbook", "mac", False, None) in calls
     assert calls[-1] == ("playbook", "mac", False, None)
+
+
+def test_deploy_devices_only_skips_mac_pass(monkeypatch):
+    """#57: --devices-only must not launch the second control_node/site.yml pass."""
+    calls = []
+    _stub_deploy_deps(monkeypatch, calls)
+    rc = df.deploy(df.Scope.FULL, ["oneui-device"], check=False, devices_only=True)
+    assert rc == 0
+    assert calls == [
+        ("playbook", None, False, "bootstrap"),
+    ]
+
+
+def test_deploy_devices_only_still_reports_device_playbook_failure(monkeypatch):
+    calls = []
+    _stub_deploy_deps(monkeypatch, calls, playbook_rc=2)
+    rc = df.deploy(df.Scope.FULL, ["oneui-device"], check=False, devices_only=True)
+    assert rc == 2
+    assert calls == [
+        ("playbook", None, False, "bootstrap"),
+    ]
 
 
 def test_deploy_check_skips_mutating_bootstrap_tag(monkeypatch):
@@ -184,6 +254,32 @@ def test_deploy_blocks_concurrent_run(monkeypatch):
         with pytest.raises(df.FleetLockHeld):
             df.deploy(df.Scope.FULL, ["oneui-device"], check=False)
     assert calls == []
+
+
+def test_main_passes_devices_only_flag(monkeypatch):
+    seen = {}
+
+    def fake_deploy(scope, hosts, *, check, verbose=0, devices_only=False):
+        seen["devices_only"] = devices_only
+        return 0
+
+    monkeypatch.setattr(df, "deploy", fake_deploy)
+    rc = df.main(["--devices-only", "oneui-device"])
+    assert rc == 0
+    assert seen["devices_only"] is True
+
+
+def test_main_defaults_devices_only_false(monkeypatch):
+    seen = {}
+
+    def fake_deploy(scope, hosts, *, check, verbose=0, devices_only=False):
+        seen["devices_only"] = devices_only
+        return 0
+
+    monkeypatch.setattr(df, "deploy", fake_deploy)
+    rc = df.main(["oneui-device"])
+    assert rc == 0
+    assert seen["devices_only"] is False
 
 
 def test_main_reports_lock_conflict_with_exit_code_3(monkeypatch):

--- a/tests/python/test_termux_pkg_nightly.py
+++ b/tests/python/test_termux_pkg_nightly.py
@@ -14,6 +14,11 @@ def test_nightly_runner_uses_resolved_site_config(monkeypatch, tmp_path):
     seen = {}
 
     monkeypatch.setattr(nightly, "resolve_ansible_context", lambda repo: context)
+    monkeypatch.setattr(
+        nightly,
+        "resolved_env",
+        lambda repo: {"ANSIBLE_CONFIG": str(context.config), "STAYTURGID_ROOT": str(repo), "PATH": "/usr/bin:/bin"},
+    )
     monkeypatch.setattr(nightly, "require_inventory", lambda selected: None)
     monkeypatch.setattr(nightly, "LOG_DIR", tmp_path / "logs")
     monkeypatch.setattr(nightly, "LOG", tmp_path / "logs" / "nightly.log")


### PR DESCRIPTION
## Summary

Follows #57's own measure-first suggested order.

- Wire in `ansible.posix.profile_tasks` globally via `resolved_env()` (the shared choke point for every fleet entry point) rather than a repo/site-specific `ansible.cfg` — works regardless of which site overlay is selected, no cross-repo change needed.
- Add `--devices-only` flag to `deploy_fleet.py` to skip the redundant `control_node/site.yml` Mac pass on a `--limit <device>` run (also exposed via `just deploy devices_only=1`).
- Cache/skip `ansible-galaxy collection install` via a `requirements.yml` hash stamp in `.ansible/collections/` when nothing changed.
- **Real bug fix found along the way**: `termux_pkg_nightly.py` built its own subprocess env by hand instead of using the shared `resolved_env()` helper, so it never got `ANSIBLE_COLLECTIONS_PATH` — the nightly Termux package-upgrade launchd job has been silently failing (`rc=4`) on every run since 2026-07-28. Fixed.

## Data-driven non-changes

Ran a live fleet deploy across s24/hd8/p7a with `profile_tasks` to evaluate the issue's other two suggestions:

- **`strategy: free`**: NOT implemented. Real per-host timing shows a bounded ~27% ceiling at best (hd8 alone takes 492s solo, the combined linear run is 676s), but more importantly found genuine cross-host correctness dependencies (`hostvars[]` SSH-mesh install, `run_once` CFEngine build/otelcol health gates/ADB key stat) inside `termux_userland` that rely on `linear`'s per-task sync barrier. Flipping to `free` risks silently incomplete SSH mesh / stale build artifacts, not just less-readable logs as the issue speculated.
- **`termux-pkg-upgrade.yml`'s `serial: 1`**: left unchanged. Measured ~18s theoretical savings on an unattended nightly job — not worth the blast-radius cost of simultaneous fleet-wide package mutation with no human watching.

Full data, citations, and reasoning: `docs/operations/sessions/handoff-2026-07-29-issue-57-fleet-deploy-speed.md`.

## Test plan

- [x] `just check` clean
- [x] `just test` clean (all pytest/ansible-test/shell-unit suites)
- [x] Live: `python3 control/bin/deploy_fleet.py` (full fleet) — `failed=0` on s24/hd8/p7a
- [x] Live: `python3 control/bin/deploy_fleet.py --devices-only s24` — confirmed no second `control_node/site.yml` launch
- [x] Live: `CHECK=1 python3 control/bin/termux_pkg_nightly.py` — confirmed `rc=0` after the bugfix (was `rc=4` before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `--devices-only` deployment option to skip the redundant control-node pass for single-device runs.
  - Added Ansible collection installation caching to avoid re-installing when dependencies haven’t changed.
  - Deployment can now enable devices-only mode via the CLI/automation environment.
- **Bug Fixes**
  - Improved nightly upgrade execution environment so Ansible path resolution is reliable.
  - Enabled consistent per-task timing by ensuring the profiling callback is set/merged correctly.
- **Documentation**
  - Added updated operational handoff notes with performance measurements and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->