### PR TITLE
Make portrait lock a standing baseline, never restored on session exit

### DIFF
--- a/control/lib/screen_control.py
+++ b/control/lib/screen_control.py
@@ -5,14 +5,24 @@ All stayturgid Mac scripts that send input events (tap, swipe, keyevent) must
 run inside ScreenControlSession. The session:
 
   1. Clears PiP / floating overlays that can steal taps (dumpsys + dismiss).
-  2. Locks natural **portrait** (auto-rotate off; restores prefs on exit).
+  2. Locks natural **portrait** (auto-rotate off) as a standing device
+     baseline — not restored on exit; see "Portrait lock" below.
   3. Requests consent on-device (agent-presence request-screen).
   4. Turns on accessibility display inversion (Mac adb — authoritative).
   5. Starts the on-device presence indicator (torch, notification via SSH).
   6. Refuses further input if inversion is off (fail closed).
   7. On exit (batch endpoint): best-effort restore of the foreground
      activity that was showing when the session started, then inversion
-     off + presence off + rotation prefs restored.
+     off + presence off.
+
+Portrait lock is intentionally NOT restored on exit: a session-scoped
+save/restore raced with manual rotation-lock changes made while a session
+was active (or by any concurrent session), silently reverting an operator's
+own lock shortly after they set it. Portrait-locked is the standing baseline
+for every fleet device once any automation has touched it; if a device
+needs auto-rotate, unlock it manually and no automation session will
+re-lock it (sessions only ever assert portrait, never read/restore a prior
+preference).
 
 Raw `adb shell input …` outside this wrapper can still bypass the policy;
 project scripts must not do that.
@@ -119,28 +129,6 @@ def set_inversion(serial, enabled):
     return rc == 0 and inversion_enabled(serial) == enabled
 
 
-class SettingsReadError(Exception):
-    pass
-
-
-def _get_system_setting(serial, key):
-    rc, out = mac_adb_shell(serial, "settings", "get", "system", key)
-    if rc != 0:
-        raise SettingsReadError(f"settings get {key} failed with rc={rc}")
-    val = out.strip()
-    if not val or val == "null":
-        return "null"
-    return val
-
-
-def read_rotation_settings(serial):
-    """Current system rotation prefs (accelerometer_rotation, user_rotation)."""
-    try:
-        return {k: _get_system_setting(serial, k) for k in _ROTATION_KEYS}
-    except SettingsReadError:
-        return None
-
-
 def apply_portrait_lock(serial):
     """Disable auto-rotate and pin natural portrait (user_rotation=0).
 
@@ -167,42 +155,9 @@ def apply_portrait_lock(serial):
 
 
 def lock_portrait_orientation(serial):
-    """Save rotation prefs, then lock portrait for the session."""
-    saved = read_rotation_settings(serial)
-    if saved is None:
-        sys.stderr.write("WARN: failed to read rotation settings, aborting portrait lock on %s\n" % serial)
-        return None
+    """Lock portrait as the device's standing baseline (never restored)."""
     if not apply_portrait_lock(serial):
         sys.stderr.write("WARN: failed to lock portrait orientation on %s\n" % serial)
-    return saved
-
-
-def restore_rotation_settings(serial, saved):
-    """Restore rotation prefs captured at session start."""
-    if not saved:
-        return True
-    ok = True
-    # Free any window-manager lock before restoring settings values.
-    for args in (
-        ("cmd", "window", "set-user-rotation", "free"),
-        ("wm", "set-user-rotation", "free"),
-        ("wm", "user-rotation", "free"),
-    ):
-        rc, _out = mac_adb_shell(serial, *args, timeout=10)
-        if rc == 0:
-            break
-    for key in _ROTATION_KEYS:
-        val = saved.get(key)
-        if val is None:
-            continue
-        if val == "null":
-            mac_adb_shell(serial, "settings", "delete", "system", key, timeout=10)
-        else:
-            mac_adb_shell(serial, "settings", "put", "system", key, val, timeout=10)
-        ok = ok and rc == 0
-    if not ok:
-        sys.stderr.write("WARN: failed to restore rotation settings on %s\n" % serial)
-    return ok
 
 
 def get_default_ime(serial):
@@ -377,7 +332,6 @@ class ScreenControlSession:
         self._skip = os.environ.get("STAYTURGID_SKIP_PRESENCE") == "1"
         self._saved_ime = None
         self._saved_component = None
-        self._saved_rotation = None
         self._stop_keepalive = threading.Event()
         self._keepalive_thread = None
         self._lease_session_id = None
@@ -482,7 +436,7 @@ class ScreenControlSession:
         # different launchers and Android versions. Commented out for now; may add
         # back via FIRERPA OCR/screen-control when the approach is more robust.
         # self._saved_component = get_foreground_component(self.serial)
-        self._saved_rotation = lock_portrait_orientation(self.serial)
+        lock_portrait_orientation(self.serial)
         cleared = uc.clear_ui_obstructions(self.serial, mac_adb_shell)
         if cleared:
             print("Cleared UI obstructions on %s: %s" % (self.host, ", ".join(cleared)))
@@ -548,7 +502,6 @@ class ScreenControlSession:
             sys.stderr.write("WARN: failed to disable display inversion on %s\n" % self.serial)
         if not restore_default_ime(self.serial, self._saved_ime):
             sys.stderr.write("WARN: failed to restore keyboard IME on %s\n" % self.serial)
-        restore_rotation_settings(self.serial, self._saved_rotation)
         self._release_cross_project_lease()
         self.active = False
         return False

--- a/device/termux/py/stayturgid_screen_control.py
+++ b/device/termux/py/stayturgid_screen_control.py
@@ -3,7 +3,9 @@
 
 Same policy as control/lib/screen_control.py, but presence is a local
 subprocess and adb is always localhost:5555. Fail closed when presence
-script is missing (rc 127).
+script is missing (rc 127). Portrait lock is a standing baseline, not
+restored on session exit — see the docstring in control/lib/screen_control.py
+for why.
 """
 
 from __future__ import annotations
@@ -74,27 +76,6 @@ def set_inversion(_serial, enabled):
     return rc == 0 and inversion_enabled() == enabled
 
 
-class SettingsReadError(Exception):
-    pass
-
-
-def _get_system_setting(key):
-    rc, out = sh.shell("settings", "get", "system", key)
-    if rc != 0:
-        raise SettingsReadError("settings get %s failed with rc=%s" % (key, rc))
-    val = out.strip()
-    if not val or val == "null":
-        return "null"
-    return val
-
-
-def read_rotation_settings(_serial=None):
-    try:
-        return {k: _get_system_setting(k) for k in _ROTATION_KEYS}
-    except SettingsReadError:
-        return None
-
-
 def apply_portrait_lock(_serial=None):
     """Disable auto-rotate and pin natural portrait (user_rotation=0)."""
     ok = True
@@ -116,39 +97,8 @@ def apply_portrait_lock(_serial=None):
 
 
 def lock_portrait_orientation(_serial=None):
-    saved = read_rotation_settings()
-    if saved is None:
-        sys.stderr.write("WARN: failed to read rotation settings, aborting portrait lock\n")
-        return None
     if not apply_portrait_lock():
         sys.stderr.write("WARN: failed to lock portrait orientation\n")
-    return saved
-
-
-def restore_rotation_settings(_serial, saved):
-    if not saved:
-        return True
-    ok = True
-    for args in (
-        ("cmd", "window", "set-user-rotation", "free"),
-        ("wm", "set-user-rotation", "free"),
-        ("wm", "user-rotation", "free"),
-    ):
-        rc, _ = sh.shell(*args)
-        if rc == 0:
-            break
-    for key in _ROTATION_KEYS:
-        val = saved.get(key)
-        if val is None:
-            continue
-        if val == "null":
-            rc, _ = sh.shell("settings", "delete", "system", key)
-        else:
-            rc, _ = sh.shell("settings", "put", "system", key, val)
-        ok = ok and rc == 0
-    if not ok:
-        sys.stderr.write("WARN: failed to restore rotation settings\n")
-    return ok
 
 
 def get_default_ime(_serial=None):
@@ -282,7 +232,6 @@ class ScreenControlSession(object):
         self._skip = os.environ.get("STAYTURGID_SKIP_PRESENCE") == "1"
         self._saved_ime = None
         self._saved_component = None
-        self._saved_rotation = None
         self._stop_keepalive = threading.Event()
         self._keepalive_thread = None
 
@@ -327,7 +276,7 @@ class ScreenControlSession(object):
         # different launchers and Android versions. May add back via FIRERPA
         # OCR/screen-control when more robust.
         # self._saved_component = get_foreground_component()
-        self._saved_rotation = lock_portrait_orientation()
+        lock_portrait_orientation()
         cleared = uc.clear_ui_obstructions(self.serial, sh.shell_fn)
         if cleared:
             print("Cleared UI obstructions: %s" % ", ".join(cleared))
@@ -383,7 +332,6 @@ class ScreenControlSession(object):
             sys.stderr.write("WARN: failed to disable display inversion\n")
         if not restore_default_ime(None, self._saved_ime):
             sys.stderr.write("WARN: failed to restore keyboard IME\n")
-        restore_rotation_settings(None, self._saved_rotation)
         self.active = False
         return False
 

--- a/docs/architecture/components/screen-control-lease.md
+++ b/docs/architecture/components/screen-control-lease.md
@@ -255,6 +255,10 @@ Do not treat a free lease as “consent granted.”
 
 While a screen-control session is held, stayturgid also applies a **natural-portrait**
 rotation preference (`user_rotation=0`, accelerometer rotation off) so multi-step UI
-automation does not flip landscape mid-batch. Restored when the session ends. See
-`control/lib/screen_control.py` (`apply_portrait_lock`) and the on-device twin in
+automation does not flip landscape mid-batch. This is a **standing baseline, not
+restored** when the session ends — a session-scoped save/restore previously raced with
+manual rotation-lock changes made while a session was active, silently reverting an
+operator's own lock. To go back to auto-rotate, unlock the device manually; no
+automation session restores a prior preference. See `control/lib/screen_control.py`
+(`apply_portrait_lock`) and the on-device twin in
 `device/termux/py/stayturgid_screen_control.py`.

--- a/tests/python/test_screen_control.py
+++ b/tests/python/test_screen_control.py
@@ -64,8 +64,7 @@ def test_skip_presence_still_enables_inversion(monkeypatch, tmp_path):
     monkeypatch.setattr(sc.ScreenControlSession, "_stop_keepalive_thread", lambda self: None)
     monkeypatch.setattr(sc.dev, "device_row", lambda *a, **k: None)
     monkeypatch.setattr(sc.dev, "resolve_adb", lambda h, *a, **k: "serial-oneui-device")
-    monkeypatch.setattr(sc, "lock_portrait_orientation", lambda _s: {})
-    monkeypatch.setattr(sc, "restore_rotation_settings", lambda *a, **k: True)
+    monkeypatch.setattr(sc, "lock_portrait_orientation", lambda _s: None)
     session.__enter__()
     assert session.active is True
     assert ("inv", True) in calls
@@ -145,8 +144,7 @@ def test_session_does_not_save_or_restore_foreground(monkeypatch, tmp_path):
     monkeypatch.setattr(sc, "get_default_ime", lambda _s: "com.example/.Ime")
     monkeypatch.setattr(sc, "set_inversion", lambda _s, en: True)
     monkeypatch.setattr(sc, "restore_default_ime", lambda *a, **k: True)
-    monkeypatch.setattr(sc, "lock_portrait_orientation", lambda _s: {"user_rotation": "1"})
-    monkeypatch.setattr(sc, "restore_rotation_settings", lambda *a, **k: True)
+    monkeypatch.setattr(sc, "lock_portrait_orientation", lambda _s: None)
     monkeypatch.setattr(
         sc,
         "restore_foreground",
@@ -252,28 +250,9 @@ def test_apply_portrait_lock_sets_system_settings(monkeypatch):
     )
 
 
-def test_restore_rotation_settings_restores_saved(monkeypatch):
-    calls = []
-
-    def fake_shell(serial, *args, **kw):
-        calls.append((serial, args))
-        return 0, ""
-
-    monkeypatch.setattr(sc, "mac_adb_shell", fake_shell)
-    saved = {"accelerometer_rotation": "1", "user_rotation": "3"}
-    assert sc.restore_rotation_settings("serial-1", saved) is True
-    assert (
-        "serial-1",
-        ("settings", "put", "system", "accelerometer_rotation", "1"),
-    ) in calls
-    assert (
-        "serial-1",
-        ("settings", "put", "system", "user_rotation", "3"),
-    ) in calls
-    assert any(c[1][:1] == ("cmd",) or c[1][:1] == ("wm",) for c in calls)
-
-
-def test_session_locks_portrait_on_enter_and_restores_on_exit(monkeypatch, tmp_path):
+def test_session_locks_portrait_on_enter_and_does_not_restore_on_exit(monkeypatch, tmp_path):
+    """Portrait lock is a standing baseline — exit must never touch rotation
+    settings, even though a prior manual lock may have happened mid-session."""
     monkeypatch.setenv("DEVICE_SCREEN_CONTROL_DIR", str(tmp_path / "dsc"))
     monkeypatch.setenv("DEVICE_SCREEN_CONTROL_PROJECT", "stayturgid")
     rotation_calls = []
@@ -294,58 +273,15 @@ def test_session_locks_portrait_on_enter_and_restores_on_exit(monkeypatch, tmp_p
     monkeypatch.setattr(
         sc,
         "lock_portrait_orientation",
-        lambda s: rotation_calls.append(("lock", s)) or {"accelerometer_rotation": "1", "user_rotation": "2"},
-    )
-    monkeypatch.setattr(
-        sc,
-        "restore_rotation_settings",
-        lambda s, saved: rotation_calls.append(("restore", s, saved)) or True,
+        lambda s: rotation_calls.append(("lock", s)),
     )
     monkeypatch.setattr(sc.ScreenControlSession, "_start_keepalive", lambda self: None)
     monkeypatch.setattr(sc.ScreenControlSession, "_stop_keepalive_thread", lambda self: None)
     session.__enter__()
     assert session.serial == "serial-oneui-device"
-    assert session._saved_rotation == {"accelerometer_rotation": "1", "user_rotation": "2"}
     assert ("lock", "serial-oneui-device") in rotation_calls
     monkeypatch.setattr(sc, "restore_default_ime", lambda *a, **k: True)
     monkeypatch.setattr(sc, "restore_foreground", lambda *a, **k: True)
     session.__exit__(None, None, None)
-    assert (
-        "restore",
-        "serial-oneui-device",
-        {"accelerometer_rotation": "1", "user_rotation": "2"},
-    ) in rotation_calls
-
-
-def test_get_system_setting_raises_on_error(monkeypatch):
-    monkeypatch.setattr(sc, "mac_adb_shell", lambda *a, **k: (1, "error\n"))
-    with pytest.raises(sc.SettingsReadError):
-        sc._get_system_setting("serial-1", "some_key")
-
-
-def test_read_rotation_settings_returns_none_on_error(monkeypatch):
-    def fake_shell(*args, **kw):
-        return 1, "error\n"
-
-    monkeypatch.setattr(sc, "mac_adb_shell", fake_shell)
-    assert sc.read_rotation_settings("serial-1") is None
-
-
-def test_restore_rotation_settings_deletes_null(monkeypatch):
-    calls = []
-
-    def fake_shell(serial, *args, **kw):
-        calls.append((serial, args))
-        return 0, ""
-
-    monkeypatch.setattr(sc, "mac_adb_shell", fake_shell)
-    saved = {"accelerometer_rotation": "null", "user_rotation": "3"}
-    assert sc.restore_rotation_settings("serial-1", saved) is True
-    assert (
-        "serial-1",
-        ("settings", "delete", "system", "accelerometer_rotation"),
-    ) in calls
-    assert (
-        "serial-1",
-        ("settings", "put", "system", "user_rotation", "3"),
-    ) in calls
+    assert not hasattr(session, "_saved_rotation")
+    assert [c for c in rotation_calls if c[0] == "restore"] == []


### PR DESCRIPTION
## Summary

Fixes a live, operator-reported regression on p7a: rotation lock kept
"getting reset away from locked" shortly after being manually set.

`ScreenControlSession` (both `control/lib/screen_control.py` and the
on-device Termux twin) snapshotted the device's rotation settings at
session start, force-locked portrait for the session, then restored the
pre-session snapshot on exit. This is a genuine race: if the operator
manually locked rotation while any automation session happened to be
active (the fleet's repair/health bridges run these periodically), that
session's `__exit__` would restore its stale pre-session value — silently
undoing the operator's own change made after the snapshot was taken.

This is a different bug from the one fixed in #136 (issue #42), which
addressed `read`-failure handling in the same file — this is a design-level
save/restore race, not a read error.

## Fix

Per operator decision: portrait lock is now a standing device baseline,
never restored. `lock_portrait_orientation()` just asserts the lock and no
longer reads/saves prior settings; `restore_rotation_settings()` and the
now-unused `read_rotation_settings()` / `SettingsReadError` /
`_get_system_setting()` are removed entirely (only `apply_portrait_lock`
remains, still used by the keepalive loop). Session `__exit__` no longer
touches rotation settings at all. To go back to auto-rotate, an operator
unlocks manually — no future automation session undoes that.

Docs updated: `docs/architecture/components/screen-control-lease.md` and
both module docstrings.

## Test plan

- [x] `.venv-test/bin/python -m pytest tests/python/ -q` — full suite, 254/254 pass
- [x] `ruff check` on all changed files — clean
- [x] `prettier --check` on the changed doc — clean
- [x] Live-confirmed root cause against p7a (`100.65.230.108:5555`) before
      writing the fix: `settings get system accelerometer_rotation` / device
      logs traced the reset to `ScreenControlSession.__exit__`'s
      `restore_rotation_settings` call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Portrait orientation is now applied as a standing baseline when a screen-control session starts.
  * Rotation settings are no longer automatically restored when the session ends.
  * To return to auto-rotate, device rotation settings must be changed manually.

* **Documentation**
  * Updated guidance to clarify the new portrait-lock behavior and prevent rotation-setting conflicts.

* **Tests**
  * Updated session behavior checks to verify portrait locking without automatic restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->