### PR TITLE
Add manual-trigger path for handsets-start, completing #121's port

### DIFF
--- a/device/native-agent/app/src/main/AndroidManifest.xml
+++ b/device/native-agent/app/src/main/AndroidManifest.xml
@@ -63,6 +63,20 @@
             </intent-filter>
         </receiver>
 
+        <!-- nosemgrep: java.android.security.exported_receiver.exported_receiver -->
+        <!-- Headless handsets-start trigger (issue #121). Exported so `adb shell am
+             broadcast` can kick it without foregrounding the UI; the action is a
+             single explicit-target, idempotent/benign push+launch, same risk profile
+             as PeerStartReceiver above. -->
+        <receiver
+            android:name=".HandsetsStartReceiver"
+            android:exported="true"
+            android:enabled="true">
+            <intent-filter>
+                <action android:name="org.stayturgid.agent.action.HANDSETS_START_NOW" />
+            </intent-filter>
+        </receiver>
+
         <!-- Required for Shizuku (not Sui-only). -->
         <provider
             android:name="rikka.shizuku.ShizukuProvider"

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/HandsetsStartReceiver.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/HandsetsStartReceiver.kt
@@ -1,0 +1,48 @@
+package org.stayturgid.agent
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+/**
+ * Headless trigger for a one-off handsets-start (issue #121) — lets ops/testing kick it **without
+ * foregrounding the app UI**, mirroring [PeerStartReceiver]'s pattern for peer-start:
+ * ```
+ * adb shell am broadcast -a org.stayturgid.agent.action.HANDSETS_START_NOW \
+ *   --es target_host <ip> --ei target_adb_port 5555 --ei handsets_port 9012 \
+ *   -n <pkg>/org.stayturgid.agent.HandsetsStartReceiver
+ * ```
+ *
+ * `target_adb_port` (the device's ADB port, [AdbClient] connects there) and `handsets_port` (the
+ * daemon's own listen port once launched) are distinct — both default sensibly if omitted.
+ *
+ * Unlike peer-start (which iterates a fleet-wide config of assigned targets), handsets-start has no
+ * config to load — it always targets whatever `target_host` the caller supplies, matching the
+ * single-target, on-demand semantics of the original `fire_peer_help.py handsets-start --target ...
+ * --port ...` CLI verb. It just forwards to [HostService.handsetsStartNow] (the already-running
+ * FGS), so it never launches an activity.
+ */
+class HandsetsStartReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        if (intent?.action != HostService.ACTION_HANDSETS_START_NOW) return
+        val host = intent.getStringExtra(HostService.EXTRA_TARGET_HOST)
+        val adbPort =
+            intent.getIntExtra(HostService.EXTRA_TARGET_ADB_PORT, PeerTarget.DEFAULT_ADB_PORT)
+        val handsetsPort =
+            intent.getIntExtra(HostService.EXTRA_HANDSETS_PORT, HandsetsStartCommands.DEFAULT_PORT)
+        if (host.isNullOrBlank()) {
+            Log.w(TAG, "handsets-start broadcast missing ${HostService.EXTRA_TARGET_HOST}")
+            return
+        }
+        Log.i(
+            TAG,
+            "handsets-start broadcast received for $host:$adbPort (daemon port $handsetsPort)",
+        )
+        HostService.handsetsStartNow(context.applicationContext, host, adbPort, handsetsPort)
+    }
+
+    companion object {
+        private const val TAG = "StayTurgidHandsetsRcv"
+    }
+}

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/HostService.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/HostService.kt
@@ -169,6 +169,18 @@ class HostService : Service() {
                 startAsForeground(bound = bound)
                 scope.launch { runPeerStart() }
             }
+            ACTION_HANDSETS_START_NOW -> {
+                startAsForeground(bound = bound)
+                val host = intent.getStringExtra(EXTRA_TARGET_HOST)
+                val adbPort = intent.getIntExtra(EXTRA_TARGET_ADB_PORT, PeerTarget.DEFAULT_ADB_PORT)
+                val handsetsPort =
+                    intent.getIntExtra(EXTRA_HANDSETS_PORT, HandsetsStartCommands.DEFAULT_PORT)
+                if (host.isNullOrBlank()) {
+                    Log.w(TAG, "handsets-start broadcast missing $EXTRA_TARGET_HOST")
+                } else {
+                    scope.launch { runHandsetsStart(host, adbPort, handsetsPort) }
+                }
+            }
             else -> {
                 // ensure FGS + bind path
                 startAsForeground(bound = bound)
@@ -359,6 +371,25 @@ class HostService : Service() {
             Log.e(TAG, "peerstart loop error", t)
         }
         updateActionNotifications()
+    }
+
+    /** One-off handsets-start against an explicit target (issue #121's manual-trigger path). */
+    private suspend fun runHandsetsStart(host: String, adbPort: Int, handsetsPort: Int) {
+        try {
+            val result =
+                withContext(Dispatchers.IO) {
+                    val key = PeerStarter.loadKey(applicationContext)
+                    HandsetsStarter.ensureHandsets(
+                        applicationContext,
+                        PeerTarget(host, adbPort),
+                        key,
+                        handsetsPort,
+                    )
+                }
+            Log.i(TAG, "handsetsstart ${result.target} -> ${result.outcome} ${result.detail}")
+        } catch (t: Throwable) {
+            Log.e(TAG, "handsetsstart error", t)
+        }
     }
 
     /**
@@ -617,6 +648,22 @@ class HostService : Service() {
         const val ACTION_PING_NOW = "org.stayturgid.agent.action.PING_NOW"
         const val ACTION_REPAIR_NOW = "org.stayturgid.agent.action.REPAIR_NOW"
         const val ACTION_PEER_START_NOW = "org.stayturgid.agent.action.PEER_START_NOW"
+        const val ACTION_HANDSETS_START_NOW = "org.stayturgid.agent.action.HANDSETS_START_NOW"
+        const val EXTRA_TARGET_HOST = "target_host"
+
+        /**
+         * The target device's **ADB** port (what [AdbClient] connects to) — not the daemon's own
+         * listen port below. Defaults to [PeerTarget.DEFAULT_ADB_PORT] (5555), matching every other
+         * [PeerTarget] in this codebase.
+         */
+        const val EXTRA_TARGET_ADB_PORT = "target_adb_port"
+
+        /**
+         * The port the Handsets daemon itself listens on once launched (`hs.jar`'s own port arg) —
+         * distinct from [EXTRA_TARGET_ADB_PORT] above. Defaults to
+         * [HandsetsStartCommands.DEFAULT_PORT] (9012).
+         */
+        const val EXTRA_HANDSETS_PORT = "handsets_port"
 
         fun start(context: Context) {
             val intent = Intent(context, HostService::class.java)
@@ -642,6 +689,30 @@ class HostService : Service() {
         fun peerStartNow(context: Context) {
             val intent =
                 Intent(context, HostService::class.java).apply { action = ACTION_PEER_START_NOW }
+            ContextCompat.startForegroundService(context, intent)
+        }
+
+        /**
+         * Headless trigger for a one-off handsets-start (issue #121) against an explicit
+         * [targetHost] — [targetAdbPort] is the device's **ADB** port ([AdbClient] connects there),
+         * [handsetsPort] is the port the daemon itself listens on once launched; these are
+         * distinct. Unlike peer-start, this has no fleet-wide config to iterate, mirroring the
+         * manual, single-target semantics of the original `fire_peer_help.py handsets-start
+         * --target ... --port ...` CLI verb.
+         */
+        fun handsetsStartNow(
+            context: Context,
+            targetHost: String,
+            targetAdbPort: Int = PeerTarget.DEFAULT_ADB_PORT,
+            handsetsPort: Int = HandsetsStartCommands.DEFAULT_PORT,
+        ) {
+            val intent =
+                Intent(context, HostService::class.java).apply {
+                    action = ACTION_HANDSETS_START_NOW
+                    putExtra(EXTRA_TARGET_HOST, targetHost)
+                    putExtra(EXTRA_TARGET_ADB_PORT, targetAdbPort)
+                    putExtra(EXTRA_HANDSETS_PORT, handsetsPort)
+                }
             ContextCompat.startForegroundService(context, intent)
         }
     }

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/PeerStarter.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/PeerStarter.kt
@@ -88,7 +88,10 @@ object PeerStarter {
         return results
     }
 
-    private fun loadKey(context: Context): AdbKey {
+    /**
+     * Visible to [HostService] so [HandsetsStarter]'s manual trigger can reuse the same identity.
+     */
+    internal fun loadKey(context: Context): AdbKey {
         val prefs = context.getSharedPreferences(ADB_KEY_PREFS, Context.MODE_PRIVATE)
         return AdbKey(PreferenceAdbKeyStore(prefs), ADB_KEY_NAME)
     }


### PR DESCRIPTION
Follow-up to #156 (#121's HandsetsStarter port). That PR added the object with no invocation path at all — this adds the manual broadcast trigger, mirroring `PeerStartReceiver`'s existing pattern for `shizuku-start` (#61).

Live-verified end-to-end against real hardware (s24 → hd8) via a throwaway `.debug`-suffixed sideload — never touched either device's production agent install or existing peer-key authorization. Confirmed:
- Broadcast → `HostService` → `HandsetsStarter` chain works correctly
- Reaches hd8's real adbd on port 5555
- Correctly returns `AUTH_PENDING` for an unauthorized key (matches `PeerStarter`'s proven exception handling)

Also fixes a real bug caught during that live test: the receiver/service originally used a single port for both the target's ADB connection and the Handsets daemon's own listen port — these are distinct (5555 vs 9012 by default) and got conflated. Now split into `target_adb_port` and `handsets_port`.

Two separate follow-up issues filed from things found during this live verification, not fixed here:
- #157 — no visible consent UI for a brand-new peer ADB key (Wireless Debugging root cause partially diagnosed)
- #158 — patch the Shizuku fork to permanently grant `org.stayturgid.agent`

`bash tests/run.sh code` and `just kt-check` both pass clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added headless handsets-start triggering without opening the app interface.
  * Handsets can now be started on a specified host using configurable ADB and service ports.
  * Added validation and error handling for manually triggered starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->