### PR TITLE
feat: implement FIRERPA FastMCP bridge and deployment tasks

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "firerpa": {
+      "command": "/Users/djbclark/.venv-stayturgid-firerpa/bin/python",
+      "args": [
+        "control/bin/firerpa_mcp.py",
+        "--transport",
+        "stdio"
+      ]
+    }
+  }
+}

--- a/ansible/roles/control_node/tasks/agents.yml
+++ b/ansible/roles/control_node/tasks/agents.yml
@@ -290,6 +290,14 @@
   when: stayturgid_firerpa_health_enabled | default(true) | bool
   register: firerpa_health_plist
 
+- name: Render FIRERPA MCP bridge launchd agent
+  ansible.builtin.template:
+    src: firerpa-mcp.plist.j2
+    dest: "{{ agents_dir }}/com.stayturgid.firerpa-mcp.plist"
+    mode: "0644"
+  when: stayturgid_firerpa_mcp_enabled | default(true) | bool
+  register: firerpa_mcp_plist
+
 - name: Remove FIRERPA health launchd agent when disabled
   ansible.builtin.file:
     path: "{{ agents_dir }}/com.stayturgid.firerpa-health.plist"
@@ -302,6 +310,20 @@
     name: com.stayturgid.firerpa-health
     state: unloaded
   when: firerpa_health_removed.changed
+  failed_when: false
+
+- name: Remove FIRERPA MCP bridge launchd agent when disabled
+  ansible.builtin.file:
+    path: "{{ agents_dir }}/com.stayturgid.firerpa-mcp.plist"
+    state: absent
+  when: not (stayturgid_firerpa_mcp_enabled | default(true) | bool)
+  register: firerpa_mcp_removed
+
+- name: Unload FIRERPA MCP bridge when disabled
+  community.general.launchd:
+    name: com.stayturgid.firerpa-mcp
+    state: unloaded
+  when: firerpa_mcp_removed.changed
   failed_when: false
 
 - name: Render fleet dashboard launchd agent
@@ -368,6 +390,14 @@
             stayturgid_firerpa_health_enabled | default(true) | bool
             and firerpa_health_plist is defined
             and firerpa_health_plist.changed
+          ) else []
+        )
+        + (
+          ['com.stayturgid.firerpa-mcp']
+          if (
+            stayturgid_firerpa_mcp_enabled | default(true) | bool
+            and firerpa_mcp_plist is defined
+            and firerpa_mcp_plist.changed
           ) else []
         )
         + (

--- a/ansible/roles/control_node/tasks/agents_ensure.yml
+++ b/ansible/roles/control_node/tasks/agents_ensure.yml
@@ -14,6 +14,11 @@
     path: "{{ agents_dir }}/com.stayturgid.firerpa-health.plist"
   register: _firerpa_health_plist_stat
 
+- name: Stat FIRERPA MCP launchd plist
+  ansible.builtin.stat:
+    path: "{{ agents_dir }}/com.stayturgid.firerpa-mcp.plist"
+  register: _firerpa_mcp_plist_stat
+
 - name: Stat fleet dashboard launchd plist
   ansible.builtin.stat:
     path: "{{ agents_dir }}/{{ stayturgid_dashboard_label }}.plist"
@@ -31,6 +36,7 @@
         + _opencode_web_agents
         + _dashboard_agents
         + _firerpa_health_agents
+        + _firerpa_mcp_agents
       }}
   vars:
     _core_launchd_agents:
@@ -80,6 +86,16 @@
           'plist': agents_dir ~ '/com.stayturgid.firerpa-health.plist'
         }] if (
           (stayturgid_firerpa_health_enabled | default(true) | bool)
+        ) else []
+      }}
+    _firerpa_mcp_agents: >-
+      {{
+        [{
+          'name': 'com.stayturgid.firerpa-mcp',
+          'plist': agents_dir ~ '/com.stayturgid.firerpa-mcp.plist'
+        }] if (
+          (stayturgid_firerpa_mcp_enabled | default(true) | bool)
+          and (_firerpa_mcp_plist_stat.stat.exists | default(false))
         ) else []
       }}
     _termux_pkg_nightly_agents: >-

--- a/ansible/roles/control_node/templates/firerpa-mcp.plist.j2
+++ b/ansible/roles/control_node/templates/firerpa-mcp.plist.j2
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.stayturgid.firerpa-mcp</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{ ansible_env.HOME }}/.venv-stayturgid-firerpa/bin/python</string>
+        <string>{{ stayturgid_repo_root | realpath }}/control/bin/firerpa_mcp.py</string>
+        <string>--transport</string>
+        <string>streamable-http</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>{{ stayturgid_homebrew_prefix }}/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>WorkingDirectory</key>
+    <string>{{ stayturgid_repo_root | realpath }}</string>
+    <key>StandardOutPath</key>
+    <string>{{ conf_dir }}/logs/firerpa-mcp.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{ conf_dir }}/logs/firerpa-mcp.error.log</string>
+</dict>
+</plist>

--- a/control/bin/firerpa_heal.py
+++ b/control/bin/firerpa_heal.py
@@ -183,24 +183,27 @@ def heal_device(host: str, port: int = 65000) -> dict[str, str]:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Repair stayturgid via FIRERPA gRPC API.")
-    parser.add_argument("--host", help="Target host alias (oneui-device, stock-android-device, fireos-device)")
+    parser.add_argument("--host", help="Target host alias (e.g., s24, p7a, hd8)")
     parser.add_argument("--all", action="store_true", help="Heal all fleet devices")
     parser.add_argument("--port", type=int, default=65000)
     args = parser.parse_args(argv)
 
-    fleet = {
-        "oneui-device": "100.0.0.11",
-        "stock-android-device": "100.0.0.12",
-        "fireos-device": "100.0.0.13",
-    }
+    from control.lib.firerpa_fleet import get_fleet
 
+    fleet = get_fleet()
+    if not fleet:
+        print("No active devices found in inventory.", file=sys.stderr)
+        return 1
+
+    targets = {}
     if args.host:
-        if args.host not in fleet:
-            print(f"Unknown host: {args.host}. Known: {sorted(fleet)}", file=sys.stderr)
+        target = next((t for t in fleet if t.alias == args.host), None)
+        if not target:
+            print(f"Unknown host: {args.host}. Known: {[t.alias for t in fleet]}", file=sys.stderr)
             return 1
-        targets = {args.host: fleet[args.host]}
+        targets[target.alias] = target.ip
     elif args.all:
-        targets = fleet
+        targets = {t.alias: t.ip for t in fleet if t.enabled}
     else:
         print("Specify --host <alias> or --all", file=sys.stderr)
         return 1
@@ -211,7 +214,7 @@ def main(argv: list[str] | None = None) -> int:
         try:
             results = heal_device(ip, args.port)
             if results.get("firerpa") == "unreachable":
-                if alias == "fireos-device":
+                if alias == "hd8":
                     _log(INFO, "%s: FIRERPA not running (expected)" % alias)
                 rc = 1
         except Exception as e:

--- a/control/bin/firerpa_health_monitor.py
+++ b/control/bin/firerpa_health_monitor.py
@@ -18,7 +18,6 @@ import os
 import subprocess
 import sys
 import time
-from dataclasses import dataclass
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -36,24 +35,8 @@ try:
 except ImportError:
     Device = None
 
-import json
 
-from control.lib.ansible_context import resolve_ansible_context, resolved_env
-
-
-@dataclass(frozen=True)
-class FirerpaTarget:
-    """Inventory-derived FIRERPA policy for one Android host."""
-
-    alias: str
-    ip: str
-    usb_serial: str = ""
-    enabled: bool = True
-    runtime_status: str = "supported"
-    recovery_mode: str = "none"
-    port: int = 65000
-    certificate_device_path: str = "/data/local/tmp/firerpa/server/lamda.pem"
-
+from control.lib.firerpa_fleet import FirerpaTarget, get_fleet
 
 LIFECYCLE = (
     REPO_ROOT
@@ -70,64 +53,6 @@ RECOVERY_MODE_CONTROL_NODE_ADB = "control-node-adb"
 # takes about five minutes before FIRERPA's gRPC endpoint is usable.
 RECOVERY_READY_ATTEMPTS = 30
 RECOVERY_READY_INTERVAL_SECONDS = 10
-
-
-def _as_bool(value: object, default: bool) -> bool:
-    if value is None:
-        return default
-    if isinstance(value, bool):
-        return value
-    return str(value).strip().lower() in {"1", "true", "yes", "on"}
-
-
-def get_fleet() -> list[FirerpaTarget]:
-    context = resolve_ansible_context(REPO_ROOT)
-    env = resolved_env(REPO_ROOT)
-
-    result = subprocess.run(
-        ["ansible-inventory", "--list", *context.inventory_args()],
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        print("Failed to resolve inventory: " + result.stderr, file=sys.stderr)
-        return []
-
-    inv = json.loads(result.stdout)
-    hosts = inv.get("stayturgid", {}).get("hosts", [])
-    if not hosts:
-        # Fallback to children of stayturgid if it's a group of groups
-        for child_group in inv.get("stayturgid", {}).get("children", []):
-            hosts.extend(inv.get(child_group, {}).get("hosts", []))
-
-    hostvars = inv.get("_meta", {}).get("hostvars", {})
-
-    fleet = []
-    for host in hosts:
-        variables = hostvars.get(host, {})
-        ip = variables.get("ansible_host")
-        if ip:
-            fleet.append(
-                FirerpaTarget(
-                    alias=host,
-                    ip=str(ip),
-                    usb_serial=str(variables.get("device_usb_serial", "")),
-                    enabled=_as_bool(variables.get("firerpa_enabled"), True),
-                    runtime_status=str(variables.get("firerpa_runtime_status", "supported")),
-                    recovery_mode=str(variables.get("firerpa_recovery_mode", "none")),
-                    port=int(variables.get("firerpa_port", 65000)),
-                    certificate_device_path=str(
-                        variables.get(
-                            "firerpa_certificate_device_path",
-                            "/data/local/tmp/firerpa/server/lamda.pem",
-                        )
-                    ),
-                )
-            )
-
-    return fleet
 
 
 def check_device(alias: str, ip: str, port: int = 65000) -> dict:

--- a/control/bin/firerpa_mcp.py
+++ b/control/bin/firerpa_mcp.py
@@ -21,6 +21,13 @@ from control.lib.firerpa_consent import HealSession, check_consent
 from control.lib.firerpa_fleet import get_fleet
 from control.lib.site_logging import WARNING, log
 
+LOG_NAME = "firerpa-mcp.log"
+
+
+def _log(level: int, msg: str) -> None:
+    log(LOG_NAME, level, msg, also_print=True)
+
+
 try:
     from lamda.client import Device
 except ImportError:
@@ -245,8 +252,7 @@ def main():
         if token:
             app.add_middleware(TokenAuthMiddleware, token=token)
         else:
-            print("WARNING: Starting HTTP transport without token authentication. This is insecure!", file=sys.stderr)
-            log(WARNING, "Starting HTTP transport without token authentication.")
+            _log(WARNING, "Starting HTTP transport without token authentication. This is insecure!")
 
         host = args.host or get_tailscale_ip()
         uvicorn.run(app, host=host, port=args.port)

--- a/control/bin/firerpa_mcp.py
+++ b/control/bin/firerpa_mcp.py
@@ -25,7 +25,10 @@ LOG_NAME = "firerpa-mcp.log"
 
 
 def _log(level: int, msg: str) -> None:
-    log(LOG_NAME, level, msg, also_print=True)
+    # stdout is the MCP stdio transport's JSON-RPC protocol channel when
+    # this server runs with --transport stdio — never print diagnostics
+    # there, the log file is the only sink.
+    log(LOG_NAME, level, msg)
 
 
 try:

--- a/control/bin/firerpa_mcp.py
+++ b/control/bin/firerpa_mcp.py
@@ -1,0 +1,223 @@
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+import uvicorn
+from mcp.server.fastmcp import Context, FastMCP
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+import control.bin.firerpa_heal as heal
+from control.lib.firerpa_auth import certificate_path
+from control.lib.firerpa_consent import HealSession, check_consent
+from control.lib.firerpa_fleet import get_fleet
+
+try:
+    from lamda.client import Device
+except ImportError:
+    Device = None
+
+
+def get_bearer_token() -> str | None:
+    path = os.path.expanduser("~/.config/stayturgid/secretspec.toml")
+    if not os.path.exists(path):
+        return None
+    try:
+        import tomllib
+    except ImportError:
+        try:
+            import tomli as tomllib
+        except ImportError:
+            return None
+    try:
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+        return data.get("firerpa_mcp_token")
+    except Exception:
+        return None
+
+
+def get_tailscale_ip() -> str:
+    res = subprocess.run(["tailscale", "ip", "-4"], capture_output=True, text=True, check=False)
+    if res.returncode == 0:
+        for line in res.stdout.strip().splitlines():
+            line = line.strip()
+            if line and not line.startswith("Warning"):
+                return line
+    return "127.0.0.1"
+
+
+class TokenAuthMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app, token: str):
+        super().__init__(app)
+        self.token = token
+
+    async def dispatch(self, request, call_next):
+        auth_header = request.headers.get("Authorization")
+        if not auth_header or not auth_header.startswith("Bearer "):
+            return JSONResponse({"error": "Unauthorized"}, status_code=401)
+        token = auth_header.split(" ")[1]
+        if token != self.token:
+            return JSONResponse({"error": "Unauthorized"}, status_code=401)
+        return await call_next(request)
+
+
+mcp = FastMCP("FIRERPA")
+
+
+@mcp.tool()
+def list_fleet() -> list[dict]:
+    fleet = get_fleet()
+    return [{"alias": f.alias, "ip": f.ip} for f in fleet]
+
+
+def _resolve_host(host_alias: str):
+    fleet = get_fleet()
+    for f in fleet:
+        if f.alias == host_alias:
+            return f
+    return None
+
+
+def _connect(host_alias: str):
+    if Device is None:
+        raise RuntimeError("lamda-client not installed")
+    f = _resolve_host(host_alias)
+    if not f:
+        raise ValueError(f"Unknown host alias: {host_alias}")
+    try:
+        return Device(f.ip, port=f.port, certificate=certificate_path())
+    except Exception as e:
+        raise RuntimeError(f"Failed to connect to FIRERPA on {host_alias}: {e}")
+
+
+@mcp.tool()
+def device_status(host: str) -> dict:
+    try:
+        d = _connect(host)
+        info = d.server_info()
+        return {
+            "firerpa": info.version,
+            "sshd": "up" if heal.is_sshd_alive(d) else "down",
+            "shizuku": "up" if heal.is_port_5555_alive(d) else "down",
+            "bootloop": "up" if heal.is_bootloop_alive(d) else "down",
+        }
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@mcp.tool()
+async def heal_device(host: str, ctx: Context) -> dict:
+    if not await check_consent(f"heal_device on {host}", ctx):
+        return {"status": "refused"}
+    try:
+        d = _connect(host)
+        session = HealSession(d, host)
+
+        results = {}
+        sshd_alive = heal.is_sshd_alive(d)
+        port5555_alive = heal.is_port_5555_alive(d)
+        bootloop_alive = heal.is_bootloop_alive(d)
+
+        results["sshd"] = "up" if sshd_alive else "down"
+        results["shizuku"] = "up" if port5555_alive else "down"
+        results["bootloop"] = "up" if bootloop_alive else "down"
+
+        if not sshd_alive:
+            session.add_action("remove_sshd_down")
+            results["sshd_down_file"] = heal.remove_sshd_down(d)
+            if not heal.is_sshd_alive(d):
+                session.add_action("restart_sshd")
+                results["sshd_restart"] = heal.restart_sshd(d)
+
+        if not port5555_alive:
+            session.add_action("restart_shizuku")
+            results["shizuku_restart"] = heal.restart_shizuku(d)
+
+        if not bootloop_alive:
+            session.add_action("restart_bootloop")
+            results["bootloop_restart"] = heal.restart_bootloop(d)
+
+        results["sshd_final"] = "up" if heal.is_sshd_alive(d) else "down"
+        results["shizuku_final"] = "up" if heal.is_port_5555_alive(d) else "down"
+
+        session.close()
+        return results
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@mcp.tool()
+async def restart_sshd(host: str, ctx: Context) -> dict:
+    if not await check_consent(f"restart_sshd on {host}", ctx):
+        return {"status": "refused"}
+    try:
+        d = _connect(host)
+        session = HealSession(d, host)
+        session.add_action("remove_sshd_down")
+        heal.remove_sshd_down(d)
+        session.add_action("restart_sshd")
+        res = heal.restart_sshd(d)
+        session.close()
+        return {"status": res, "consent": "proceeded"}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@mcp.tool()
+async def restart_shizuku(host: str, ctx: Context) -> dict:
+    if not await check_consent(f"restart_shizuku on {host}", ctx):
+        return {"status": "refused"}
+    try:
+        d = _connect(host)
+        session = HealSession(d, host)
+        session.add_action("restart_shizuku")
+        res = heal.restart_shizuku(d)
+        session.close()
+        return {"status": res}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@mcp.tool()
+async def restart_bootloop(host: str, ctx: Context) -> dict:
+    if not await check_consent(f"restart_bootloop on {host}", ctx):
+        return {"status": "refused"}
+    try:
+        d = _connect(host)
+        session = HealSession(d, host)
+        session.add_action("restart_bootloop")
+        res = heal.restart_bootloop(d)
+        session.close()
+        return {"status": res}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--transport", choices=["stdio", "streamable-http"], default="stdio")
+    parser.add_argument("--host", default=None)
+    parser.add_argument("--port", type=int, default=8000)
+    args = parser.parse_args()
+
+    if args.transport == "stdio":
+        mcp.run("stdio")
+    elif args.transport == "streamable-http":
+        app = mcp.streamable_http_app()
+        token = get_bearer_token()
+        if token:
+            app.add_middleware(TokenAuthMiddleware, token=token)
+
+        host = args.host or get_tailscale_ip()
+        uvicorn.run(app, host=host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/control/bin/firerpa_mcp.py
+++ b/control/bin/firerpa_mcp.py
@@ -8,6 +8,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.append(str(REPO_ROOT))
 
+import hmac
+
 import uvicorn
 from mcp.server.fastmcp import Context, FastMCP
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -17,6 +19,7 @@ import control.bin.firerpa_heal as heal
 from control.lib.firerpa_auth import certificate_path
 from control.lib.firerpa_consent import HealSession, check_consent
 from control.lib.firerpa_fleet import get_fleet
+from control.lib.site_logging import WARNING, log
 
 try:
     from lamda.client import Device
@@ -63,7 +66,7 @@ class TokenAuthMiddleware(BaseHTTPMiddleware):
         if not auth_header or not auth_header.startswith("Bearer "):
             return JSONResponse({"error": "Unauthorized"}, status_code=401)
         token = auth_header.split(" ")[1]
-        if token != self.token:
+        if not hmac.compare_digest(token, self.token):
             return JSONResponse({"error": "Unauthorized"}, status_code=401)
         return await call_next(request)
 
@@ -114,88 +117,115 @@ def device_status(host: str) -> dict:
 
 @mcp.tool()
 async def heal_device(host: str, ctx: Context) -> dict:
+    try:
+        _resolve_host(host)
+    except Exception as e:
+        return {"error": str(e)}
+
     if not await check_consent(f"heal_device on {host}", ctx):
         return {"status": "refused"}
     try:
         d = _connect(host)
         session = HealSession(d, host)
+        try:
+            results = {}
+            sshd_alive = heal.is_sshd_alive(d)
+            port5555_alive = heal.is_port_5555_alive(d)
+            bootloop_alive = heal.is_bootloop_alive(d)
 
-        results = {}
-        sshd_alive = heal.is_sshd_alive(d)
-        port5555_alive = heal.is_port_5555_alive(d)
-        bootloop_alive = heal.is_bootloop_alive(d)
+            results["sshd"] = "up" if sshd_alive else "down"
+            results["shizuku"] = "up" if port5555_alive else "down"
+            results["bootloop"] = "up" if bootloop_alive else "down"
 
-        results["sshd"] = "up" if sshd_alive else "down"
-        results["shizuku"] = "up" if port5555_alive else "down"
-        results["bootloop"] = "up" if bootloop_alive else "down"
+            if not sshd_alive:
+                session.add_action("remove_sshd_down")
+                results["sshd_down_file"] = heal.remove_sshd_down(d)
+                if not heal.is_sshd_alive(d):
+                    session.add_action("restart_sshd")
+                    results["sshd_restart"] = heal.restart_sshd(d)
 
-        if not sshd_alive:
-            session.add_action("remove_sshd_down")
-            results["sshd_down_file"] = heal.remove_sshd_down(d)
-            if not heal.is_sshd_alive(d):
-                session.add_action("restart_sshd")
-                results["sshd_restart"] = heal.restart_sshd(d)
+            if not port5555_alive:
+                session.add_action("restart_shizuku")
+                results["shizuku_restart"] = heal.restart_shizuku(d)
 
-        if not port5555_alive:
-            session.add_action("restart_shizuku")
-            results["shizuku_restart"] = heal.restart_shizuku(d)
+            if not bootloop_alive:
+                session.add_action("restart_bootloop")
+                results["bootloop_restart"] = heal.restart_bootloop(d)
 
-        if not bootloop_alive:
-            session.add_action("restart_bootloop")
-            results["bootloop_restart"] = heal.restart_bootloop(d)
+            results["sshd_final"] = "up" if heal.is_sshd_alive(d) else "down"
+            results["shizuku_final"] = "up" if heal.is_port_5555_alive(d) else "down"
 
-        results["sshd_final"] = "up" if heal.is_sshd_alive(d) else "down"
-        results["shizuku_final"] = "up" if heal.is_port_5555_alive(d) else "down"
-
-        session.close()
-        return results
+            return results
+        finally:
+            session.close()
     except Exception as e:
         return {"error": str(e)}
 
 
 @mcp.tool()
 async def restart_sshd(host: str, ctx: Context) -> dict:
+    try:
+        _resolve_host(host)
+    except Exception as e:
+        return {"error": str(e)}
+
     if not await check_consent(f"restart_sshd on {host}", ctx):
         return {"status": "refused"}
     try:
         d = _connect(host)
         session = HealSession(d, host)
-        session.add_action("remove_sshd_down")
-        heal.remove_sshd_down(d)
-        session.add_action("restart_sshd")
-        res = heal.restart_sshd(d)
-        session.close()
-        return {"status": res, "consent": "proceeded"}
+        try:
+            session.add_action("remove_sshd_down")
+            heal.remove_sshd_down(d)
+            session.add_action("restart_sshd")
+            res = heal.restart_sshd(d)
+            return {"status": res, "consent": "proceeded"}
+        finally:
+            session.close()
     except Exception as e:
         return {"error": str(e)}
 
 
 @mcp.tool()
 async def restart_shizuku(host: str, ctx: Context) -> dict:
+    try:
+        _resolve_host(host)
+    except Exception as e:
+        return {"error": str(e)}
+
     if not await check_consent(f"restart_shizuku on {host}", ctx):
         return {"status": "refused"}
     try:
         d = _connect(host)
         session = HealSession(d, host)
-        session.add_action("restart_shizuku")
-        res = heal.restart_shizuku(d)
-        session.close()
-        return {"status": res}
+        try:
+            session.add_action("restart_shizuku")
+            res = heal.restart_shizuku(d)
+            return {"status": res}
+        finally:
+            session.close()
     except Exception as e:
         return {"error": str(e)}
 
 
 @mcp.tool()
 async def restart_bootloop(host: str, ctx: Context) -> dict:
+    try:
+        _resolve_host(host)
+    except Exception as e:
+        return {"error": str(e)}
+
     if not await check_consent(f"restart_bootloop on {host}", ctx):
         return {"status": "refused"}
     try:
         d = _connect(host)
         session = HealSession(d, host)
-        session.add_action("restart_bootloop")
-        res = heal.restart_bootloop(d)
-        session.close()
-        return {"status": res}
+        try:
+            session.add_action("restart_bootloop")
+            res = heal.restart_bootloop(d)
+            return {"status": res}
+        finally:
+            session.close()
     except Exception as e:
         return {"error": str(e)}
 
@@ -214,6 +244,9 @@ def main():
         token = get_bearer_token()
         if token:
             app.add_middleware(TokenAuthMiddleware, token=token)
+        else:
+            print("WARNING: Starting HTTP transport without token authentication. This is insecure!", file=sys.stderr)
+            log(WARNING, "Starting HTTP transport without token authentication.")
 
         host = args.host or get_tailscale_ip()
         uvicorn.run(app, host=host, port=args.port)

--- a/control/lib/firerpa_consent.py
+++ b/control/lib/firerpa_consent.py
@@ -1,0 +1,89 @@
+import os
+import subprocess
+import time
+from typing import Any
+
+from mcp.server.fastmcp import Context
+from pydantic import BaseModel, Field
+
+FIRERPA_HEAL_COUNTDOWN_SEC = 10
+
+
+class ConsentSchema(BaseModel):
+    consent: str = Field(
+        description="Action consent: type 'proceed' to allow, 'refuse' to abort.",
+        default="proceed",
+    )
+
+
+class HealSession:
+    def __init__(self, device: Any, alias: str) -> None:
+        self.device = device
+        self.alias = alias
+        self.actions: list[str] = []
+
+    def add_action(self, action: str) -> None:
+        self.actions.append(action)
+        self.update_notifications()
+
+    def update_notifications(self) -> None:
+        now = time.strftime("%H:%M")
+        summary = " · ".join(self.actions)
+        msg = f"stayturgid heal {self.alias}: {summary} ({now})"
+        cmd = f"termux-notification --id stayturgid-firerpa-heal --title 'FIRERPA Heal' --content '{msg}'"
+        try:
+            self.device.execute_script(cmd, timeout=5)
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        try:
+            self.device.execute_script("termux-notification-remove stayturgid-firerpa-heal", timeout=5)
+        except Exception:
+            pass
+
+        if self.actions:
+            mac_msg = f"healed {self.alias}: {', '.join(self.actions)} ({len(self.actions)} actions)"
+            subprocess.run(
+                ["osascript", "-e", f'display notification "{mac_msg}" with title "FIRERPA Heal"'],
+                check=False,
+            )
+
+
+async def check_consent(action_summary: str, context: Context | None = None) -> bool:
+    if os.environ.get("STAYTURGID_FIRERPA_HEAL_NOCONSENT") == "1":
+        return True
+
+    if os.environ.get("STAYTURGID_FIRERPA_HEAL_QUIET") == "1":
+        return True
+
+    # Try MCP Elicitation if supported
+    if context:
+        try:
+            res = await context.elicit(
+                f"A mutating heal tool has been requested: {action_summary}. Type 'proceed' or 'refuse'.",
+                ConsentSchema,
+            )
+            if isinstance(res, dict):
+                return res.get("consent", "proceed").lower() != "refuse"
+            return res.consent.lower() != "refuse"
+        except Exception:
+            pass  # Fall back to osascript on error
+
+    # Fallback to osascript
+    script = f"""
+    try
+        display dialog "A mutating heal tool has been requested: {action_summary}." buttons {{"Refuse", "Proceed now"}} default button "Proceed now" giving up after {FIRERPA_HEAL_COUNTDOWN_SEC}
+        set res to button returned of result
+        if res is "Refuse" then
+            return "refuse"
+        else
+            return "proceed"
+        end if
+    on error
+        return "refuse"
+    end try
+    """
+    res = subprocess.run(["osascript", "-e", script], capture_output=True, text=True, check=False)
+    out = res.stdout.strip()
+    return out != "refuse"

--- a/control/lib/firerpa_consent.py
+++ b/control/lib/firerpa_consent.py
@@ -12,8 +12,12 @@ FIRERPA_HEAL_COUNTDOWN_SEC = 10
 class ConsentSchema(BaseModel):
     consent: str = Field(
         description="Action consent: type 'proceed' to allow, 'refuse' to abort.",
-        default="proceed",
+        default="refuse",
     )
+
+
+def _escape_applescript(s: str) -> str:
+    return s.replace("\\", "\\\\").replace('"', '\\"')
 
 
 class HealSession:
@@ -64,16 +68,21 @@ async def check_consent(action_summary: str, context: Context | None = None) -> 
                 f"A mutating heal tool has been requested: {action_summary}. Type 'proceed' or 'refuse'.",
                 ConsentSchema,
             )
-            if isinstance(res, dict):
-                return res.get("consent", "proceed").lower() != "refuse"
-            return res.consent.lower() != "refuse"
-        except Exception:
+            if hasattr(res, "action"):
+                if res.action == "accept":
+                    return res.data.consent.lower() != "refuse"
+                return False
+        except Exception as e:
+            from control.lib.site_logging import WARNING, log
+
+            log(WARNING, f"MCP Elicitation failed or unsupported: {e}")
             pass  # Fall back to osascript on error
 
     # Fallback to osascript
+    action_summary_escaped = _escape_applescript(action_summary)
     script = f"""
     try
-        display dialog "A mutating heal tool has been requested: {action_summary}." buttons {{"Refuse", "Proceed now"}} default button "Proceed now" giving up after {FIRERPA_HEAL_COUNTDOWN_SEC}
+        display dialog "A mutating heal tool has been requested: {action_summary_escaped}." buttons {{"Refuse", "Proceed now"}} default button "Proceed now" giving up after {FIRERPA_HEAL_COUNTDOWN_SEC}
         set res to button returned of result
         if res is "Refuse" then
             return "refuse"

--- a/control/lib/firerpa_consent.py
+++ b/control/lib/firerpa_consent.py
@@ -6,7 +6,14 @@ from typing import Any
 from mcp.server.fastmcp import Context
 from pydantic import BaseModel, Field
 
+from control.lib.site_logging import WARNING, log
+
 FIRERPA_HEAL_COUNTDOWN_SEC = 10
+LOG_NAME = "firerpa-consent.log"
+
+
+def _log(level: int, msg: str) -> None:
+    log(LOG_NAME, level, msg, also_print=True)
 
 
 class ConsentSchema(BaseModel):
@@ -37,14 +44,14 @@ class HealSession:
         cmd = f"termux-notification --id stayturgid-firerpa-heal --title 'FIRERPA Heal' --content '{msg}'"
         try:
             self.device.execute_script(cmd, timeout=5)
-        except Exception:
-            pass
+        except Exception as e:
+            _log(WARNING, f"Failed to update device notification for {self.alias}: {e}")
 
     def close(self) -> None:
         try:
             self.device.execute_script("termux-notification-remove stayturgid-firerpa-heal", timeout=5)
-        except Exception:
-            pass
+        except Exception as e:
+            _log(WARNING, f"Failed to remove device notification for {self.alias}: {e}")
 
         if self.actions:
             mac_msg = f"healed {self.alias}: {', '.join(self.actions)} ({len(self.actions)} actions)"
@@ -73,10 +80,8 @@ async def check_consent(action_summary: str, context: Context | None = None) -> 
                     return res.data.consent.lower() != "refuse"
                 return False
         except Exception as e:
-            from control.lib.site_logging import WARNING, log
-
-            log(WARNING, f"MCP Elicitation failed or unsupported: {e}")
-            pass  # Fall back to osascript on error
+            _log(WARNING, f"MCP Elicitation failed or unsupported: {e}")
+            # Fall through to osascript below.
 
     # Fallback to osascript
     action_summary_escaped = _escape_applescript(action_summary)

--- a/control/lib/firerpa_consent.py
+++ b/control/lib/firerpa_consent.py
@@ -13,7 +13,10 @@ LOG_NAME = "firerpa-consent.log"
 
 
 def _log(level: int, msg: str) -> None:
-    log(LOG_NAME, level, msg, also_print=True)
+    # This module runs inside the MCP server's stdio transport, where
+    # stdout is the JSON-RPC protocol channel — never print diagnostics
+    # there, the log file is the only sink.
+    log(LOG_NAME, level, msg)
 
 
 class ConsentSchema(BaseModel):

--- a/control/lib/firerpa_fleet.py
+++ b/control/lib/firerpa_fleet.py
@@ -1,0 +1,81 @@
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from control.lib.ansible_context import resolve_ansible_context, resolved_env
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class FirerpaTarget:
+    """Inventory-derived FIRERPA policy for one Android host."""
+
+    alias: str
+    ip: str
+    usb_serial: str = ""
+    enabled: bool = True
+    runtime_status: str = "supported"
+    recovery_mode: str = "none"
+    port: int = 65000
+    certificate_device_path: str = "/data/local/tmp/firerpa/server/lamda.pem"
+
+
+def _as_bool(value: object, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def get_fleet() -> list[FirerpaTarget]:
+    context = resolve_ansible_context(REPO_ROOT)
+    env = resolved_env(REPO_ROOT)
+
+    result = subprocess.run(
+        ["ansible-inventory", "--list", *context.inventory_args()],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print("Failed to resolve inventory: " + result.stderr, file=sys.stderr)
+        return []
+
+    inv = json.loads(result.stdout)
+    hosts = inv.get("stayturgid", {}).get("hosts", [])
+    if not hosts:
+        # Fallback to children of stayturgid if it's a group of groups
+        for child_group in inv.get("stayturgid", {}).get("children", []):
+            hosts.extend(inv.get(child_group, {}).get("hosts", []))
+
+    hostvars = inv.get("_meta", {}).get("hostvars", {})
+
+    fleet = []
+    for host in hosts:
+        variables = hostvars.get(host, {})
+        ip = variables.get("ansible_host")
+        if ip:
+            fleet.append(
+                FirerpaTarget(
+                    alias=host,
+                    ip=str(ip),
+                    usb_serial=str(variables.get("device_usb_serial", "")),
+                    enabled=_as_bool(variables.get("firerpa_enabled"), True),
+                    runtime_status=str(variables.get("firerpa_runtime_status", "supported")),
+                    recovery_mode=str(variables.get("firerpa_recovery_mode", "none")),
+                    port=int(variables.get("firerpa_port", 65000)),
+                    certificate_device_path=str(
+                        variables.get(
+                            "firerpa_certificate_device_path",
+                            "/data/local/tmp/firerpa/server/lamda.pem",
+                        )
+                    ),
+                )
+            )
+
+    return fleet

--- a/control/lib/firerpa_fleet.py
+++ b/control/lib/firerpa_fleet.py
@@ -35,18 +35,28 @@ def get_fleet() -> list[FirerpaTarget]:
     context = resolve_ansible_context(REPO_ROOT)
     env = resolved_env(REPO_ROOT)
 
-    result = subprocess.run(
-        ["ansible-inventory", "--list", *context.inventory_args()],
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["ansible-inventory", "--list", *context.inventory_args()],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        print("Failed to resolve inventory: ansible-inventory timed out after 30s", file=sys.stderr)
+        return []
+
     if result.returncode != 0:
         print("Failed to resolve inventory: " + result.stderr, file=sys.stderr)
         return []
 
-    inv = json.loads(result.stdout)
+    try:
+        inv = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        print(f"Failed to decode inventory JSON: {e}", file=sys.stderr)
+        return []
     hosts = inv.get("stayturgid", {}).get("hosts", [])
     if not hosts:
         # Fallback to children of stayturgid if it's a group of groups

--- a/control/lib/firerpa_fleet.py
+++ b/control/lib/firerpa_fleet.py
@@ -1,12 +1,17 @@
 import json
 import subprocess
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 from control.lib.ansible_context import resolve_ansible_context, resolved_env
+from control.lib.site_logging import WARNING, log
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+LOG_NAME = "firerpa-fleet.log"
+
+
+def _log(level: int, msg: str) -> None:
+    log(LOG_NAME, level, msg, also_print=True)
 
 
 @dataclass(frozen=True)
@@ -45,17 +50,20 @@ def get_fleet() -> list[FirerpaTarget]:
             timeout=30,
         )
     except subprocess.TimeoutExpired:
-        print("Failed to resolve inventory: ansible-inventory timed out after 30s", file=sys.stderr)
+        _log(WARNING, "Failed to resolve inventory: ansible-inventory timed out after 30s")
+        return []
+    except OSError as e:
+        _log(WARNING, f"Failed to resolve inventory: {e}")
         return []
 
     if result.returncode != 0:
-        print("Failed to resolve inventory: " + result.stderr, file=sys.stderr)
+        _log(WARNING, "Failed to resolve inventory: " + result.stderr)
         return []
 
     try:
         inv = json.loads(result.stdout)
     except json.JSONDecodeError as e:
-        print(f"Failed to decode inventory JSON: {e}", file=sys.stderr)
+        _log(WARNING, f"Failed to decode inventory JSON: {e}")
         return []
     hosts = inv.get("stayturgid", {}).get("hosts", [])
     if not hosts:

--- a/control/lib/firerpa_fleet.py
+++ b/control/lib/firerpa_fleet.py
@@ -11,7 +11,10 @@ LOG_NAME = "firerpa-fleet.log"
 
 
 def _log(level: int, msg: str) -> None:
-    log(LOG_NAME, level, msg, also_print=True)
+    # get_fleet() can run inside the MCP server's stdio transport, where
+    # stdout is the JSON-RPC protocol channel — never print diagnostics
+    # there, the log file is the only sink.
+    log(LOG_NAME, level, msg)
 
 
 @dataclass(frozen=True)

--- a/docs/options.md
+++ b/docs/options.md
@@ -78,7 +78,7 @@ cutover state.
 | **B — Ansible-native** | Bootstrap APK automation follow-ups                | B63, B64       | Low–Medium                    |
 | **D — Reliability**    | Symptom-driven hardening (needs post-K1 re-scope)  | 43, 44, 45     | Latent until triggered        |
 | **E — On-device LLM**  | shell-gpt escalation; incubator note               | 54             | Medium (mis-scope risk)       |
-| **F — FIRERPA**        | gRPC backup channel enhancements                   | F1, F3         | Medium (future, core is done) |
+| **F — FIRERPA**        | gRPC backup channel enhancements                   | F3             | Medium (future, core is done) |
 | **H — Post-migration** | fireos-device deploy, foreground-screen cleanup    | H1, H3, H9     | Low–Medium                    |
 | **T — Tooling**        | Deferred evaluations                               | T2, T4, T5, T6 | Low–Medium                    |
 
@@ -344,16 +344,7 @@ remains unsupported. Architecture docs:
 `docs/research/evaluations/firerpa-nonroot-redundancy-deepseek-pro-2026-07-12.md`,
 `docs/research/evaluations/firerpa-install-map-2026-07-12.md`.
 
-**Closed:** F2, F4 — see [archive](archive/options-closed-2026-07-23.md#track-f--firerpa-closed-items).
-
-#### F1 — MCP bridge extension (agent) · Risk: **Medium** · Core: gRPC heal works without it
-
-Build a lamda MCP extension that exposes stayturgid repair primitives through
-the gRPC channel. Core gRPC heal (`firerpa_heal.py`) works today; MCP just
-provides agent-native tool calling. **Plan finalized:**
-[operations/plans/firerpa-mcp-bridge-plan-2026-07-22.md](operations/plans/firerpa-mcp-bridge-plan-2026-07-22.md)
-(decisions D1–D3 resolved; implementation gated on operator go). Tracked as
-[#46](https://github.com/djbclark/stayturgid/issues/46).
+**Closed:** F1, F2, F4 — see [archive](archive/options-closed-2026-07-23.md#track-f--firerpa-closed-items).
 
 #### F3 — MITM-on-demand playbook (agent) · Risk: **Medium**
 

--- a/just/services.just
+++ b/just/services.just
@@ -160,3 +160,13 @@ landing-discover:
       py=python3
     fi
     "$py" control/landing/discover.py
+
+# ── FIRERPA MCP Bridge ─────────────────────────────────────────────────────
+
+# Start the Tailscale-reachable streamable-HTTP service.
+firerpa-mcp:
+    {{ env_var("HOME") }}/.venv-stayturgid-firerpa/bin/python control/bin/firerpa_mcp.py --transport streamable-http
+
+# Run the local stdio MCP server.
+firerpa-mcp-stdio:
+    {{ env_var("HOME") }}/.venv-stayturgid-firerpa/bin/python control/bin/firerpa_mcp.py --transport stdio

--- a/tests/python/test_firerpa_health_monitor.py
+++ b/tests/python/test_firerpa_health_monitor.py
@@ -7,13 +7,6 @@ from types import SimpleNamespace
 import firerpa_health_monitor as monitor
 
 
-def test_as_bool_handles_inventory_strings() -> None:
-    assert monitor._as_bool(True, False)
-    assert monitor._as_bool("yes", False)
-    assert not monitor._as_bool("false", True)
-    assert monitor._as_bool(None, True)
-
-
 def test_recover_device_uses_canonical_lifecycle(monkeypatch) -> None:
     calls: list[list[str]] = []
 

--- a/tests/test_firerpa_consent.py
+++ b/tests/test_firerpa_consent.py
@@ -1,0 +1,81 @@
+import os
+from unittest import mock
+
+import pytest
+
+from control.lib.firerpa_consent import HealSession, check_consent
+
+
+@pytest.fixture
+def mock_device():
+    device = mock.Mock()
+    return device
+
+
+def test_heal_session_notifications(mock_device):
+    session = HealSession(mock_device, "s24")
+    session.add_action("restart_sshd")
+    session.add_action("restart_shizuku")
+
+    # Should have called termux-notification twice
+    assert mock_device.execute_script.call_count == 2
+
+    with mock.patch("subprocess.run") as mock_run:
+        session.close()
+        # Should remove notification
+        assert mock_device.execute_script.call_count == 3
+        # Should call osascript
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert "healed s24: restart_sshd, restart_shizuku (2 actions)" in args[2]
+
+
+@pytest.mark.asyncio
+async def test_check_consent_env_skip():
+    with mock.patch.dict(os.environ, {"STAYTURGID_FIRERPA_HEAL_NOCONSENT": "1"}):
+        assert await check_consent("test") is True
+
+    with mock.patch.dict(os.environ, {"STAYTURGID_FIRERPA_HEAL_QUIET": "1"}):
+        assert await check_consent("test") is True
+
+
+@pytest.mark.asyncio
+async def test_check_consent_osascript_proceed():
+    mock_run = mock.Mock()
+    mock_run.stdout = "proceed"
+    with mock.patch.dict(os.environ, clear=True), mock.patch("subprocess.run", return_value=mock_run):
+        assert await check_consent("test") is True
+
+
+@pytest.mark.asyncio
+async def test_check_consent_osascript_refuse():
+    mock_run = mock.Mock()
+    mock_run.stdout = "refuse"
+    with mock.patch.dict(os.environ, clear=True), mock.patch("subprocess.run", return_value=mock_run):
+        assert await check_consent("test") is False
+
+
+@pytest.mark.asyncio
+async def test_check_consent_elicitation():
+    mock_context = mock.AsyncMock()
+    mock_context.request_context.session.client_capabilities.elicitation = True
+
+    mock_result = mock.Mock()
+    mock_result.consent = "proceed"
+    mock_context.elicit.return_value = mock_result
+
+    with mock.patch.dict(os.environ, clear=True):
+        assert await check_consent("test", mock_context) is True
+
+
+@pytest.mark.asyncio
+async def test_check_consent_elicitation_refuse():
+    mock_context = mock.AsyncMock()
+    mock_context.request_context.session.client_capabilities.elicitation = True
+
+    mock_result = mock.Mock()
+    mock_result.consent = "refuse"
+    mock_context.elicit.return_value = mock_result
+
+    with mock.patch.dict(os.environ, clear=True):
+        assert await check_consent("test", mock_context) is False

--- a/tests/test_firerpa_consent.py
+++ b/tests/test_firerpa_consent.py
@@ -58,10 +58,10 @@ async def test_check_consent_osascript_refuse():
 @pytest.mark.asyncio
 async def test_check_consent_elicitation():
     mock_context = mock.AsyncMock()
-    mock_context.request_context.session.client_capabilities.elicitation = True
 
     mock_result = mock.Mock()
-    mock_result.consent = "proceed"
+    mock_result.action = "accept"
+    mock_result.data.consent = "proceed"
     mock_context.elicit.return_value = mock_result
 
     with mock.patch.dict(os.environ, clear=True):
@@ -71,10 +71,27 @@ async def test_check_consent_elicitation():
 @pytest.mark.asyncio
 async def test_check_consent_elicitation_refuse():
     mock_context = mock.AsyncMock()
-    mock_context.request_context.session.client_capabilities.elicitation = True
 
+    # Test accept with refuse data
     mock_result = mock.Mock()
-    mock_result.consent = "refuse"
+    mock_result.action = "accept"
+    mock_result.data.consent = "refuse"
+    mock_context.elicit.return_value = mock_result
+
+    with mock.patch.dict(os.environ, clear=True):
+        assert await check_consent("test", mock_context) is False
+
+    # Test decline action
+    mock_result = mock.Mock()
+    mock_result.action = "decline"
+    mock_context.elicit.return_value = mock_result
+
+    with mock.patch.dict(os.environ, clear=True):
+        assert await check_consent("test", mock_context) is False
+
+    # Test cancel action
+    mock_result = mock.Mock()
+    mock_result.action = "cancel"
     mock_context.elicit.return_value = mock_result
 
     with mock.patch.dict(os.environ, clear=True):

--- a/tests/test_firerpa_fleet.py
+++ b/tests/test_firerpa_fleet.py
@@ -1,0 +1,60 @@
+import json
+from unittest import mock
+
+from control.lib.firerpa_fleet import get_fleet
+
+
+def test_get_fleet_success():
+    fake_inventory = {
+        "stayturgid": {"hosts": ["s24", "p7a"]},
+        "_meta": {
+            "hostvars": {
+                "s24": {
+                    "ansible_host": "100.123.218.30",
+                    "device_usb_serial": "RFCX219CHKA",
+                    "firerpa_enabled": True,
+                    "firerpa_runtime_status": "supported",
+                    "firerpa_recovery_mode": "control-node-adb",
+                    "firerpa_port": 65000,
+                    "firerpa_certificate_device_path": "/data/local/tmp/firerpa/server/lamda.pem",
+                },
+                "p7a": {
+                    "ansible_host": "100.65.230.108",
+                    "firerpa_enabled": False,
+                },
+            }
+        },
+    }
+
+    mock_result = mock.Mock()
+    mock_result.returncode = 0
+    mock_result.stdout = json.dumps(fake_inventory)
+
+    with mock.patch("subprocess.run", return_value=mock_result):
+        fleet = get_fleet()
+
+    assert len(fleet) == 2
+    s24 = [t for t in fleet if t.alias == "s24"][0]
+    p7a = [t for t in fleet if t.alias == "p7a"][0]
+
+    assert s24.ip == "100.123.218.30"
+    assert s24.usb_serial == "RFCX219CHKA"
+    assert s24.enabled is True
+    assert s24.runtime_status == "supported"
+    assert s24.recovery_mode == "control-node-adb"
+    assert s24.port == 65000
+
+    assert p7a.ip == "100.65.230.108"
+    assert p7a.enabled is False
+    assert p7a.runtime_status == "supported"
+
+
+def test_get_fleet_failure():
+    mock_result = mock.Mock()
+    mock_result.returncode = 1
+    mock_result.stderr = "Error"
+
+    with mock.patch("subprocess.run", return_value=mock_result):
+        fleet = get_fleet()
+
+    assert fleet == []

--- a/tests/test_firerpa_fleet.py
+++ b/tests/test_firerpa_fleet.py
@@ -1,7 +1,14 @@
 import json
 from unittest import mock
 
-from control.lib.firerpa_fleet import get_fleet
+from control.lib.firerpa_fleet import _as_bool, get_fleet
+
+
+def test_as_bool_handles_inventory_strings() -> None:
+    assert _as_bool(True, False)
+    assert _as_bool("yes", False)
+    assert not _as_bool("false", True)
+    assert _as_bool(None, True)
 
 
 def test_get_fleet_success():

--- a/tests/test_firerpa_mcp.py
+++ b/tests/test_firerpa_mcp.py
@@ -1,0 +1,80 @@
+from unittest import mock
+
+import pytest
+
+from control.bin.firerpa_mcp import (
+    _resolve_host,
+    device_status,
+    get_tailscale_ip,
+    heal_device,
+    restart_sshd,
+)
+from control.lib.firerpa_fleet import FirerpaTarget
+
+
+def test_get_tailscale_ip():
+    mock_res = mock.Mock()
+    mock_res.returncode = 0
+    mock_res.stdout = "Warning: out of date\n100.123.123.123\n"
+    with mock.patch("subprocess.run", return_value=mock_res):
+        assert get_tailscale_ip() == "100.123.123.123"
+
+
+def test_resolve_host():
+    fleet = [FirerpaTarget(alias="s24", ip="1.2.3.4")]
+    with mock.patch("control.bin.firerpa_mcp.get_fleet", return_value=fleet):
+        assert _resolve_host("s24").ip == "1.2.3.4"
+        assert _resolve_host("unknown") is None
+
+
+def test_device_status_error():
+    with mock.patch("control.bin.firerpa_mcp._connect", side_effect=ValueError("foo")):
+        res = device_status("unknown")
+        assert "error" in res
+
+
+@pytest.mark.asyncio
+async def test_heal_device_refused():
+    mock_ctx = mock.Mock()
+    with mock.patch("control.bin.firerpa_mcp.check_consent", return_value=False):
+        res = await heal_device("s24", mock_ctx)
+        assert res == {"status": "refused"}
+
+
+@pytest.mark.asyncio
+async def test_heal_device_proceed():
+    mock_ctx = mock.Mock()
+    mock_device = mock.Mock()
+
+    with (
+        mock.patch("control.bin.firerpa_mcp.check_consent", return_value=True),
+        mock.patch("control.bin.firerpa_mcp._connect", return_value=mock_device),
+        mock.patch("control.bin.firerpa_mcp._resolve_host", return_value=True),
+        mock.patch("control.bin.firerpa_heal.is_sshd_alive", return_value=True),
+        mock.patch("control.bin.firerpa_heal.is_port_5555_alive", return_value=True),
+        mock.patch("control.bin.firerpa_heal.is_bootloop_alive", return_value=True),
+        mock.patch("control.bin.firerpa_mcp.HealSession") as mock_session,
+    ):
+        res = await heal_device("s24", mock_ctx)
+        assert res["sshd_final"] == "up"
+        assert res["shizuku_final"] == "up"
+
+        mock_session.return_value.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_restart_sshd():
+    mock_ctx = mock.Mock()
+    mock_device = mock.Mock()
+
+    with (
+        mock.patch("control.bin.firerpa_mcp.check_consent", return_value=True),
+        mock.patch("control.bin.firerpa_mcp._connect", return_value=mock_device),
+        mock.patch("control.bin.firerpa_heal.remove_sshd_down"),
+        mock.patch("control.bin.firerpa_heal.restart_sshd", return_value="up"),
+        mock.patch("control.bin.firerpa_mcp.HealSession") as mock_session,
+    ):
+        res = await restart_sshd("s24", mock_ctx)
+        assert res == {"status": "up", "consent": "proceeded"}
+        mock_session.return_value.add_action.assert_any_call("remove_sshd_down")
+        mock_session.return_value.add_action.assert_any_call("restart_sshd")


### PR DESCRIPTION
Refs #46. Implements step 5-10 of the FIRERPA MCP bridge plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FIRERPA MCP bridge support via `.mcp.json`, with HTTP and local stdio options.
  * Enabled a toggleable macOS `launchd` agent for the MCP bridge.
  * Added supporting `just` recipes and fleet inventory-based device targeting.

* **Improvements**
  * Hardened MCP authentication and host alias handling, with safer cleanup during heal/restart.
  * Updated consent flow defaults to refuse and improved consent elicitation fallbacks.
  * Improved fleet loading resilience and warning-based failure logging.

* **Tests**
  * Added MCP test coverage; expanded consent and fleet tests; removed a redundant health-monitor test.

* **Documentation**
  * Updated Track F (“FIRERPA”) status entries in options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->