### PR TITLE
fix(landing): bidirectional registry cross-check and retention policy

### DIFF
--- a/control/landing/discover.py
+++ b/control/landing/discover.py
@@ -371,6 +371,7 @@ def _scan_localhost(
     *,
     registered_ports: set[int] | dict[int, str] | None = None,
     public_host: str | None = None,
+    skip_ports: set[int] | None = None,
 ) -> list[dict]:
     """Scan the Mac's local ports for HTTP servers using lsof.
 
@@ -412,6 +413,8 @@ def _scan_localhost(
         except ValueError:
             continue
         if port in scanned or port < 1 or port > 65535 or port in CADDY_PROXIED_PORTS:
+            continue
+        if skip_ports and port in skip_ports:
             continue
         scanned.add(port)
 
@@ -480,7 +483,54 @@ def discover(environ: Mapping[str, str] | None = None) -> dict:
 
     # Discover new http ports on localhost; badge registry drift (D4).
     registered = load_registered_ports(site_dir=site_dir, return_map=True)
-    for s in _scan_localhost(registered_ports=registered if registered else None, public_host=public_host):
+
+    path_ports: set[int] = set()
+    for url in known_urls:
+        try:
+            if url.startswith("http"):
+                base = url.split("://", 1)[1]
+                if "/" in base:
+                    host_port, path = base.split("/", 1)
+                    if ":" in host_port:
+                        port = int(host_port.split(":")[-1])
+                        if path and path != "":
+                            path_ports.add(port)
+        except ValueError:
+            pass
+
+    for url in list(known_urls.keys()):
+        try:
+            if url.startswith("http"):
+                base = url.split("://", 1)[1]
+                if "/" in base:
+                    host_port, path = base.split("/", 1)
+                    if (not path or path == "") and ":" in host_port:
+                        port = int(host_port.split(":")[-1])
+                        if port in path_ports:
+                            del known_urls[url]
+                else:
+                    if ":" in base:
+                        port = int(base.split(":")[-1])
+                        if port in path_ports:
+                            del known_urls[url]
+        except ValueError:
+            pass
+
+    if registered:
+        for port, svc_name in registered.items():
+            if port not in path_ports:
+                host_name = public_host if public_host else "localhost"
+                url = f"http://{host_name}:{port}"
+                if url not in known_urls:
+                    known_urls[url] = {
+                        "url": url,
+                        "label": _format_service_label(svc_name),
+                        "group": "mac",
+                    }
+
+    for s in _scan_localhost(
+        registered_ports=registered if registered else None, public_host=public_host, skip_ports=path_ports
+    ):
         url = s["url"]
         if url not in known_urls:
             known_urls[url] = s
@@ -489,6 +539,8 @@ def discover(environ: Mapping[str, str] | None = None) -> dict:
             known_urls[url]["label"] = s["label"]
             if s.get("unregistered"):
                 known_urls[url]["unregistered"] = True
+            else:
+                known_urls[url].pop("unregistered", None)
     # Discover non-HTTP services (Termux SSH, Wireless ADB) on detected Android devices
     device_names = {
         state._extract_device_name(s) for s in known_urls.values() if s.get("group") in ("devices", "android")
@@ -564,12 +616,51 @@ if __name__ == "__main__":
     except SiteDiscoveryError as exc:
         print(f"error: {exc}", file=sys.stderr)
         raise SystemExit(1) from exc
-    reachable = sum(1 for s in result["services"] if s.get("reachable"))
+
+    import os
+
+    selection = _resolve_site(os.environ)
+    registered = load_registered_ports(site_dir=selection.path)
+    static_urls = {ks["url"] for ks in _known_services_for_site(selection.path)}
+
+    reachable = 0
     total = len(result["services"])
-    unregistered = sum(1 for s in result["services"] if s.get("unregistered"))
+    unregistered_up = 0
+    registered_down = 0
+    catalog_unreachable = 0
+
+    for s in result["services"]:
+        is_up = s.get("reachable", False)
+        if is_up:
+            reachable += 1
+
+        url = s["url"]
+        port = None
+        try:
+            if "://" in url:
+                part = url.split("://", 1)[1].split("/", 1)[0]
+                if ":" in part:
+                    port = int(part.split(":")[-1])
+        except ValueError:
+            pass
+
+        is_reg = (port in registered) if port else False
+        is_cat = url in static_urls
+
+        if is_cat and not is_up:
+            catalog_unreachable += 1
+        elif is_reg and not is_up:
+            registered_down += 1
+
+        if s.get("unregistered") and is_up:
+            unregistered_up += 1
+
     print(f"Discovery complete: {reachable}/{total} services reachable")
-    if unregistered:
-        print(f"Registry drift: {unregistered} unregistered listener(s) (not in registry/ports.yml)")
+    print(
+        f"Summary: {registered_down} registered-down, {unregistered_up} unregistered-up, {catalog_unreachable} catalog-unreachable"
+    )
+    if unregistered_up:
+        print(f"Registry drift: {unregistered_up} unregistered listener(s) (not in registry/ports.yml)")
     for s in result["services"]:
         status = "✓" if s.get("reachable") else "✗"
         badge = " [unregistered]" if s.get("unregistered") else ""

--- a/docs/adding-a-launchd-service.md
+++ b/docs/adding-a-launchd-service.md
@@ -131,6 +131,18 @@ tail ~/Library/Logs/my-agent.log
 
 ---
 
+## Dashboard / Discovery Retention
+
+When a new service is added, it typically appears on the Fleet Dashboard. The discovery scanner (`discover.py`) categorizes and retains services based on the following policy:
+
+- **Registered services (kept when down):** If the service's port or path is listed in `registry/ports.yml` or `registry/paths.yml`, it is considered a permanent part of the infrastructure. If the service crashes or is stopped, it will remain visible on the dashboard in a "down" (`reachable: false`) state to alert the operator.
+- **Catalog services (kept when down):** Services hardcoded in the static `control/landing/services.json` catalog are also permanently retained and will show as down if unreachable.
+- **Ephemeral / Unregistered services (pruned when down):** If a service is discovered running (e.g., via a local port scan) but is not in the registry or the static catalog, it will appear on the dashboard while it is active (as `unregistered-up`). However, once it stops listening, it is immediately **pruned** from the state and disappears from the dashboard.
+
+To ensure your new launchd service remains visible when down for monitoring and healing, always claim its port or path in the registry.
+
+---
+
 ## Common patterns
 
 ### KeepAlive server (long-running daemon)

--- a/tests/python/test_landing_discover.py
+++ b/tests/python/test_landing_discover.py
@@ -1,0 +1,143 @@
+import pytest
+
+from control.landing import discover, state
+from control.lib.site_discovery import SiteSelection
+
+
+@pytest.fixture
+def mock_env(monkeypatch, tmp_path):
+    site_dir = tmp_path / "site"
+    site_dir.mkdir()
+
+    def mock_resolve(env):
+        return SiteSelection(path=site_dir, source="test")
+
+    monkeypatch.setattr(discover, "_resolve_site", mock_resolve)
+    monkeypatch.setattr(discover, "announce_site_selection", lambda s, command: None)
+    monkeypatch.setattr(state, "write_state", lambda d: None)
+    return site_dir
+
+
+@pytest.fixture
+def mock_known_services(monkeypatch):
+    monkeypatch.setattr(discover, "_known_services_for_site", lambda site_dir: [])
+
+
+def test_gap1_registered_not_listening(mock_env, mock_known_services, monkeypatch):
+    monkeypatch.setattr(
+        discover,
+        "load_registered_ports",
+        lambda site_dir, return_map=False: {8080: "My Service"} if return_map else {8080},
+    )
+    monkeypatch.setattr(state, "load_state", lambda: {"services": [], "hidden": []})
+    monkeypatch.setattr(discover, "_scan_localhost", lambda **kwargs: [])
+    monkeypatch.setattr(discover, "_http_probe", lambda url, **kwargs: None)
+    monkeypatch.setattr(discover, "_tcp_probe", lambda host, port, **kwargs: False)
+
+    result = discover.discover({})
+
+    services = result["services"]
+    assert len(services) == 1
+    svc = services[0]
+    assert svc["url"] == "http://localhost:8080"
+    assert svc["reachable"] is False
+    assert svc["label"] == "My Service"
+
+
+def test_retention_registered_unreachable(mock_env, mock_known_services, monkeypatch):
+    monkeypatch.setattr(
+        discover,
+        "load_registered_ports",
+        lambda site_dir, return_map=False: {9090: "Old Service"} if return_map else {9090},
+    )
+    monkeypatch.setattr(
+        state,
+        "load_state",
+        lambda: {
+            "services": [
+                {
+                    "url": "http://localhost:9090",
+                    "label": "Old Service",
+                    "group": "mac",
+                    "reachable": True,
+                    "last_seen": "2026-01-01T00:00:00Z",
+                }
+            ],
+            "hidden": [],
+        },
+    )
+
+    monkeypatch.setattr(discover, "_scan_localhost", lambda **kwargs: [])
+    monkeypatch.setattr(discover, "_http_probe", lambda url, **kwargs: None)
+    monkeypatch.setattr(discover, "_tcp_probe", lambda host, port, **kwargs: False)
+
+    result = discover.discover({})
+
+    services = result["services"]
+    assert len(services) == 1
+    svc = services[0]
+    assert svc["url"] == "http://localhost:9090"
+    assert svc["reachable"] is False
+    assert svc["last_seen"] == "2026-01-01T00:00:00Z"
+
+
+def test_prune_unregistered_unreachable(mock_env, mock_known_services, monkeypatch):
+    monkeypatch.setattr(
+        discover, "load_registered_ports", lambda site_dir, return_map=False: {} if return_map else set()
+    )
+    monkeypatch.setattr(
+        state,
+        "load_state",
+        lambda: {
+            "services": [
+                {
+                    "url": "http://localhost:12345",
+                    "label": "Port 12345 [unregistered]",
+                    "group": "mac",
+                    "unregistered": True,
+                    "reachable": True,
+                    "last_seen": "2026-01-01T00:00:00Z",
+                }
+            ],
+            "hidden": [],
+        },
+    )
+
+    monkeypatch.setattr(discover, "_scan_localhost", lambda **kwargs: [])
+    monkeypatch.setattr(discover, "_http_probe", lambda url, **kwargs: None)
+    monkeypatch.setattr(discover, "_tcp_probe", lambda host, port, **kwargs: False)
+
+    result = discover.discover({})
+
+    services = result["services"]
+    assert len(services) == 0
+
+
+def test_gap2_dual_row_ambiguity(mock_env, monkeypatch):
+    monkeypatch.setattr(
+        discover,
+        "load_registered_ports",
+        lambda site_dir, return_map=False: {6736: "OpenUsage"} if return_map else {6736},
+    )
+    monkeypatch.setattr(
+        discover,
+        "_known_services_for_site",
+        lambda site_dir: [{"url": "http://localhost:6736/v1/limits", "label": "OpenUsage Limits API", "group": "mac"}],
+    )
+    monkeypatch.setattr(state, "load_state", lambda: {"services": [], "hidden": []})
+
+    def mock_scan(*, registered_ports=None, public_host=None, skip_ports=None):
+        if skip_ports and 6736 in skip_ports:
+            return []
+        return [{"url": "http://localhost:6736", "label": "OpenUsage", "group": "mac"}]
+
+    monkeypatch.setattr(discover, "_scan_localhost", mock_scan)
+    monkeypatch.setattr(discover, "_http_probe", lambda url, **kwargs: 200)
+    monkeypatch.setattr(discover, "_tcp_probe", lambda host, port, **kwargs: True)
+
+    result = discover.discover({})
+
+    services = result["services"]
+    urls = [s["url"] for s in services]
+    assert "http://localhost:6736/v1/limits" in urls
+    assert "http://localhost:6736" not in urls


### PR DESCRIPTION
Addresses gap 1 (seeding offline registry ports), gap 2 (scrubbing redundant root urls), and gap 3 (status breakdown). Documents dashboard retention policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved service discovery to avoid duplicate entries and prioritize more specific service paths.
  - Registered services remain visible when temporarily unavailable, while inactive unregistered services are removed.
  - Discovery results now provide clearer availability and registry-drift summaries.

- **Documentation**
  - Added guidance explaining how registered and unregistered services are retained or removed from the Dashboard.

- **Bug Fixes**
  - Corrected stale service status flags and preserved the last-seen information for unavailable registered services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->