### PR TITLE
agent: bump native-agent to 0.9.0-new-icon

### DIFF
--- a/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
+++ b/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
@@ -41,10 +41,10 @@ stayturgid_debug_key_alias: "androiddebugkey"
 stayturgid_bootstrap_apks:
   - id: org.stayturgid.agent
     gh_repo: djbclark/stayturgid
-    gh_tag: agent-v0.8.0
+    gh_tag: agent-v0.9.0
     gh_pattern: app-release.apk
-    version_name: 0.8.0-handsets-shizuku-notify
-    checksum: "sha256:504a3c9b12b8c046dada230cc069a49cd5d76d451550c68029de20cb398e66f5"
+    version_name: 0.9.0-new-icon
+    checksum: "sha256:ef1639ca449bc8510be370ce38df36f0185d79966f1b7117ee96beec03e5a19b"
     resign: false
     start_broadcast_action: org.stayturgid.agent.action.PEER_START_NOW
     start_broadcast_component: org.stayturgid.agent/org.stayturgid.agent.PeerStartReceiver

--- a/device/native-agent/app/build.gradle.kts
+++ b/device/native-agent/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "org.stayturgid.agent"
         minSdk = 26
         targetSdk = 36
-        versionCode = 17
-        versionName = "0.8.0-handsets-shizuku-notify"
+        versionCode = 18
+        versionName = "0.9.0-new-icon"
         val buildTimeUtc =
             System.getenv("SOURCE_DATE_EPOCH")?.toLongOrNull()?.let { Instant.ofEpochSecond(it) }
                 ?: Instant.now().truncatedTo(ChronoUnit.SECONDS)

--- a/tests/python/test_bootstrap_apk_lock.py
+++ b/tests/python/test_bootstrap_apk_lock.py
@@ -23,9 +23,9 @@ def test_every_github_apk_is_immutably_locked():
 
 def test_native_agent_uses_its_release_stream_and_real_asset_name():
     agent = next(apk for apk in _catalog() if apk["id"] == "org.stayturgid.agent")
-    assert agent["gh_tag"] == "agent-v0.8.0"
+    assert agent["gh_tag"] == "agent-v0.9.0"
     assert agent["gh_pattern"] == "app-release.apk"
-    assert agent["version_name"] == "0.8.0-handsets-shizuku-notify"
+    assert agent["version_name"] == "0.9.0-new-icon"
     assert agent["remove_packages"] == ["org.stayturgid.agent.debug"]
     assert agent["service_component"] == "org.stayturgid.agent/.HostService"
     assert agent["start_broadcast_action"] == "org.stayturgid.agent.action.PEER_START_NOW"


### PR DESCRIPTION
## Summary

Bumps versionCode 17→18, versionName to `0.9.0-new-icon` for the new adaptive launcher icon + notification icon landed in #169. This just cuts the actual release for those already-merged resource/manifest changes — #169 changed the app's icon resources but never bumped the version or published a build.

`gh_tag: agent-v0.9.0` in the bootstrap_apks lock is a placeholder — no such GitHub Release exists yet. Must not be deployed until that release is published with the exact `app-release.apk` this checksum matches.

## Test plan

- [x] `just check` — clean
- [x] `just kt-test` — BUILD SUCCESSFUL
- [x] `.venv-test/bin/pytest tests/python/test_bootstrap_apk_lock.py` — 5 passed
- [x] `./gradlew :app:assembleRelease` — signed with the real project keystore (`CN=StayTurgid`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Android agent to release 0.9.0, including a refreshed app icon.
  * Increased the app version to 18.

* **Bug Fixes**
  * Updated bootstrap validation to recognize and verify the latest agent package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->