### PR TITLE
feat: Add CFEngine processes promises for sshd and otelcol-contrib (#103)

### DIFF
--- a/device/termux/cfengine/policy/stayturgid.cf
+++ b/device/termux/cfengine/policy/stayturgid.cf
@@ -1,4 +1,4 @@
-# @heals: SSHD-RUNNING BOOTLOOP-ALIVE NATIVE-AGENT-RUNNING
+# @heals: SSHD-RUNNING BOOTLOOP-ALIVE NATIVE-AGENT-RUNNING OTELCOL-RUNNING
 # stayturgid.cf — Standalone self-heal policy for CFEngine on Termux
 # Deploy to: ~/.stayturgid/cfengine/stayturgid.cf
 # Run: cf-agent -f ~/.stayturgid/cfengine/stayturgid.cf

--- a/device/termux/cfengine/policy/stayturgid.cf
+++ b/device/termux/cfengine/policy/stayturgid.cf
@@ -23,6 +23,7 @@ bundle agent stayturgid_heal {
 
   methods:
     "heal" usebundle => check_sshd("$(prefix)");
+    "heal" usebundle => check_otelcol("$(prefix)", "$(home)");
     "heal" usebundle => check_bootloop("$(stg)");
     "heal" usebundle => check_stayturgid_agent("$(prefix)", "$(stg)");
     "heal" usebundle => check_bootloop_repair("$(prefix)", "$(home)");
@@ -35,19 +36,38 @@ bundle agent stayturgid_heal {
 # ── Individual check bundles ──────────────────────────────────────────────
 
 bundle agent check_sshd(p) {
-  classes:
-    "sshd_running" expression => returnszero("$(p)/bin/pgrep -x sshd >/dev/null 2>&1 || $(p)/bin/pgrep -f '[s]shd' >/dev/null 2>&1", "useshell");
+  processes:
+    ".*bin/sshd.*"
+      restart_class => "restart_sshd";
 
   reports:
-    sshd_running::
+    !restart_sshd::
       "sshd: running";
-    !sshd_running::
+    restart_sshd::
       "sshd: RESTARTING";
 
   commands:
-    !sshd_running::
+    restart_sshd::
       "$(p)/bin/bash"
         args => "-c 'rm -f $(p)/var/service/sshd/down 2>/dev/null; $(p)/bin/sshd'",
+        contain => silent_bg;
+}
+
+bundle agent check_otelcol(p, home) {
+  processes:
+    ".*otelcol-contrib.*"
+      restart_class => "restart_otelcol";
+
+  reports:
+    !restart_otelcol::
+      "otelcol: running";
+    restart_otelcol::
+      "otelcol: RESTARTING";
+
+  commands:
+    restart_otelcol::
+      "$(p)/bin/bash"
+        args => "-c '$(home)/.termux/boot/start-otelcol.sh stop >/dev/null 2>&1 || true; $(home)/.termux/boot/start-otelcol.sh'",
         contain => silent_bg;
 }
 

--- a/tests/healing_registry.json
+++ b/tests/healing_registry.json
@@ -194,7 +194,7 @@
     },
     "OTELCOL-RUNNING": {
       "description": "Edge otelcol-contrib is installed, boot-integrated, and restarted by the Termux supervisor",
-      "must_cover": ["termux_repair", "ansible_deploy"],
+      "must_cover": ["termux_repair", "ansible_deploy", "cfengine"],
       "should_cover": []
     },
     "APK-RELEASE-LOCK": {


### PR DESCRIPTION
This PR implements the structural (tier 2) self-heal proposed in issue #103.

### What was done:
1. **Immediate (Ansible self-heal)**: Deliberately skipped. This was already completed and merged via PR #109, which added the retry mechanism to `otelcol.yml` and the Termux wake step to `preflight.yml`.
2. **Structural (CFEngine supervision)**: Added `processes:` promises for both `sshd` and `otelcol-contrib` to `stayturgid.cf` to ensure they are checked on CFEngine's own schedule, not just during fleet deploys. These checks will restart the services if they are killed by Android's low memory killer.

### Notes
- A full check suite (`bash tests/run.sh code`) was run to verify the CFEngine syntax changes, passing successfully.
- Best effort mechanism: Android may still win the race against these supervisors.
- Live verification via adb/ssh may be valuable for the orchestrator to perform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and recovery for the SSH service.
  * Added monitoring and automatic restart for the OpenTelemetry Collector when it is not running.
  * Healing status now more accurately reports whether services are running or being restarted.
  * Updated service health coverage to include the OpenTelemetry Collector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->