### PR TITLE
feat(deploy): add bootstrap-apks-only deploy scope

### DIFF
--- a/control/bin/deploy_fleet.py
+++ b/control/bin/deploy_fleet.py
@@ -15,6 +15,10 @@ Usage:
   deploy_fleet.py --scope fdroid oneui-device      # F-Droid roles only
   deploy_fleet.py --scope play oneui-device        # Play roles
   deploy_fleet.py --devices-only oneui-device      # skip the redundant Mac control_node pass
+  deploy_fleet.py --scope bootstrap-apks --devices-only oneui-device
+                                                    # APK ensure/verify/Shizuku-start only (#166) --
+                                                    # skips termux_userland/post-ui/validate/control_node
+                                                    # entirely; use for a pure app version bump
   CHECK=1 deploy_fleet.py oneui-device             # ansible --check --diff (no post-UI / validate asserts)
 
 Scopes map to ansible-playbook --tags on site.yml (see site.yml header).
@@ -66,6 +70,7 @@ class Scope(str, Enum):
     FDROID = "fdroid"
     PLAY = "play"
     APP_STORES = "app-stores"
+    BOOTSTRAP_APKS = "bootstrap-apks"
 
     @property
     def ansible_tags(self) -> str | None:

--- a/docs/architecture/components/control.md
+++ b/docs/architecture/components/control.md
@@ -44,6 +44,9 @@ Launchd agents and `devices.conf` are rendered by `ansible/playbooks/control_nod
 CHECK=1 ./control/bin/deploy_fleet.py oneui-device      # same as just deploy-check
 ./control/bin/deploy_fleet.py --scope fdroid oneui-device # F-Droid (parked until app stores re-enabled)
 ./control/bin/deploy_fleet.py --scope play oneui-device   # Play / Aurora (parked)
+./control/bin/deploy_fleet.py --scope bootstrap-apks --devices-only oneui-device
+                                                          # pure app version bump — skips
+                                                          # termux_userland/post-ui/validate/control_node (#166)
 ```
 
 Verify: `just verify` or `just verify-heal` or `bash tests/run.sh device --heal [host]`

--- a/just/fleet.just
+++ b/just/fleet.just
@@ -13,6 +13,14 @@ deploy-legacy:
 deploy host="":
     @just _deploy_impl {{ host }}
 
+# ---------- Deploy (bootstrap-apks scope only — pure APK version bump, #166) ----------
+# Skips termux_userland/post-ui/validate/control_node entirely; ~4x faster
+# than a full deploy when the only thing that changed is an app's locked
+# version (checksum/gh_tag/version_name in bootstrap_apks defaults).
+# Usage: hosts=s24 just deploy-apks
+deploy-apks:
+    python3 control/bin/deploy_fleet.py {{ deploy_args }} --scope bootstrap-apks --devices-only
+
 # ---------- Deploy Check (dry‑run) ----------
 _deploy_check_impl:
     CHECK=1 python3 control/bin/deploy_fleet.py {{ deploy_args }} {{ deploy_scope_arg }}

--- a/tests/python/test_deploy_fleet.py
+++ b/tests/python/test_deploy_fleet.py
@@ -101,6 +101,7 @@ def test_scope_ansible_tags():
     assert df.Scope.FDROID.ansible_tags == "fdroid"
     assert df.Scope.PLAY.ansible_tags == "play,post-ui"
     assert df.Scope.APP_STORES.ansible_tags == "app-stores"
+    assert df.Scope.BOOTSTRAP_APKS.ansible_tags == "bootstrap-apks"
 
 
 def test_resolve_hosts_explicit():


### PR DESCRIPTION
## Summary

- Adds `Scope.BOOTSTRAP_APKS = "bootstrap-apks"` to `deploy_fleet.py`, mapping to the tag already applied to `site.yml`'s ensure/verify-bootstrap-apks/ensure-shizuku plays.
- Exposes it as `--scope bootstrap-apks --devices-only <host>` and a new `just deploy-apks` recipe (`hosts=s24 just deploy-apks`).
- Addresses #1 item in #166: a pure app version bump currently pays the full ~5-6 min `site.yml` cost even though only the APK-related tasks actually change anything. Everything else (termux_userland, post-ui, validate, control_node) is a no-op on a routine version bump but still costs real wall-clock per task.

## Test plan

- [x] `just check` — clean
- [x] `.venv-test/bin/pytest tests/python/test_deploy_fleet.py` — 33 passed (added a `Scope.BOOTSTRAP_APKS.ansible_tags` assertion)
- [x] `just deploy-apks` registers correctly (`just --list`)
- [x] Dry-run tested against s24 with `--scope bootstrap-apks --devices-only` (collided harmlessly with an in-flight unrelated deploy's fleet lock — confirms the lock still applies correctly to the new scope too)

Part of #166.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fleet deployment option to update bootstrap APK versions on devices only.
  * Added a convenient `deploy-apks` command for running APK-only deployments.
  * Documented the new deployment scope and its behavior.

* **Tests**
  * Added coverage confirming the new deployment scope selects the correct deployment tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->