### PR TITLE
Remove now-stale placeholder note from agent-v0.7.0 lock entry

### DIFF
--- a/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
+++ b/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
@@ -41,10 +41,6 @@ stayturgid_debug_key_alias: "androiddebugkey"
 stayturgid_bootstrap_apks:
   - id: org.stayturgid.agent
     gh_repo: djbclark/stayturgid
-    # PLACEHOLDER — agent-v0.7.0 has not been published yet as of this commit.
-    # This tag name is the intended release name; do not deploy until a real
-    # `agent-v0.7.0` GitHub Release with app-release.apk (matching the
-    # checksum below) has actually been published.
     gh_tag: agent-v0.7.0
     gh_pattern: app-release.apk
     version_name: 0.7.0-liveness-hardening


### PR DESCRIPTION
Real GitHub Release published at agent-v0.7.0 (verified: downloaded the actual asset, checksum matches the lock entry exactly). The "not yet published, don't deploy" comment in the PR that bumped this lock entry no longer applies.

## Verification
- `gh release view agent-v0.7.0` — published, asset `app-release.apk`
- Real download + `shasum -a 256` matches lock entry's checksum exactly
- `apksigner verify --print-certs` on the built APK matches the fleet's confirmed signing key
- yamllint clean with the project's actual config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an outdated deployment warning for the Android agent package.
  * The existing locked installation settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->