### PR TITLE
agent: bump native-agent to 0.8.0-handsets-shizuku-notify

### DIFF
--- a/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
+++ b/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
@@ -41,10 +41,10 @@ stayturgid_debug_key_alias: "androiddebugkey"
 stayturgid_bootstrap_apks:
   - id: org.stayturgid.agent
     gh_repo: djbclark/stayturgid
-    gh_tag: agent-v0.7.0
+    gh_tag: agent-v0.8.0
     gh_pattern: app-release.apk
-    version_name: 0.7.0-liveness-hardening
-    checksum: "sha256:df62d17bd779e6fd92694012d085cdde7fe33fbdc23194c34243c800577792f6"
+    version_name: 0.8.0-handsets-shizuku-notify
+    checksum: "sha256:504a3c9b12b8c046dada230cc069a49cd5d76d451550c68029de20cb398e66f5"
     resign: false
     start_broadcast_action: org.stayturgid.agent.action.PEER_START_NOW
     start_broadcast_component: org.stayturgid.agent/org.stayturgid.agent.PeerStartReceiver

--- a/device/native-agent/app/build.gradle.kts
+++ b/device/native-agent/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "org.stayturgid.agent"
         minSdk = 26
         targetSdk = 36
-        versionCode = 16
-        versionName = "0.7.0-liveness-hardening"
+        versionCode = 17
+        versionName = "0.8.0-handsets-shizuku-notify"
         val buildTimeUtc =
             System.getenv("SOURCE_DATE_EPOCH")?.toLongOrNull()?.let { Instant.ofEpochSecond(it) }
                 ?: Instant.now().truncatedTo(ChronoUnit.SECONDS)

--- a/tests/python/test_bootstrap_apk_lock.py
+++ b/tests/python/test_bootstrap_apk_lock.py
@@ -23,9 +23,9 @@ def test_every_github_apk_is_immutably_locked():
 
 def test_native_agent_uses_its_release_stream_and_real_asset_name():
     agent = next(apk for apk in _catalog() if apk["id"] == "org.stayturgid.agent")
-    assert agent["gh_tag"] == "agent-v0.7.0"
+    assert agent["gh_tag"] == "agent-v0.8.0"
     assert agent["gh_pattern"] == "app-release.apk"
-    assert agent["version_name"] == "0.7.0-liveness-hardening"
+    assert agent["version_name"] == "0.8.0-handsets-shizuku-notify"
     assert agent["remove_packages"] == ["org.stayturgid.agent.debug"]
     assert agent["service_component"] == "org.stayturgid.agent/.HostService"
     assert agent["start_broadcast_action"] == "org.stayturgid.agent.action.PEER_START_NOW"


### PR DESCRIPTION
## Summary

Bundles two feature landings on `device/native-agent/` since agent-v0.7.0:
- Manual-trigger handsets-start path completing #121's peer-start port (#159)
- Auto-fire Shizuku permission request when the missing-permission notification is tapped (#160)

`gh_tag: agent-v0.8.0` in the bootstrap_apks lock is a placeholder — no such GitHub Release exists yet. This must not be deployed until that release is published with the exact `app-release.apk` this PR's checksum matches.

versionCode 17, versionName 0.8.0-handsets-shizuku-notify.

## Test plan

- [x] `just check` — clean
- [x] `just kt-test` — BUILD SUCCESSFUL
- [x] `.venv-test/bin/pytest tests/python/test_bootstrap_apk_lock.py` — 5 passed
- [x] `./gradlew :app:assembleRelease` — signed with the real project keystore (`CN=StayTurgid`, not the Android debug keystore)
- [ ] GitHub Release `agent-v0.8.0` still needs to be published with this exact APK before this is safe to deploy