### PR TITLE
fix: headless Shizuku grant uses pm grant + restart, not shizuku.json

### DIFF
--- a/ansible_collections/stayturgid/android_common/plugins/module_utils/shizuku.py
+++ b/ansible_collections/stayturgid/android_common/plugins/module_utils/shizuku.py
@@ -5,29 +5,12 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import json
 import re
 
 SHIZUKU_PERMISSION = "moe.shizuku.manager.permission.API_V23"
-DEFAULT_SHIZUKU_JSON = "/data/local/tmp/shizuku/shizuku.json"
-DEFAULT_STAGING = "/sdcard/Download/shizuku-grant.json"
 
 
 def parse_uid(pm_output):
     """`pm list packages -U <pkg>` -> uid string, or None."""
     m = re.search(r"uid:(\d+)", pm_output or "")
     return m.group(1) if m else None
-
-
-def patch_shizuku_json(current_text, uid, pkg):
-    """Add/replace a uid->pkg authorization, preserving all other entries."""
-    uid = int(uid)
-    raw = (current_text or "").strip()
-    try:
-        data = json.loads(raw) if raw else {"version": 2, "packages": []}
-    except ValueError:
-        data = {"version": 2, "packages": []}
-    pkgs = [e for e in data.get("packages", []) if e.get("uid") != uid]
-    pkgs.append({"uid": uid, "flags": 2, "packages": [pkg]})
-    data["packages"] = pkgs
-    return json.dumps(data, separators=(",", ":"))

--- a/ansible_collections/stayturgid/android_common/plugins/module_utils/shizuku_lifecycle.py
+++ b/ansible_collections/stayturgid/android_common/plugins/module_utils/shizuku_lifecycle.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""Shared Shizuku process-lifecycle helpers.
+
+Extracted from shizuku_start.py so shizuku_grant.py can force a restart
+after changing a permission grant (stayturgid#<TBD>): ShizukuConfigManager's
+in-memory authorization state is only reconciled from the real Android
+permission grant (`pm grant`/`pm revoke`) at server *startup* -- a `pm
+grant` alone has no effect on an already-running server, and neither does
+hand-editing shizuku.json. Only a restart (or the very first start) makes a
+new grant/revoke actually take effect.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_shell import (
+    adb_shell,
+    normalize_adb_output,
+)
+
+SHIZUKU_PKG = "moe.shizuku.privileged.api"
+HEADLESS_STATUS = "moe.shizuku.privileged.api.HEADLESS_STATUS"
+
+
+def shizuku_running(run_command, device):
+    """True if the Shizuku server process is currently alive on device."""
+    rc, out, _err = adb_shell(run_command, device, "am broadcast -a %s 2>/dev/null" % HEADLESS_STATUS)
+    text = normalize_adb_output(out)
+    if rc == 0 and "result=1" in text:
+        return True
+    rc, out, _err = adb_shell(run_command, device, "pgrep -f '[s]hizuku_server' >/dev/null && echo up")
+    return rc == 0 and "up" in normalize_adb_output(out)
+
+
+def resolve_libdir(run_command, device, pkg=SHIZUKU_PKG):
+    """Resolve the installed Shizuku APK's native lib dir via `pm path`.
+
+    Dynamic resolution (rather than a fixed pre-extracted starter binary
+    path) so this stays correct across Shizuku app updates.
+    """
+    rc, out, _err = adb_shell(run_command, device, "pm path %s" % pkg)
+    if rc != 0:
+        return None
+    for line in normalize_adb_output(out).splitlines():
+        line = line.strip()
+        if line.startswith("package:"):
+            apk = line.split(":", 1)[1]
+            return apk.rsplit("/", 1)[0] + "/lib/arm64"
+    return None
+
+
+def start_native(run_command, device, libdir, pkg=SHIZUKU_PKG):
+    """Launch (or relaunch) shizuku_server via the APK's own libshizuku.so.
+
+    libshizuku.so kills any existing shizuku_server before starting a new
+    one, so this doubles as the "force restart" primitive -- no separate
+    kill step is needed.
+    """
+    cmd = (
+        "test -x %s/libshizuku.so && "
+        "LD_LIBRARY_PATH=%s %s/libshizuku.so || "
+        "sh /storage/emulated/0/Android/data/%s/start.sh"
+    ) % (libdir, libdir, libdir, pkg)
+    return adb_shell(run_command, device, cmd)
+
+
+def restart_shizuku_if_running(run_command, device, shizuku_pkg=SHIZUKU_PKG):
+    """Force a Shizuku server restart, but only if one is already running.
+
+    A permission change made while Shizuku isn't running needs no action --
+    the next natural start already reconciles from the real `pm grant`
+    state (see ShizukuConfigManager's constructor). Restarting a server
+    that isn't up would be a no-op start, not a meaningful restart, so this
+    is intentionally conditional.
+
+    Returns (attempted, ok): ``attempted`` is False when Shizuku wasn't
+    running (nothing to do); ``ok`` is only meaningful when ``attempted``
+    is True.
+    """
+    if not shizuku_running(run_command, device):
+        return False, True
+    libdir = resolve_libdir(run_command, device, shizuku_pkg)
+    if not libdir:
+        return True, False
+    rc, _out, _err = start_native(run_command, device, libdir, shizuku_pkg)
+    return True, rc == 0

--- a/ansible_collections/stayturgid/android_common/plugins/modules/shizuku_grant.py
+++ b/ansible_collections/stayturgid/android_common/plugins/modules/shizuku_grant.py
@@ -10,13 +10,20 @@ DOCUMENTATION = r"""
 module: shizuku_grant
 short_description: Grant Shizuku API access to an app via the privileged adb shell
 description:
-  - Grants C(moe.shizuku.manager.permission.API_V23) with C(pm grant) and adds the
-    app's uid to Shizuku's C(shizuku.json) authorization file, preserving all
-    other entries.
+  - Grants C(moe.shizuku.manager.permission.API_V23) with C(pm grant), then forces
+    a Shizuku server restart (only if one is already running) so the grant takes
+    effect immediately.
   - Runs on the control node against an adb target with a privileged shell
     (Shizuku adbd, uid 2000).
-  - Fails rather than clobbering C(shizuku.json) when the file exists but cannot
-    be read.
+  - >-
+    Historically this module also hand-patched Shizuku's C(shizuku.json)
+    authorization file directly. That file's per-app C(flags) are only ever a
+    cache reconciled from the real C(pm grant)/C(pm revoke) state at Shizuku
+    server *startup* (see C(ShizukuConfigManager)'s constructor upstream) --
+    editing it directly, or restarting without first fixing the underlying
+    C(pm) grant, has no effect on an already-running server. This module no
+    longer touches that file at all; C(pm grant) plus a conditional restart is
+    both simpler and is the mechanism actually verified to work end-to-end.
 options:
   device:
     description: ADB device serial or C(host:5555) target with privileged shell.
@@ -30,14 +37,6 @@ options:
     description: Run C(adb connect) before other operations (for wireless targets).
     type: bool
     default: true
-  shizuku_json:
-    description: Path to Shizuku's authorization file on the device.
-    type: str
-    default: /data/local/tmp/shizuku/shizuku.json
-  staging_path:
-    description: Shared-storage staging path used when pushing the patched file.
-    type: str
-    default: /sdcard/Download/shizuku-grant.json
 """
 
 EXAMPLES = r"""
@@ -50,82 +49,30 @@ EXAMPLES = r"""
 
 RETURN = r"""
 changed:
-  description: True when shizuku.json was updated.
+  description: True when the permission was not already granted (a grant + restart happened).
   type: bool
 uid:
   description: Resolved app uid.
   type: str
+restarted:
+  description: True when a Shizuku server restart was attempted as part of this run.
+  type: bool
 """
-
-import os
-import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_shell import (
     adb_connect,
     adb_shell,
-    normalize_adb_output,
+    permission_granted,
 )
 from ansible_collections.stayturgid.android_common.plugins.module_utils.shizuku import (
     SHIZUKU_PERMISSION,
     parse_uid,
-    patch_shizuku_json,
 )
-
-try:
-    from ansible_collections.stayturgid.android_common.plugins.module_utils.adb_timeout import (
-        DEFAULT_SLOW_TIMEOUT,
-        run_command_with_timeout,
-    )
-except ImportError:
-    import os
-    import sys
-
-    _mod_utils = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "module_utils")
-    if _mod_utils not in sys.path:
-        sys.path.insert(0, _mod_utils)
-    from adb_timeout import (
-        DEFAULT_SLOW_TIMEOUT,
-        run_command_with_timeout,
-    )
-
-
-def read_shizuku_json(run_command, device, path):
-    """(text, ok). Missing file is ok (fresh config); unreadable is not."""
-    rc, _out, _err = adb_shell(run_command, device, "test -f %s" % path)
-    if rc != 0:
-        return "", True
-    rc, out, _err = adb_shell(run_command, device, "cat %s" % path)
-    text = normalize_adb_output(out)
-    if rc != 0 or not text:
-        return "", False
-    return text, True
-
-
-def push_shizuku_json(module, device, content, staging, path):
-    tmp = tempfile.NamedTemporaryFile("w", dir=module.tmpdir, delete=False)
-    try:
-        tmp.write(content)
-        tmp.close()
-        rc, _out, err = run_command_with_timeout(
-            module.run_command,
-            ["adb", "-s", device, "push", tmp.name, staging],
-            timeout=DEFAULT_SLOW_TIMEOUT,
-            get_bin_path_fn=module.get_bin_path,
-        )
-        if rc != 0:
-            return False, "adb push failed: %s" % normalize_adb_output(err)
-    finally:
-        os.unlink(tmp.name)
-    rc, _out, err = adb_shell(
-        module.run_command,
-        device,
-        "cp %s %s && chmod 666 %s" % (staging, path, path),
-    )
-    if rc != 0:
-        return False, "install into %s failed: %s" % (path, normalize_adb_output(err))
-    return True, "installed"
+from ansible_collections.stayturgid.android_common.plugins.module_utils.shizuku_lifecycle import (
+    restart_shizuku_if_running,
+)
 
 
 def main():
@@ -134,15 +81,12 @@ def main():
             device=dict(type="str", required=True),
             package=dict(type="str", required=True),
             connect=dict(type="bool", default=True),
-            shizuku_json=dict(type="str", default="/data/local/tmp/shizuku/shizuku.json"),
-            staging_path=dict(type="str", default="/sdcard/Download/shizuku-grant.json"),
         ),
         supports_check_mode=True,
     )
 
     device = module.params["device"]
     pkg = module.params["package"]
-    json_path = module.params["shizuku_json"]
 
     if module.params["connect"] and not module.check_mode:
         adb_connect(module.run_command, device)
@@ -156,25 +100,26 @@ def main():
     if not uid:
         module.fail_json(msg="%s not installed on %s" % (pkg, device))
 
-    current, ok = read_shizuku_json(module.run_command, device, json_path)
-    if not ok:
-        module.fail_json(msg="unreadable %s — aborting to avoid clobbering existing grants" % json_path)
-
-    patched = patch_shizuku_json(current, uid, pkg)
-    json_changed = patched.strip() != (current or "").strip()
+    already_granted = permission_granted(module.run_command, device, pkg, SHIZUKU_PERMISSION)
 
     if module.check_mode:
-        module.exit_json(changed=json_changed, uid=uid)
+        module.exit_json(changed=not already_granted, uid=uid, restarted=False)
 
-    # pm grant is idempotent and cheap; always ensure it.
-    adb_shell(module.run_command, device, "pm grant %s %s" % (pkg, SHIZUKU_PERMISSION))
+    if already_granted:
+        module.exit_json(changed=False, uid=uid, restarted=False)
 
-    if json_changed:
-        pushed, msg = push_shizuku_json(module, device, patched, module.params["staging_path"], json_path)
-        if not pushed:
-            module.fail_json(msg=msg)
+    rc, _out, err = adb_shell(module.run_command, device, "pm grant %s %s" % (pkg, SHIZUKU_PERMISSION))
+    if rc != 0:
+        module.fail_json(msg="pm grant %s %s failed: %s" % (pkg, SHIZUKU_PERMISSION, err))
 
-    module.exit_json(changed=json_changed, uid=uid)
+    attempted, restart_ok = restart_shizuku_if_running(module.run_command, device)
+    if attempted and not restart_ok:
+        module.warn(
+            "granted %s but the Shizuku server restart failed — the grant "
+            "will only take effect on the next natural restart" % pkg
+        )
+
+    module.exit_json(changed=True, uid=uid, restarted=attempted)
 
 
 if __name__ == "__main__":

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_shizuku_grant.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_shizuku_grant.py
@@ -112,6 +112,30 @@ def test_shizuku_grant_restarts_when_shizuku_running(mocker):
     assert out["restarted"] is True
 
 
+def test_shizuku_grant_warns_when_restart_attempted_but_fails(mocker):
+    out = run_module(
+        mocker,
+        dict(
+            device="localhost:5555",
+            package="com.machiav3lli.fdroid",
+            connect=False,
+        ),
+        cmd_results=[
+            ("am broadcast -a moe.shizuku.privileged.api.HEADLESS_STATUS", (0, "result=1", "")),
+            (
+                "pm path moe.shizuku.privileged.api",
+                (0, "package:/data/app/~~x/moe.shizuku.privileged.api/base.apk", ""),
+            ),
+            ("libshizuku.so", (1, "", "start failed")),
+        ],
+    )
+    # The grant itself still succeeded -- only the restart attempt failed --
+    # so changed/restarted both reflect that a restart was tried, and main()
+    # surfaces the failure via module.warn() rather than fail_json().
+    assert out["changed"] is True
+    assert out["restarted"] is True
+
+
 def test_shizuku_grant_fails_when_pm_grant_fails(mocker):
     out = run_module(
         mocker,

--- a/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_shizuku_grant.py
+++ b/ansible_collections/stayturgid/android_common/tests/unit/plugins/modules/test_shizuku_grant.py
@@ -10,23 +10,7 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..",
 sys.path.insert(0, os.path.join(ROOT, "plugins", "modules"))
 sys.path.insert(0, os.path.join(ROOT, "plugins", "module_utils"))
 
-import shizuku as shizuku_utils
-import shizuku_grant as mod
-
-
-def test_patch_shizuku_json_adds_entry():
-    current = '{"version":2,"packages":[{"uid":10001,"flags":2,"packages":["com.other"]}]}'
-    patched = shizuku_utils.patch_shizuku_json(current, 10002, "com.machiav3lli.fdroid")
-    data = json.loads(patched)
-    uids = [e["uid"] for e in data["packages"]]
-    assert 10001 in uids
-    assert 10002 in uids
-
-
-def test_patch_shizuku_json_idempotent():
-    current = '{"version":2,"packages":[{"uid":10002,"flags":2,"packages":["com.machiav3lli.fdroid"]}]}'
-    patched = shizuku_utils.patch_shizuku_json(current, 10002, "com.machiav3lli.fdroid")
-    assert patched.strip() == current.strip()
+import shizuku_grant as mod  # noqa: E402
 
 
 def run_module(mocker, args, cmd_results=None, expect_fail=False):
@@ -45,16 +29,15 @@ def run_module(mocker, args, cmd_results=None, expect_fail=False):
             return (0, "", "")
         if "pm list packages -U" in joined:
             return (0, "package:com.machiav3lli.fdroid uid:10002", "")
-        if "test -f" in joined:
-            return (0, "", "")
-        if "cat /data/local/tmp/shizuku/shizuku.json" in joined:
-            return (0, '{"version":2,"packages":[]}', "")
+        if "dumpsys package" in joined:
+            # Not yet granted by default; tests override via cmd_results.
+            return (0, "moe.shizuku.manager.permission.API_V23:\n  granted=false", "")
         if "pm grant" in joined:
             return (0, "", "")
-        if "adb push" in joined:
+        if "HEADLESS_STATUS" in joined:
             return (0, "", "")
-        if "cp /sdcard" in joined:
-            return (0, "", "")
+        if "pgrep" in joined:
+            return (1, "", "")
         return (0, "", "")
 
     def fake_exit(self, **kw):
@@ -77,7 +60,7 @@ def run_module(mocker, args, cmd_results=None, expect_fail=False):
     return captured
 
 
-def test_shizuku_grant_changes_json(mocker):
+def test_shizuku_grant_grants_and_skips_restart_when_not_running(mocker):
     out = run_module(
         mocker,
         dict(
@@ -88,9 +71,11 @@ def test_shizuku_grant_changes_json(mocker):
     )
     assert out["changed"] is True
     assert out["uid"] == "10002"
+    # Shizuku wasn't running (HEADLESS_STATUS empty, pgrep rc=1) -> no restart needed.
+    assert out["restarted"] is False
 
 
-def test_shizuku_grant_unreadable_json(mocker):
+def test_shizuku_grant_already_granted_is_noop(mocker):
     out = run_module(
         mocker,
         dict(
@@ -99,24 +84,45 @@ def test_shizuku_grant_unreadable_json(mocker):
             connect=False,
         ),
         cmd_results=[
-            ("cat /data/local/tmp/shizuku/shizuku.json", (1, "", "read error")),
-        ],
-        expect_fail=True,
-    )
-    assert "unreadable" in out.get("msg", "")
-
-
-def test_shizuku_grant_already_granted(mocker):
-    existing = shizuku_utils.patch_shizuku_json("", 10002, "com.machiav3lli.fdroid")
-    out = run_module(
-        mocker,
-        dict(
-            device="localhost:5555",
-            package="com.machiav3lli.fdroid",
-            connect=False,
-        ),
-        cmd_results=[
-            ("cat /data/local/tmp/shizuku/shizuku.json", (0, existing, "")),
+            ("dumpsys package", (0, "moe.shizuku.manager.permission.API_V23:\n  granted=true", "")),
         ],
     )
     assert out["changed"] is False
+    assert out["restarted"] is False
+
+
+def test_shizuku_grant_restarts_when_shizuku_running(mocker):
+    out = run_module(
+        mocker,
+        dict(
+            device="localhost:5555",
+            package="com.machiav3lli.fdroid",
+            connect=False,
+        ),
+        cmd_results=[
+            ("am broadcast -a moe.shizuku.privileged.api.HEADLESS_STATUS", (0, "result=1", "")),
+            (
+                "pm path moe.shizuku.privileged.api",
+                (0, "package:/data/app/~~x/moe.shizuku.privileged.api/base.apk", ""),
+            ),
+            ("libshizuku.so", (0, "", "")),
+        ],
+    )
+    assert out["changed"] is True
+    assert out["restarted"] is True
+
+
+def test_shizuku_grant_fails_when_pm_grant_fails(mocker):
+    out = run_module(
+        mocker,
+        dict(
+            device="localhost:5555",
+            package="com.machiav3lli.fdroid",
+            connect=False,
+        ),
+        cmd_results=[
+            ("pm grant", (1, "", "Package moe.shizuku.manager.permission.API_V23 has not been requested")),
+        ],
+        expect_fail=True,
+    )
+    assert "pm grant" in out.get("msg", "")

--- a/control/lib/stayturgid_device.py
+++ b/control/lib/stayturgid_device.py
@@ -201,6 +201,41 @@ from ui_parse import (  # noqa: F401
     parse_text_center,
 )
 
+_ADB_SHELL_MOD = None
+
+
+def _adb_shell_module():
+    """Lazily load the collection's adb_shell.py for its dumpsys parser.
+
+    Same dynamic-load pattern as [resolve_adb] -- reuses the collection's
+    already-tested text parsing (multi-user-profile ``--`` sections) instead
+    of duplicating it here.
+    """
+    global _ADB_SHELL_MOD
+    if _ADB_SHELL_MOD is not None:
+        return _ADB_SHELL_MOD
+    import importlib.util
+
+    repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    mod_path = os.path.join(
+        repo_root,
+        "ansible_collections",
+        "stayturgid",
+        "android_common",
+        "plugins",
+        "module_utils",
+        "adb_shell.py",
+    )
+    spec = importlib.util.spec_from_file_location("_adb_shell", mod_path)
+    _mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(_mod)
+    _ADB_SHELL_MOD = _mod
+    return _ADB_SHELL_MOD
+
+
+def _parse_permission_granted(dumpsys_output, permission):
+    return _adb_shell_module().parse_permission_granted(dumpsys_output, permission)
+
 
 # --------------------------------------------------------------------------
 # I/O
@@ -276,3 +311,68 @@ class PrivShell:
         finally:
             os.unlink(tmp.name)
         return self.sh("cp %s %s && chmod 666 %s" % (staging, path, path))[0] == 0
+
+    # ----------------------------------------------------------------------
+    # Shizuku process lifecycle
+    #
+    # ShizukuConfigManager only reconciles its in-memory authorization state
+    # (and shizuku.json's cached flags) from the real `pm grant`/`pm revoke`
+    # state at server *startup*. A `pm grant` alone has no effect on an
+    # already-running server -- only a restart (or the very first start)
+    # makes a new grant/revoke actually take effect. Mirrors
+    # ansible_collections/.../module_utils/shizuku_lifecycle.py.
+    # ----------------------------------------------------------------------
+    SHIZUKU_PKG = "moe.shizuku.privileged.api"
+    HEADLESS_STATUS = "moe.shizuku.privileged.api.HEADLESS_STATUS"
+
+    def shizuku_running(self):
+        """True if the Shizuku server process is currently alive on device."""
+        rc, out = self.sh("am broadcast -a %s 2>/dev/null" % self.HEADLESS_STATUS)
+        if rc == 0 and "result=1" in out:
+            return True
+        rc, out = self.sh("pgrep -f '[s]hizuku_server' >/dev/null && echo up")
+        return rc == 0 and "up" in out
+
+    def resolve_shizuku_libdir(self, pkg=None):
+        """Resolve the installed Shizuku APK's native lib dir via `pm path`."""
+        pkg = pkg or self.SHIZUKU_PKG
+        rc, out = self.sh("pm path %s" % pkg)
+        if rc != 0:
+            return None
+        for line in out.splitlines():
+            line = line.strip()
+            if line.startswith("package:"):
+                apk = line.split(":", 1)[1]
+                return apk.rsplit("/", 1)[0] + "/lib/arm64"
+        return None
+
+    def restart_shizuku_if_running(self, pkg=None):
+        """Force a Shizuku server restart, but only if one is already running.
+
+        Returns (attempted, ok). A permission change made while Shizuku isn't
+        running needs no action -- the next natural start already reconciles
+        from the real `pm grant` state.
+        """
+        pkg = pkg or self.SHIZUKU_PKG
+        if not self.shizuku_running():
+            return False, True
+        libdir = self.resolve_shizuku_libdir(pkg)
+        if not libdir:
+            return True, False
+        rc, _out = self.sh(
+            "test -x %s/libshizuku.so && LD_LIBRARY_PATH=%s %s/libshizuku.so" % (libdir, libdir, libdir),
+            timeout=30,
+        )
+        return True, rc == 0
+
+    def is_permission_granted(self, pkg, permission):
+        """True if `permission` shows granted=true in `pkg`'s runtime permissions.
+
+        Reuses the collection's own dumpsys-section parser (handles the
+        multi-user-profile ``--`` separated sections correctly) rather than
+        re-implementing text parsing here.
+        """
+        rc, out = self.sh("dumpsys package %s" % pkg)
+        if rc != 0:
+            return False
+        return _parse_permission_granted(out, permission)

--- a/control/tools/native-agent/grant_shizuku.py
+++ b/control/tools/native-agent/grant_shizuku.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Grant Shizuku API access to stayturgid-agent (native Kotlin APK).
 
-Same mechanism as control/tools/autojs6/grant_shizuku.py: pm grant + patch
-/data/local/tmp/shizuku/shizuku.json. Restart Shizuku after if the app still
-sees permission denied:
-
-  adb -s <serial> shell /data/local/tmp/shizuku_starter
+`pm grant`, then a conditional Shizuku server restart (only if one is already
+running) so the grant takes effect immediately. ShizukuConfigManager's
+in-memory authorization state -- and shizuku.json's cached flags -- are only
+ever reconciled from the real `pm grant`/`pm revoke` state at server
+*startup*; hand-patching shizuku.json (the old approach here) has no live
+effect on an already-running server, so this no longer touches that file.
 
 Usage:
   ./grant_shizuku.py <host-or-serial> [package]
@@ -25,8 +26,6 @@ import stayturgid_device as dev  # noqa: E402
 
 DEFAULT_PKG = "org.stayturgid.agent.debug"
 SHIZUKU_PERM = "moe.shizuku.manager.permission.API_V23"
-SHIZUKU_JSON = "/data/local/tmp/shizuku/shizuku.json"
-STAGING = "/sdcard/Download/shizuku.json"
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -43,20 +42,22 @@ def main(argv: list[str] | None = None) -> int:
         sys.stderr.write(f"ERROR: could not resolve uid for {pkg}\n")
         return 1
 
-    shell.sh(f"pm grant {pkg} {SHIZUKU_PERM}")
+    if shell.is_permission_granted(pkg, SHIZUKU_PERM):
+        print(f"Shizuku: {pkg} (uid={uid}) already granted on {shell.target}")
+        return 0
 
-    current, ok = shell.read_shizuku_json(SHIZUKU_JSON)
-    if not ok:
-        sys.stderr.write(f"ERROR: no privileged shell or unreadable {SHIZUKU_JSON} — aborting\n")
+    rc, out = shell.sh(f"pm grant {pkg} {SHIZUKU_PERM}")
+    if rc != 0:
+        sys.stderr.write(f"ERROR: pm grant {pkg} {SHIZUKU_PERM} failed: {out}\n")
         return 1
 
-    patched = dev.patch_shizuku_json(current, uid, pkg)
-    if not shell.install_shizuku_json(patched, STAGING, SHIZUKU_JSON):
-        sys.stderr.write("ERROR: failed to install patched shizuku.json\n")
+    attempted, restart_ok = shell.restart_shizuku_if_running()
+    if attempted and not restart_ok:
+        print(f"WARN: granted {pkg} (uid={uid}) but the Shizuku server restart failed")
+        print("      grant will only take effect on the next natural restart")
         return 1
 
-    print(f"Shizuku: allowed {pkg} (uid={uid}) on {shell.target}")
-    print("If the app still reports denied, restart Shizuku (shizuku_starter).")
+    print(f"Shizuku: allowed {pkg} (uid={uid}) on {shell.target}" + (" (restarted server)" if attempted else ""))
     return 0
 
 

--- a/control/tools/native-agent/rollout.py
+++ b/control/tools/native-agent/rollout.py
@@ -3,9 +3,8 @@
 
 Steps per host (when adb-reachable):
   1. adb install -r debug APK
-  2. grant_shizuku.py (pm + shizuku.json)
-  3. restart Shizuku via /data/local/tmp/shizuku_starter (if present)
-  4. start_agent.py (MainActivity → HostService)
+  2. grant_shizuku.py (pm grant + conditional Shizuku server restart)
+  3. start_agent.py (MainActivity → HostService)
 
 Does **not** remove AutoJs6. Dual-run only (OPTIONS K1).
 
@@ -168,22 +167,13 @@ def _rollout_one(label: str, serial: str) -> bool:
     )
     if r.returncode != 0:
         print("  WARN grant failed — continue start attempt")
-    # Restart Shizuku so json grant is live (starter may no-op if missing)
-    print("  restart Shizuku server...")
-    st = _run(
-        ["adb", "-s", serial, "shell", "/data/local/tmp/shizuku_starter"],
-        timeout=30,
-    )
-    if st.stdout:
-        for line in st.stdout.strip().splitlines()[-4:]:
-            print("   ", line)
     time.sleep(4)
     srv = _run(
         ["adb", "-s", serial, "shell", "pgrep -f shizuku_server"],
         timeout=10,
     )
     if not (srv.stdout or "").strip():
-        print("  WARN: shizuku_server not running after starter (UserService will not bind)")
+        print("  WARN: shizuku_server not running after grant (UserService will not bind)")
     stale = stop_stale_user_services(serial)
     if stale:
         print(f"  stopped stale UserService pid(s): {' '.join(stale)}")


### PR DESCRIPTION
## Summary

- shizuku.json patching never actually worked, at any path — `ShizukuConfigManager`'s constructor unconditionally re-syncs every known app's authorization flags from the real Android permission grant at every Shizuku server startup, so hand-editing the file has zero live effect and no lasting effect across a restart either. `pm grant`/`pm revoke` was always the real, only lever.
- `shizuku_grant` (Ansible module) and `control/tools/native-agent/grant_shizuku.py` now check the real permission via the already-proven `adb_shell.permission_granted()` helper, `pm grant` if needed, then restart the Shizuku server **only if one is currently running**.
- `rollout.py`'s separate explicit restart step (hardcoded `/data/local/tmp/shizuku_starter` path) is now redundant since `grant_shizuku.py` handles its own dynamic restart — removed.
- New shared `module_utils/shizuku_lifecycle.py` extracts the restart primitives already used by `shizuku_start.py`; `control/lib/stayturgid_device.py` gets equivalent `PrivShell` methods for the Mac-side control script.
- Dropped the now-dead `patch_shizuku_json`/`DEFAULT_SHIZUKU_JSON`/`DEFAULT_STAGING` from the Ansible `module_utils/shizuku.py` (nothing in `ansible_collections/` used them anymore). The separate AutoJs6-era copy in `control/lib/stayturgid_device.py` is deliberately left untouched — still used by AutoJs6 tooling, tracked by #162.

Fixes #163 (root-cause writeup with the full empirical proof).

## Test plan

- [x] `just check` — clean
- [x] `just ansible-test` — 69 module + 17 module_utils tests pass (rewrote `test_shizuku_grant.py` for the new pm-grant+restart behavior)
- [x] `just pytest` — 643 passed, 1 skipped (script-twin tests, confirms `stayturgid_device.py` changes didn't break anything)
- [x] Live-verified end-to-end on hd8 (`org.stayturgid.agent`, both the Ansible module and the standalone script):
  - Already-granted → `changed=false`, `restarted=false` (idempotent)
  - `--check` mode → reports `changed=true`, zero side effects on device
  - After `pm revoke` → module/script detect it, `pm grant`, restart (confirmed via a real Shizuku server PID change, not just self-report), `dumpsys package` shows `granted=true` immediately — no reboot needed
  - Re-run after grant → idempotent no-op again
- [x] Device left in the correct final state (`org.stayturgid.agent` Shizuku-granted, server running)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shizuku permissions are now granted directly through Android permission controls.
  * Running Shizuku servers restart automatically when required.
  * Permission and restart status are reported clearly.

* **Bug Fixes**
  * Improved handling of failed permission grants and server restarts.
  * Rollouts verify that Shizuku is running before starting the agent.
  * Removed reliance on manual Shizuku configuration-file updates.

* **Tests**
  * Expanded coverage for successful grants, no-op behavior, restarts, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->