### PR TITLE
agent: bump native-agent to 0.7.0-liveness-hardening

### DIFF
--- a/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
+++ b/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
@@ -41,10 +41,14 @@ stayturgid_debug_key_alias: "androiddebugkey"
 stayturgid_bootstrap_apks:
   - id: org.stayturgid.agent
     gh_repo: djbclark/stayturgid
-    gh_tag: agent-v0.6.0
+    # PLACEHOLDER — agent-v0.7.0 has not been published yet as of this commit.
+    # This tag name is the intended release name; do not deploy until a real
+    # `agent-v0.7.0` GitHub Release with app-release.apk (matching the
+    # checksum below) has actually been published.
+    gh_tag: agent-v0.7.0
     gh_pattern: app-release.apk
-    version_name: 0.6.0-boot-stability
-    checksum: "sha256:b99b3c9a7c28c53fc0a8b339dceeff5d394bb60507842dedd8bdbf18898d883d"
+    version_name: 0.7.0-liveness-hardening
+    checksum: "sha256:df62d17bd779e6fd92694012d085cdde7fe33fbdc23194c34243c800577792f6"
     resign: false
     start_broadcast_action: org.stayturgid.agent.action.PEER_START_NOW
     start_broadcast_component: org.stayturgid.agent/org.stayturgid.agent.PeerStartReceiver

--- a/device/native-agent/app/build.gradle.kts
+++ b/device/native-agent/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "org.stayturgid.agent"
         minSdk = 26
         targetSdk = 36
-        versionCode = 15
-        versionName = "0.6.0-boot-stability"
+        versionCode = 16
+        versionName = "0.7.0-liveness-hardening"
         val buildTimeUtc =
             System.getenv("SOURCE_DATE_EPOCH")?.toLongOrNull()?.let { Instant.ofEpochSecond(it) }
                 ?: Instant.now().truncatedTo(ChronoUnit.SECONDS)

--- a/tests/python/test_bootstrap_apk_lock.py
+++ b/tests/python/test_bootstrap_apk_lock.py
@@ -23,9 +23,9 @@ def test_every_github_apk_is_immutably_locked():
 
 def test_native_agent_uses_its_release_stream_and_real_asset_name():
     agent = next(apk for apk in _catalog() if apk["id"] == "org.stayturgid.agent")
-    assert agent["gh_tag"] == "agent-v0.6.0"
+    assert agent["gh_tag"] == "agent-v0.7.0"
     assert agent["gh_pattern"] == "app-release.apk"
-    assert agent["version_name"] == "0.6.0-boot-stability"
+    assert agent["version_name"] == "0.7.0-liveness-hardening"
     assert agent["remove_packages"] == ["org.stayturgid.agent.debug"]
     assert agent["service_component"] == "org.stayturgid.agent/.HostService"
     assert agent["start_broadcast_action"] == "org.stayturgid.agent.action.PEER_START_NOW"


### PR DESCRIPTION
## Summary

Bundles 7 commits that landed on `device/native-agent/` since `agent-v0.6.0` was cut and never shipped to the fleet:

- **Durable heartbeat/liveness monitoring** (#86, e2f7d81): HostService now writes a MediaStore heartbeat file every 120s from a thread independent of Shizuku/coroutines, so a hung Shizuku call can't block it. `check_stayturgid_agent` in CFEngine and `fleet_health.py` both read this heartbeat instead of the old adb-loopback/dumpsys checks, which were flaky on Pixel and dead on Fire OS (false-negative restarts). Restart path tries Termux's own `am start` first, falls back to adb-loopback, and after 3 consecutive failures writes an alert-only reboot-candidate marker (never reboots itself — hd8 has a bootloop hazard on `adb reboot`).
- **CatastrophicRepair loopback gate** (#60, d6e6ec6): stops `CatastrophicRepair` from unconditionally running `adb connect 127.0.0.1:5555` on Fire OS, where that connect pattern is known to be dropped by adbd — now gated on `privilegedShellExpected` like Termux's own scripts already were.
- **Shizuku UserService reap fixes** (#65, 2e62dac + 594633d + 60cccbc): live-verified the UserService-leak fix already on master, then fixed two real follow-on bugs — `reapStaleUserServices()` was scoped to both the release and debug application IDs regardless of which variant was actually running (risk of killing a legitimately running variant's service), and `runPidof`/`killPids` didn't manage child-process lifecycle or log unexpected exit codes.
- **Mac adb transport resolution for peer-start reminders** (#66, e55e1d4): `set_target_reminder()` was calling `resolve_target()` with a Tailscale host:port even though `devices.conf` lookups match by alias, making it a silent no-op for devices only reachable by USB serial. Added a reverse alias lookup so the Mac resolves the correct adb transport per device.

New version: `versionCode 16`, `versionName "0.7.0-liveness-hardening"`.

Also updates the `org.stayturgid.agent` entry in `bootstrap_apks`'s lock (`ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml`) to match the freshly built APK:

- `version_name: 0.7.0-liveness-hardening`
- `checksum: sha256:df62d17bd779e6fd92694012d085cdde7fe33fbdc23194c34243c800577792f6` (real SHA-256 of the built `app-release.apk`, verified genuinely release-signed with the fleet's real key, cert fingerprint `66:51:CB:15:82:A2:AB:9F:83:BC:82:03:DA:4E:45:91:BC:76:EF:18:7E:8B:4C:77:1D:CC:7A:97:68:BE:29:3E`)
- **`gh_tag: agent-v0.7.0` is a placeholder** — no GitHub Release with that tag exists yet. Do not deploy this lock entry until a real `agent-v0.7.0` release is published with this exact APK (same checksum) as its `app-release.apk` asset. Publishing that release is out of scope for this PR.

## Out of scope (explicitly, per task brief)

- No `gh release create` — publishing the release is a separate, deliberate step for whoever cuts it.
- No live device changes — no `adb install`, no fleet deploy.
- This PR is not self-merged.

## Test plan

- [x] `just worktree-setup` run for real (fresh installs confirmed, not silently skipped)
- [x] `just kt-build-release` — build succeeded, produced `app-release.apk`
- [x] `apksigner verify --print-certs` — confirmed cert SHA-256 matches the known fleet signing key
- [x] `aapt dump badging` — confirmed `versionCode='16' versionName='0.7.0-liveness-hardening'` baked into the APK, `applicationId=org.stayturgid.agent` (release, not debug)
- [x] `just check` — clean (ansible-lint, yamllint, markdownlint, shellcheck, etc.)
- [x] `just test` — 643 pytest + all node/bash suites pass (fixed a stale hardcoded assertion in `test_bootstrap_apk_lock.py` referencing the old `agent-v0.6.0`/`0.6.0-boot-stability` values)
- [x] `just kt-check` (spotless + detekt + kotlin test) — clean
- [x] CI-exact `lychee --offline --exclude-path 'node_modules|\.html$' --root-dir . .` — 0 errors

Built APK saved to `/tmp/agent-v0.7.0-app-release.apk` for whoever cuts the actual release (same bytes/checksum as what CI will rebuild).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the native Android agent to release version 0.7.0, including liveness hardening improvements.
  * Updated release metadata to use the corresponding APK package and checksum.

* **Tests**
  * Updated release validation checks for the new agent version and release assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->