### PR TITLE
Fix findings from issue #139 (stayturgid repo docs audit)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,8 @@ per-site agents.
 ## Conventions
 
 - Use bash (not zsh). Termux has no zsh by default.
+- **Modern CLI tools:** use modern Rust rewrites on the Mac control node when available (`rg` instead of `grep`, `fd` instead of `find`, `bat`, `sd`, `eza`, `hck`, `delta`, `jq`).
+- **File counting/listing:** use `git ls-files '*.md'` instead of `find . -name '*.md'` to avoid traversing gitignored bloat (node_modules, caches).
 - Announce before device interaction: 🚨📱🚨 USING — host — why — ~N min
 - Screen control requires `ScreenControlSession` (fail-closed).
 - Accessibility is detection-only. Never `settings put` accessibility services automatically.

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -117,7 +117,7 @@ ansible_python_interpreter: /data/data/com.termux/files/usr/bin/python
 
 Reusable modules live in domain collections under `ansible_collections/stayturgid/`
 (`termux`, `obtainium`, `fdroid`, `play`, `android_common`). See
-[../ansible_collections/README.md](../control/lib/README.md) for install
+[../ansible_collections/README.md](../ansible_collections/README.md) for install
 and adoption docs. In development, `ansible.cfg` discovers collections from
 `../ansible_collections` — no separate `ansible-galaxy install` for stayturgid
 modules beyond `ansible.posix`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -95,12 +95,10 @@ more than a day or two old.
 
 1. Answer the seven ownership questions in the private #50 audit before any
    repository moves.
-2. Set OpenObserve credentials for the Vector LaunchAgent and restart it
-   ([#44](https://github.com/djbclark/stayturgid/issues/44)).
-3. Decide the F1 consent-surface phasing question ([#46](https://github.com/djbclark/stayturgid/issues/46)).
-4. Decide whether to publish Shizuku release20 through the normal APK path.
-5. Retest p7a only after firerpa/lamda#147 publishes a compatible runtime.
-6. Remove (or authorize removal of) the stray `~/stayturgid` file.
+2. Decide the F1 consent-surface phasing question ([#46](https://github.com/djbclark/stayturgid/issues/46)).
+3. Decide whether to publish Shizuku release20 through the normal APK path.
+4. Retest p7a only after firerpa/lamda#147 publishes a compatible runtime.
+5. Remove (or authorize removal of) the stray `~/stayturgid` file.
 
 ## Where things are documented
 

--- a/docs/architecture/components/control.md
+++ b/docs/architecture/components/control.md
@@ -104,16 +104,16 @@ and kept up by `just deploy-mac` / `control_node` agents:
 | Path                                                         | Purpose                                                                         |
 | ------------------------------------------------------------ | ------------------------------------------------------------------------------- |
 | `ansible/roles/control_node/tasks/hermes.yml`                | Install, model config, `.env` allowlist, launchd plist                          |
-| `~/.hermes/config.yaml`                                      | Default model (e.g. `grok-4.5`)                                                 |
+| `~/.hermes/config.yaml`                                      | Default model (e.g. `deepseek-chat`)                                            |
 | `~/.hermes/.env`                                             | **Secrets** — `TELEGRAM_BOT_TOKEN`, optional allowlist (mode `0600`, never git) |
-| `~/.hermes/auth.json`                                        | xAI OAuth tokens after `hermes auth add xai-oauth`                              |
+| `~/.hermes/auth.json`                                        | API keys after `hermes auth add deepseek-api`                                   |
 | `~/Library/LaunchAgents/com.stayturgid.hermes-gateway.plist` | KeepAlive gateway                                                               |
 
 **First-time (human):**
 
 ```bash
-# SuperGrok / Premium+ OAuth (browser)
-hermes auth add xai-oauth --type oauth
+# DeepSeek API (requires key)
+hermes auth add deepseek-api --type api-key
 
 # Bot token from @BotFather → ~/.hermes/.env
 # TELEGRAM_BOT_TOKEN=123:AA…

--- a/docs/architecture/components/control.md
+++ b/docs/architecture/components/control.md
@@ -104,16 +104,16 @@ and kept up by `just deploy-mac` / `control_node` agents:
 | Path                                                         | Purpose                                                                         |
 | ------------------------------------------------------------ | ------------------------------------------------------------------------------- |
 | `ansible/roles/control_node/tasks/hermes.yml`                | Install, model config, `.env` allowlist, launchd plist                          |
-| `~/.hermes/config.yaml`                                      | Default model (e.g. `deepseek-chat`)                                            |
+| `~/.hermes/config.yaml`                                      | Default model + fallback chain (e.g. routed via DeepSeek/OpenRouter)            |
 | `~/.hermes/.env`                                             | **Secrets** — `TELEGRAM_BOT_TOKEN`, optional allowlist (mode `0600`, never git) |
-| `~/.hermes/auth.json`                                        | API keys after `hermes auth add deepseek-api`                                   |
+| `~/.hermes/auth.json`                                        | API keys after `hermes auth add deepseek`                                       |
 | `~/Library/LaunchAgents/com.stayturgid.hermes-gateway.plist` | KeepAlive gateway                                                               |
 
 **First-time (human):**
 
 ```bash
-# DeepSeek API (requires key)
-hermes auth add deepseek-api --type api-key
+# DeepSeek API (requires key) — provider id is "deepseek", not "deepseek-api"
+hermes auth add deepseek --type api-key
 
 # Bot token from @BotFather → ~/.hermes/.env
 # TELEGRAM_BOT_TOKEN=123:AA…

--- a/docs/architecture/site-contract.md
+++ b/docs/architecture/site-contract.md
@@ -1,6 +1,6 @@
 # Site Contract v1 (specification)
 
-**Status:** Accepted spec, unimplemented (Phase C of the segmentation plan)
+**Status:** Shipped (Phase C+D). See the root `SITE-CONTRACT.md` for the living literate contract. This document serves as the historical architecture specification.
 **Authored:** 2026-07-18 by a senior model so junior implementers do not have
 to make design decisions. Implementers: follow this spec; deviations require
 operator approval. Companion: [ADR 005](adr/005-two-repo-topology.md), the

--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -8,9 +8,9 @@ This document gets a developer from a clean Android + macOS install to a fully w
 
 | Layer                   | Role                                                                |
 | ----------------------- | ------------------------------------------------------------------- |
-| Android device          | Runs AutoJs6, Shizuku, Termux — the managed stack                   |
+| Android device          | Runs stayturgid-agent, Shizuku, Termux — the managed stack          |
 | macOS (Mac)             | Development workstation; runs ADB, Ansible, AI coding agent         |
-| AutoJs6                 | Watchdog automation on the device (accessibility + Termux bridge)   |
+| stayturgid-agent        | Native Android agent (Kotlin/Shizuku UserService)                   |
 | Shizuku (thedjchi fork) | Shell-privileged adbd on port 5555 via Wireless Debugging (no root) |
 | Termux                  | Linux environment on Android — runs sshd, adb, the boot script      |
 
@@ -23,7 +23,7 @@ This document gets a developer from a clean Android + macOS install to a fully w
 | App                     | Package                      | Version                    | Source             |
 | ----------------------- | ---------------------------- | -------------------------- | ------------------ |
 | Android                 | —                            | 16 (SDK 36)                | —                  |
-| AutoJs6                 | `org.autojs.autojs6`         | 6.7.0                      | GitHub (see below) |
+| stayturgid-agent        | `com.stayturgid.agent`       | current                    | Built from source  |
 | Shizuku (thedjchi fork) | `moe.shizuku.privileged.api` | 13.6.0.r1349-thedjchi-beta | GitHub (see below) |
 | Termux                  | `com.termux`                 | 0.118.3                    | GitHub             |
 | Termux:Boot             | `com.termux.boot`            | 0.8.1                      | F-Droid / GitHub   |
@@ -42,17 +42,17 @@ This document gets a developer from a clean Android + macOS install to a fully w
 
 ### macOS development tools
 
-| Tool                        | Version                  | Install                                                  |
-| --------------------------- | ------------------------ | -------------------------------------------------------- |
-| macOS                       | Sequoia 15.x+            | —                                                        |
-| Homebrew                    | current                  | https://brew.sh                                          |
-| ADB (platform-tools)        | 1.0.41 / 37.0.0-14910828 | `brew install android-platform-tools`                    |
-| Python                      | 3.14.6                   | `brew install python`                                    |
-| uv                          | 0.x                      | `brew install uv`                                        |
-| Handsets (`~/.handsets/hs`) | 0.1.x                    | Mac primary UI driver — see `control/lib/ui_driver.py`   |
-| uiautomator2 (Python)       | 3.7.0                    | Optional Mac debug only (`uv tool install uiautomator2`) |
-| Claude Code (AI agent)      | current                  | `npm install -g @anthropic-ai/claude-code`               |
-| git                         | current                  | `brew install git`                                       |
+| Tool                              | Version                  | Install                                                  |
+| --------------------------------- | ------------------------ | -------------------------------------------------------- |
+| macOS                             | macOS 26.5.2             | —                                                        |
+| Homebrew                          | current                  | https://brew.sh                                          |
+| ADB (platform-tools)              | 1.0.41 / 37.0.0-14910828 | `brew install android-platform-tools`                    |
+| Python                            | 3.12+                    | `brew install python`                                    |
+| uv                                | 0.x                      | `brew install uv`                                        |
+| Handsets (`~/.handsets/hs`)       | 0.1.x                    | Mac primary UI driver — see `control/lib/ui_driver.py`   |
+| uiautomator2 (Python)             | 3.7.0                    | Optional Mac debug only (`uv tool install uiautomator2`) |
+| AI Agents (Hermes, Codex, Cursor) | current                  | Varies by agent                                          |
+| git                               | current                  | `brew install git`                                       |
 
 ---
 
@@ -109,16 +109,6 @@ https://github.com/termux/termux-api
 ```
 
 Or F-Droid: search "Termux:API".
-
-#### AutoJs6 (stayturgid watchdog)
-
-JavaScript automation engine — runs the stayturgid watchdog (accessibility UI repair + Termux bridge). See [docs/architecture/components/autojs6.md](architecture/components/autojs6.md).
-
-**Source:** https://github.com/djbclark/AutoJs6/releases (fleet-profile-553 build with non-UI configuration)
-
-**Source:** https://github.com/djbclark/AutoJs6/releases
-
-APK filter: `arm64-v8a` (or enable auto-filter-by-arch). Grant **Run commands in Termux environment** after install.
 
 #### Tailscale
 
@@ -234,22 +224,6 @@ termux-battery-status
 ```
 
 If the command hangs or errors, make sure the Termux:API app is installed (section 1.2) and that you've granted it the necessary permissions when prompted.
-
----
-
-### 1.5 Install and configure the AutoJs6 watchdog
-
-All of this is scripted from the Mac (device connected via USB or wireless ADB):
-
-```bash
-./control/tools/autojs6/setup_autojs6.py stock-android-device     # install/verify AutoJs6, grant permissions, deploy project
-./control/tools/autojs6/set_automation_mode.py stock-android-device
-./control/tools/autojs6/start_watchdog.py stock-android-device
-```
-
-On-device setup is automated: `enable_autojs6_shizuku.py` enables the accessibility service and Shizuku drawer; `setup_autojs6.py` / fleet harden grant storage, `RUN_COMMAND`, and battery settings. Termux `allow-external-apps=true` is set by the Ansible deploy (or manually in `~/.termux/termux.properties`).
-
-See [docs/architecture/components/autojs6.md](architecture/components/autojs6.md) for details.
 
 ---
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -61,13 +61,6 @@ an ID is ambiguous.
 config change, recoverable · **High** = fleet-wide or credential/publish blast
 radius · **Latent** = only act if a symptom returns.
 
-**Post-K1 note (2026-07-22):** the AutoJs6 watchdog/co-monitor runtime was
-retired fleet-wide by the native-agent cutover. Entries below that presuppose
-a live AutoJs6 runtime (43, 44, T2's device-test seam) need re-scoping against
-the native agent before any work starts — see
-[docs/STATUS.md](STATUS.md) for the current, **not yet fully verified**,
-cutover state.
-
 ---
 
 ## Pick a track
@@ -76,7 +69,7 @@ cutover state.
 | ---------------------- | -------------------------------------------------- | -------------- | ----------------------------- |
 | **A — Operational**    | Live deploy, human unblockers, current reliability | H1, H3, H5, 38 | Low–High                      |
 | **B — Ansible-native** | Bootstrap APK automation follow-ups                | B63, B64       | Low–Medium                    |
-| **D — Reliability**    | Symptom-driven hardening (needs post-K1 re-scope)  | 43, 44, 45     | Latent until triggered        |
+| **D — Reliability**    | Symptom-driven hardening                           | 44, 45         | Latent until triggered        |
 | **E — On-device LLM**  | shell-gpt escalation; incubator note               | 54             | Medium (mis-scope risk)       |
 | **F — FIRERPA**        | gRPC backup channel enhancements                   | F3             | Medium (future, core is done) |
 | **H — Post-migration** | fireos-device deploy, foreground-screen cleanup    | H1, H3, H9     | Low–Medium                    |
@@ -134,17 +127,9 @@ Mac soft health: launchd `com.stayturgid.fleet-health` →
 
 **Merged:** A11 — see [archive](archive/options-closed-2026-07-23.md#track-d--reliability).
 
-#### 43 — AutoJs6 WorkManager (agent) · Risk: **Latent** · Needs re-scope
+#### 44 — Tasker kicker for native agent/Shizuku recovery (agent) · Risk: **Latent**
 
-Presupposes a live AutoJs6 runtime, which the K1 cutover retired fleet-wide
-(2026-07-22). Likely moot; re-scope against the native agent's own scheduling
-model before picking this up, or close as superseded.
-
-#### 44 — Tasker kicker on stock-android-device (agent) · Risk: **Latent** · Needs re-scope
-
-Same caveat as 43 — was scoped against AutoJs6/watchdog stalls, which no
-longer exist post-K1. Re-scope against native-agent stalls if the symptom
-recurs, otherwise close as superseded.
+Investigate a minimal Tasker profile (e.g., triggered on a schedule or Shizuku stop) as an additional safeguard layer for the native Kotlin agent. Tasker has a strong track record surviving OEM background-process killing.
 
 #### 45 — Termux `sshd -D` if freeze returns (agent) · Risk: **Latent / Medium** · Trigger: sshd freeze
 


### PR DESCRIPTION
Fixes the in-scope stayturgid repo findings from #139.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated setup guidance for routing/model fallback and refreshed credential and first-time command examples for the control-node Hermes/Telegram setup.
  * Refreshed platform/dev environment details (Android-managed stack, updated macOS tooling versions) and removed retired AutoJs6/watchdog instructions.
  * Updated operator-action queue to reflect the new “human-only” step ordering.
  * Marked the site contract as shipped and clarified where to find the living version.
  * Corrected the Ansible collections link and revised contributor CLI conventions (prefer modern tools; avoid `find` for Markdown listings).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->