### PR TITLE
Remove remaining Aurora Store residuals

### DIFF
--- a/ansible_collections/stayturgid/android_common/plugins/modules/shizuku_grant.py
+++ b/ansible_collections/stayturgid/android_common/plugins/modules/shizuku_grant.py
@@ -23,7 +23,7 @@ options:
     type: str
     required: true
   package:
-    description: App package to authorize (e.g. Neo Store, Aurora Store).
+    description: App package to authorize (e.g. org.stayturgid.agent, com.termux).
     type: str
     required: true
   connect:

--- a/ansible_collections/stayturgid/android_common/roles/ensure_apps/defaults/main.yml
+++ b/ansible_collections/stayturgid/android_common/roles/ensure_apps/defaults/main.yml
@@ -1,18 +1,14 @@
 ---
 # Unified app ensure specs — each entry picks a source backend.
 #
-# Supported sources (control-node unless noted):
-#   play      — stayturgid.play.play_apps (apkeep/gplaycli + adb)
-#   apk       — stayturgid.android_common.android_apk (local/url/gh)
-#   fdroid    — fdroidcl install <id> on control node
-#   obtainium — stayturgid.obtainium.obtainium_app (runs on device over SSH)
+# Supported sources (control-node, delegate_to: localhost):
+#   play — stayturgid.play.play_apps (apkeep/gplaycli + adb)
+#   apk  — stayturgid.android_common.android_apk (local/url/gh)
 #
 # Example:
 # stayturgid_ensure_apps:
-#   - id: com.aurora.store
+#   - id: com.google.android.apps.authenticator2
 #     source: play
-#   - id: org.breezyweather
-#     source: fdroid
 #   - id: org.stayturgid.agent
 #     source: apk
 #     gh_repo: djbclark/stayturgid

--- a/ansible_collections/stayturgid/play/plugins/modules/play_apps.py
+++ b/ansible_collections/stayturgid/play/plugins/modules/play_apps.py
@@ -12,7 +12,6 @@ short_description: Ensure Play apps are installed via apkeep/gplaycli + adb
 description:
   - Downloads APKs on the control node (C(apkeep) or C(gplaycli)) and installs
     on a device with C(adb). Optionally spoofs C(com.android.vending) as installer.
-  - Does not install Aurora Store — use the C(play_store) role / Obtainium first.
   - Google Play downloads require credentials on the control node (env vars or
     gplaycli.conf); see C(docs/modules/play.md).
 options:

--- a/control/bin/deploy_fleet.py
+++ b/control/bin/deploy_fleet.py
@@ -217,7 +217,7 @@ def warn_prerequisites(scope: Scope) -> None:
             print("WARNING: " + msg + " — F-Droid repo sync will fail", file=sys.stderr)
     if needs_apkeep and not shutil.which("apkeep"):
         print(
-            "WARNING: apkeep not found (brew install apkeep) — Aurora auto-install will fail",
+            "WARNING: apkeep not found (brew install apkeep) — Play app installs will fail",
             file=sys.stderr,
         )
     env = repo_env()

--- a/control/bin/harden_fleet_apps.py
+++ b/control/bin/harden_fleet_apps.py
@@ -3,8 +3,7 @@
 
 Grants runtime permissions, disables unused-app restrictions, and applies
 per-package battery policy from control/lib/fleet_app_profiles.json (most fleet
-apps are Doze-whitelisted; Aurora Store stays battery-optimized). Mirrors
-android_common.app_privileges Ansible role.
+apps are Doze-whitelisted). Mirrors android_common.app_privileges Ansible role.
 
 Usage: ./harden_fleet_apps.py <oneui-device|stock-android-device|fireos-device|serial>
 """

--- a/control/lib/hd8_google_stack.py
+++ b/control/lib/hd8_google_stack.py
@@ -214,11 +214,6 @@ def reinstall_gsf(run_command, device: str, zip_path: Path, work_dir: Path) -> d
     }
 
 
-def stop_aurora_churn(run_command, device: str) -> None:
-    """Aurora Store (parked) triggers GMS BadAuthentication on uncertified Fire."""
-    adb_shell(run_command, device, "am", "force-stop", "com.aurora.store")
-
-
 def _install_splits(run_command, device: str, apks: list[Path]) -> tuple[int, str]:
     if not apks:
         return 1, "no APK splits"
@@ -275,7 +270,6 @@ def repair_if_needed(
     *,
     force: bool = False,
     cache_dir: Path | None = None,
-    stop_aurora: bool = True,
 ) -> dict:
     """Whitelist always; reinstall GSF 10 if missing; pin GMS/Play only if force/opt-in.
 
@@ -286,8 +280,6 @@ def repair_if_needed(
     play_ver = package_version_code(run_command, device, PLAY_PKG)
     gsf_ver = package_version_name(run_command, device, GSF_PKG)
     whitelist = ensure_doze_whitelist(run_command, device)
-    if stop_aurora:
-        stop_aurora_churn(run_command, device)
     # Full stack pin only when explicitly forced or pin policy enabled + drift.
     pin_stack = force or (pin_gms_enabled() and (needs_gms_downgrade(gms_ver) or needs_play_downgrade(play_ver)))
     out: dict[str, Any] = {


### PR DESCRIPTION
Follow-up to #145 (Aurora Store client automation removal) — a sweep of
remaining code/doc references found real live code still touching Aurora:

- `hd8_google_stack.py`'s `stop_aurora_churn()` was still force-stopping
  `com.aurora.store` on every hd8 repair pass — a no-op now, removed along
  with the unused `stop_aurora` parameter.
- Stale docstrings in `play_apps.py`, `shizuku_grant.py`,
  `harden_fleet_apps.py`, `deploy_fleet.py` naming Aurora/Obtainium as if
  still live.
- `ensure_apps/defaults/main.yml` documented 4 source backends but only 2
  are actually dispatched — corrected.

## Verification
Full `just worktree-setup` + `just check` + `just test` + the exact CI
`lychee --offline` command all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated app installation guidance and examples to reflect supported sources: Play and APK.
  * Clarified package examples, prerequisite warnings, and fleet app protection details.
  * Removed outdated references to separate Aurora Store installation handling.

* **Behavior Changes**
  * App repair operations no longer forcibly stop Aurora Store before continuing maintenance tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->