### PR TITLE
Fix portrait lock corruption (issue #42) by correctly deleting null settings and catching read errors

### DIFF
--- a/control/lib/screen_control.py
+++ b/control/lib/screen_control.py
@@ -119,19 +119,26 @@ def set_inversion(serial, enabled):
     return rc == 0 and inversion_enabled(serial) == enabled
 
 
+class SettingsReadError(Exception):
+    pass
+
+
 def _get_system_setting(serial, key):
     rc, out = mac_adb_shell(serial, "settings", "get", "system", key)
     if rc != 0:
-        return None
+        raise SettingsReadError(f"settings get {key} failed with rc={rc}")
     val = out.strip()
     if not val or val == "null":
-        return None
+        return "null"
     return val
 
 
 def read_rotation_settings(serial):
     """Current system rotation prefs (accelerometer_rotation, user_rotation)."""
-    return {k: _get_system_setting(serial, k) for k in _ROTATION_KEYS}
+    try:
+        return {k: _get_system_setting(serial, k) for k in _ROTATION_KEYS}
+    except SettingsReadError:
+        return None
 
 
 def apply_portrait_lock(serial):
@@ -162,6 +169,9 @@ def apply_portrait_lock(serial):
 def lock_portrait_orientation(serial):
     """Save rotation prefs, then lock portrait for the session."""
     saved = read_rotation_settings(serial)
+    if saved is None:
+        sys.stderr.write("WARN: failed to read rotation settings, aborting portrait lock on %s\n" % serial)
+        return None
     if not apply_portrait_lock(serial):
         sys.stderr.write("WARN: failed to lock portrait orientation on %s\n" % serial)
     return saved
@@ -185,7 +195,10 @@ def restore_rotation_settings(serial, saved):
         val = saved.get(key)
         if val is None:
             continue
-        rc, _out = mac_adb_shell(serial, "settings", "put", "system", key, val, timeout=10)
+        if val == "null":
+            mac_adb_shell(serial, "settings", "delete", "system", key, timeout=10)
+        else:
+            mac_adb_shell(serial, "settings", "put", "system", key, val, timeout=10)
         ok = ok and rc == 0
     if not ok:
         sys.stderr.write("WARN: failed to restore rotation settings on %s\n" % serial)

--- a/device/termux/py/stayturgid_screen_control.py
+++ b/device/termux/py/stayturgid_screen_control.py
@@ -74,18 +74,25 @@ def set_inversion(_serial, enabled):
     return rc == 0 and inversion_enabled() == enabled
 
 
+class SettingsReadError(Exception):
+    pass
+
+
 def _get_system_setting(key):
     rc, out = sh.shell("settings", "get", "system", key)
     if rc != 0:
-        return None
+        raise SettingsReadError("settings get %s failed with rc=%s" % (key, rc))
     val = out.strip()
     if not val or val == "null":
-        return None
+        return "null"
     return val
 
 
 def read_rotation_settings(_serial=None):
-    return {k: _get_system_setting(k) for k in _ROTATION_KEYS}
+    try:
+        return {k: _get_system_setting(k) for k in _ROTATION_KEYS}
+    except SettingsReadError:
+        return None
 
 
 def apply_portrait_lock(_serial=None):
@@ -110,6 +117,9 @@ def apply_portrait_lock(_serial=None):
 
 def lock_portrait_orientation(_serial=None):
     saved = read_rotation_settings()
+    if saved is None:
+        sys.stderr.write("WARN: failed to read rotation settings, aborting portrait lock\n")
+        return None
     if not apply_portrait_lock():
         sys.stderr.write("WARN: failed to lock portrait orientation\n")
     return saved
@@ -131,7 +141,10 @@ def restore_rotation_settings(_serial, saved):
         val = saved.get(key)
         if val is None:
             continue
-        rc, _ = sh.shell("settings", "put", "system", key, val)
+        if val == "null":
+            rc, _ = sh.shell("settings", "delete", "system", key)
+        else:
+            rc, _ = sh.shell("settings", "put", "system", key, val)
         ok = ok and rc == 0
     if not ok:
         sys.stderr.write("WARN: failed to restore rotation settings\n")

--- a/tests/python/test_screen_control.py
+++ b/tests/python/test_screen_control.py
@@ -315,3 +315,36 @@ def test_session_locks_portrait_on_enter_and_restores_on_exit(monkeypatch, tmp_p
         "serial-oneui-device",
         {"accelerometer_rotation": "1", "user_rotation": "2"},
     ) in rotation_calls
+
+def test_get_system_setting_raises_on_error(monkeypatch):
+    monkeypatch.setattr(sc, "mac_adb_shell", lambda *a, **k: (1, "error\n"))
+    with pytest.raises(sc.SettingsReadError):
+        sc._get_system_setting("serial-1", "some_key")
+
+
+def test_read_rotation_settings_returns_none_on_error(monkeypatch):
+    def fake_shell(*args, **kw):
+        return 1, "error\n"
+
+    monkeypatch.setattr(sc, "mac_adb_shell", fake_shell)
+    assert sc.read_rotation_settings("serial-1") is None
+
+
+def test_restore_rotation_settings_deletes_null(monkeypatch):
+    calls = []
+
+    def fake_shell(serial, *args, **kw):
+        calls.append((serial, args))
+        return 0, ""
+
+    monkeypatch.setattr(sc, "mac_adb_shell", fake_shell)
+    saved = {"accelerometer_rotation": "null", "user_rotation": "3"}
+    assert sc.restore_rotation_settings("serial-1", saved) is True
+    assert (
+        "serial-1",
+        ("settings", "delete", "system", "accelerometer_rotation"),
+    ) in calls
+    assert (
+        "serial-1",
+        ("settings", "put", "system", "user_rotation", "3"),
+    ) in calls


### PR DESCRIPTION
Fixes issue #42 where skipping the restore left the device in free rotation.

Also fixes a bug where `lock_portrait_orientation` unconditionally locked the screen even when the initial settings read failed. Without this fix, an initial ADB failure would leave the device permanently locked because there was no saved state to restore from.

I also investigated the battery percentage issue (#41 and #16) but found no `settings put` for `status_bar_show_battery_percent`. The reset is likely a secondary symptom of the portrait lock corruption/UI crashes.