### PR TITLE
chore: pin shellcheck version in CI, auto-install pinned shfmt via pre-commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,15 @@ jobs:
           curl -sSLO https://github.com/mvdan/sh/releases/download/v3.13.1/shfmt_v3.13.1_linux_amd64
           chmod +x shfmt_v3.13.1_linux_amd64
           sudo mv shfmt_v3.13.1_linux_amd64 /usr/local/bin/shfmt
+      - name: Install shellcheck
+        # Pinned to match local dev exactly (brew) -- previously relied on
+        # whatever version ubuntu-latest's image happened to bundle, which
+        # drifts independently of local dev and isn't guaranteed to match.
+        run: |
+          curl -sSL -o shellcheck.tar.xz https://github.com/koalaman/shellcheck/releases/download/v0.11.0/shellcheck-v0.11.0.linux.x86_64.tar.xz
+          tar -xJf shellcheck.tar.xz
+          sudo mv shellcheck-v0.11.0/shellcheck /usr/local/bin/shellcheck
+          rm -rf shellcheck.tar.xz shellcheck-v0.11.0
       - name: Install markdownlint
         run: npm install -g markdownlint-cli
       - name: Install prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,14 +79,14 @@ repos:
         language: system
         files: '^(just/tools/.*\.(js|ts)|docs/research/.*\.(js|ts)|control/static/.*\.css)$'
 
-  - repo: local
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.13.1-1
     hooks:
       - id: shfmt
-        name: shfmt
-        entry: shfmt
+        # Pinned to the same v3.13.1 used in CI and (via brew) local dev --
+        # auto-installed by pre-commit itself, so contributors no longer
+        # need `brew install shfmt` and can't drift to a different version.
         args: ["-d", "-i", "2", "-ci"]
-        language: system
-        types: [shell]
         # Upstream Gradle wrapper scripts; do not reformat.
         exclude: '(^|/)gradlew$'
 


### PR DESCRIPTION
## Summary

Follow-up from an end-of-session shell-tooling audit: `shfmt` was already version-pinned identically in CI and (coincidentally) local dev, but `shellcheck` was not pinned anywhere — CI just used whatever ubuntu-latest's runner image happened to bundle.

- Pin `shellcheck` to v0.11.0 in CI (matches local dev via brew today), installed the same way `shfmt` already is — curl the upstream release tarball, not the runner image's baked-in version.
- Swap the local `system`-language `shfmt` pre-commit hook for `scop/pre-commit-shfmt` pinned to `v3.13.1-1` (same v3.13.1 already used in CI). It auto-installs the pinned binary itself, so contributors no longer need `brew install shfmt` and can't silently drift to a different version.

Evaluated two other options for this (not adopted): `luizm/action-sh-checker` (would duplicate the existing justfile-based CI checks and doesn't support version pinning either) and `tesh` (a command-output assertion tool with no real sandboxing — not a fit for this repo's actual shell-testing needs).

## Test plan

- [x] `pre-commit run shfmt --all-files` — auto-installs and passes with the exact pinned v3.13.1
- [x] `just check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated checks to use a consistent, explicitly specified ShellCheck version.
  * Improved shell script formatting checks with a pinned, pre-commit-managed shfmt version.
  * Retained existing formatting rules and exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->