### PR TITLE
Auto-fire Shizuku permission request when the notification is tapped

### DIFF
--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/HostService.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/HostService.kt
@@ -579,11 +579,19 @@ class HostService : Service() {
     }
 
     private fun buildNotification(bound: Boolean, needPermission: Boolean): Notification {
+        val openIntent =
+            Intent(this, MainActivity::class.java).apply {
+                // Tapping the notification while permission is missing should fire the
+                // Shizuku request immediately — no manual button hunt required.
+                if (needPermission) {
+                    putExtra(MainActivity.EXTRA_AUTO_REQUEST_SHIZUKU, true)
+                }
+            }
         val open =
             PendingIntent.getActivity(
                 this,
                 0,
-                Intent(this, MainActivity::class.java),
+                openIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
             )
         val text =

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/MainActivity.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/MainActivity.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
@@ -206,11 +207,29 @@ class MainActivity : ComponentActivity() {
         refreshActionState()
         // App-context FGS start (shell am start-foreground-service is denied on API 34+).
         HostService.start(this)
+        maybeAutoRequestShizuku(intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        maybeAutoRequestShizuku(intent)
     }
 
     override fun onResume() {
         super.onResume()
         refreshActionState()
+    }
+
+    /**
+     * Tapping the "Shizuku permission missing" notification ([HostService.buildNotification])
+     * carries [EXTRA_AUTO_REQUEST_SHIZUKU] so the request fires immediately — no manual button tap
+     * needed once the operator has already tapped the notification to get here.
+     */
+    private fun maybeAutoRequestShizuku(intent: Intent?) {
+        if (intent?.getBooleanExtra(EXTRA_AUTO_REQUEST_SHIZUKU, false) != true) return
+        intent.removeExtra(EXTRA_AUTO_REQUEST_SHIZUKU)
+        requestShizuku()
     }
 
     /** Show the peer-start authorization prompt when one is outstanding (issue #61). */
@@ -324,5 +343,12 @@ class MainActivity : ComponentActivity() {
         private const val TAG = "StayTurgidMain"
         private const val REQUEST_SHIZUKU = 9001
         private const val REQUEST_NOTIF = 9002
+
+        /**
+         * Set by [HostService.buildNotification] on the "Shizuku permission missing" notification's
+         * PendingIntent so tapping it fires [requestShizuku] immediately, no manual button tap
+         * needed.
+         */
+        const val EXTRA_AUTO_REQUEST_SHIZUKU = "auto_request_shizuku"
     }
 }


### PR DESCRIPTION
Motivated by a real live incident today: hd8's agent had silently lost its Shizuku permission grant, and recovering it required manually navigating to the app and hunting for the right button. This makes a single notification tap enough.

The "Shizuku permission missing" foreground-service notification now carries an extra that `MainActivity` checks in both `onCreate` (fresh launch) and `onNewIntent` (already-running, `launchMode=singleTop`) to fire `Shizuku.requestPermission()` immediately on tap.

Live-verified end-to-end on hd8 via a throwaway `.debug`-suffixed sideload (never touching the production agent) — simulated the notification tap by sending the same intent+extra the PendingIntent fires, confirmed via screenshot that the Shizuku permission dialog appears immediately with no manual button tap, in both the fresh-launch and already-running cases.

`bash tests/run.sh code` and `just kt-check` both pass clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tapping the foreground notification can now automatically open the app and prompt for the required Shizuku permission.
  * Permission requests are handled when launching the app or returning to an already open app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->