### PR TITLE
chore: bump ops-release.json to 1.1.0

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.0.13"
+  "version": "1.1.0"
 }


### PR DESCRIPTION
Coordinated ops-v1.1.0 release cut — bundling all unreleased work since ops-v1.0.13. Part of a 3-repo coordinated version bump (stayturgid, site-djbclark, site-private).