### PR TITLE
fix: stop auto-tapping the USB/wireless debugging consent dialog

### DIFF
--- a/control/bin/fleet_health_monitor.py
+++ b/control/bin/fleet_health_monitor.py
@@ -505,6 +505,7 @@ def check_device(name: str, ts_ip: str, lan_ip: str) -> None:
             import adb_cli
 
             if adb_cli.debugging_dialog_present(target):
+                _fleet_log(INFO, "%s: USB/wireless debugging dialog detected" % name)
                 if _heal_cooldown_ok_dir(name, DEBUGGING_DIALOG_STATE_DIR, DEBUGGING_DIALOG_NOTIFY_COOLDOWN_SEC):
                     notify(
                         "stayturgid: action needed",
@@ -513,8 +514,8 @@ def check_device(name: str, ts_ip: str, lan_ip: str) -> None:
                     )
                     _touch_heal_dir(name, DEBUGGING_DIALOG_STATE_DIR)
             adb_cli.dismiss_app_compatibility_dialog(target)
-        except Exception:
-            pass
+        except Exception as e:
+            _fleet_log(WARNING, "%s: debugging-dialog check failed: %s" % (name, e))
     path, report = fh.probe_device(name, ts_ip, lan_ip)
     if not path:
         _fleet_log(INFO, "%s unreachable — skip soft health (see access-monitor)" % name)

--- a/control/bin/fleet_health_monitor.py
+++ b/control/bin/fleet_health_monitor.py
@@ -68,6 +68,8 @@ REPO = _REPO
 REPAIR_HEAL_STATE_DIR = os.path.join(ROOT, "state", "repair-heal")
 REPAIR_HEAL_COOLDOWN_SEC = 30 * 60
 REPAIR_HEAL_AFTER = 2
+DEBUGGING_DIALOG_STATE_DIR = os.path.join(ROOT, "state", "debugging-dialog-notify")
+DEBUGGING_DIALOG_NOTIFY_COOLDOWN_SEC = 30 * 60
 
 
 def _stats_event(event_type: str, device: str, **details: str | int | float) -> None:
@@ -490,13 +492,26 @@ def check_device(name: str, ts_ip: str, lan_ip: str) -> None:
         write_state(state_file, 0)
         return
 
-    # Dismiss system dialogs that appear on debuggable-app devices and block the screen.
+    # The USB/wireless debugging consent dialog is a per-network human
+    # authorization gate — Android does not allow granting it
+    # programmatically, and a human only needs to tap it once per network.
+    # This used to try to auto-accept it via blind keyevent sequences, which
+    # raced with an actual human tapping the real dialog and cancelled their
+    # in-progress interaction (confirmed live on hd8, 2026-07-31 — issue
+    # #43). Detect and notify instead of touching it.
     target = dev.resolve_adb(name) if dev else None
     if target:
         try:
             import adb_cli
 
-            adb_cli.dismiss_usb_debugging_dialog(target)
+            if adb_cli.debugging_dialog_present(target):
+                if _heal_cooldown_ok_dir(name, DEBUGGING_DIALOG_STATE_DIR, DEBUGGING_DIALOG_NOTIFY_COOLDOWN_SEC):
+                    notify(
+                        "stayturgid: action needed",
+                        "%s: USB/wireless debugging dialog is waiting for a human tap (Allow + Always allow)." % name,
+                        sound="Basso",
+                    )
+                    _touch_heal_dir(name, DEBUGGING_DIALOG_STATE_DIR)
             adb_cli.dismiss_app_compatibility_dialog(target)
         except Exception:
             pass

--- a/control/lib/adb_cli.py
+++ b/control/lib/adb_cli.py
@@ -101,53 +101,28 @@ def scp(local: Path, host: str, remote: str) -> None:
     run(["scp", "-q", str(local), f"{host}:{remote}"], check=True)
 
 
-def dismiss_usb_debugging_dialog(serial: str) -> bool:
-    """Dismiss the 'Allow USB debugging?' dialog.
+def debugging_dialog_present(serial: str) -> bool:
+    """Detect (never interact with) the 'Allow USB/wireless debugging?' dialog.
 
-    On Android 11+, /data/misc/adb/adb_keys is not directly writable by
-    the shell uid — only adbd can write it after the user confirms the
-    dialog. This function checks for the dialog and accepts it via
-    keyevents (check 'Always allow' + tap 'Allow').
+    This is a per-network/per-key human consent gate — Android does not let
+    it be granted programmatically, and it only needs a human's own tap
+    once per network. A prior version of this function tried to accept it
+    via blind keyevent sequences (checkbox + Allow), guessing at dialog
+    layout across OEM variants. That automation raced with an actual human
+    trying to tap the real dialog: fleet_health_monitor.py calls this check
+    unconditionally on every health-check pass, and a keyevent-based retry
+    firing mid-tap reset the dialog and cancelled the human's in-progress
+    interaction (confirmed live on hd8, 2026-07-31 — see issue #43).
 
-    Returns True if the dialog was found and dismissed.
+    Returns True if the dialog is currently showing, so the caller can
+    notify a human to go tap it themselves instead.
     """
     result = run(
         ["adb", "-s", serial, "shell", "dumpsys", "activity", "activities"],
         check=False,
     )
     text = (result.stdout or "") + (result.stderr or "")
-    if "UsbDebuggingActivity" not in text and "WifiDebuggingActivity" not in text:
-        return False
-
-    # Try multiple focus sequences — the dialog layout varies across Android
-    # versions and OEMs (standard, Samsung bottom-sheet, etc.).
-    sequences = [
-        # Standard: checkbox (1 TAB) → Allow (1 TAB)
-        [["KEYCODE_TAB"], ["KEYCODE_SPACE"], ["KEYCODE_TAB"], ["KEYCODE_ENTER"]],
-        # Samsung: checkbox (2 TABs) → Allow (1 TAB)
-        [["KEYCODE_TAB"], ["KEYCODE_TAB"], ["KEYCODE_SPACE"], ["KEYCODE_TAB"], ["KEYCODE_ENTER"]],
-        # Samsung bottom sheet: Cancel(1) → checkbox(2) → Allow(1)
-        [["KEYCODE_TAB"], ["KEYCODE_TAB"], ["KEYCODE_TAB"], ["KEYCODE_SPACE"], ["KEYCODE_TAB"], ["KEYCODE_ENTER"]],
-    ]
-    for seq in sequences:
-        for key in seq:
-            run(["adb", "-s", serial, "shell", "input", "keyevent", key[0]], check=False)
-            time.sleep(0.15)
-        time.sleep(0.5)
-        # Check if dialog is gone
-        check = run(
-            ["adb", "-s", serial, "shell", "dumpsys", "activity", "activities"],
-            check=False,
-        )
-        text = (check.stdout or "") + (check.stderr or "")
-        if "UsbDebuggingActivity" not in text and "WifiDebuggingActivity" not in text:
-            print("Dismissed 'Allow USB debugging?' dialog on %s." % serial)
-            return True
-        # Reset focus: HOME then re-open the dialog... actually just BACK
-        run(["adb", "-s", serial, "shell", "input", "keyevent", "KEYCODE_BACK"], check=False)
-        time.sleep(0.5)
-    print("WARN: could not dismiss USB debugging dialog on %s — try manual." % serial)
-    return False
+    return "UsbDebuggingActivity" in text or "WifiDebuggingActivity" in text
 
 
 def dismiss_app_compatibility_dialog(serial: str) -> bool:

--- a/control/lib/adb_cli.py
+++ b/control/lib/adb_cli.py
@@ -101,6 +101,11 @@ def scp(local: Path, host: str, remote: str) -> None:
     run(["scp", "-q", str(local), f"{host}:{remote}"], check=True)
 
 
+def _dump_activities(serial: str) -> str:
+    result = adb(serial, "shell", "dumpsys", "activity", "activities", check=False)
+    return (result.stdout or "") + (result.stderr or "")
+
+
 def debugging_dialog_present(serial: str) -> bool:
     """Detect (never interact with) the 'Allow USB/wireless debugging?' dialog.
 
@@ -117,11 +122,7 @@ def debugging_dialog_present(serial: str) -> bool:
     Returns True if the dialog is currently showing, so the caller can
     notify a human to go tap it themselves instead.
     """
-    result = run(
-        ["adb", "-s", serial, "shell", "dumpsys", "activity", "activities"],
-        check=False,
-    )
-    text = (result.stdout or "") + (result.stderr or "")
+    text = _dump_activities(serial)
     return "UsbDebuggingActivity" in text or "WifiDebuggingActivity" in text
 
 
@@ -132,11 +133,7 @@ def dismiss_app_compatibility_dialog(serial: str) -> bool:
     The dialog has [OK] and [Don't Show Again] buttons. Returns True if found
     and dismissed.
     """
-    result = run(
-        ["adb", "-s", serial, "shell", "dumpsys", "activity", "activities"],
-        check=False,
-    )
-    text = (result.stdout or "") + (result.stderr or "")
+    text = _dump_activities(serial)
     if "AppCompatibility" not in text and "16 KB" not in text:
         return False
 

--- a/tests/python/test_adb_cli.py
+++ b/tests/python/test_adb_cli.py
@@ -1,6 +1,7 @@
 """Unit tests for control/lib/adb_cli.py."""
 
 import os
+import subprocess
 import sys
 
 sys.path.insert(
@@ -33,3 +34,43 @@ def test_alias_for_host_forwards_to_stayturgid_device(monkeypatch):
     monkeypatch.setattr(ac.dev, "alias_for_host", fake_alias_for_host)
     assert ac.alias_for_host("100.124.55.39") == "hd8"
     assert seen["host"] == "100.124.55.39"
+
+
+def test_debugging_dialog_present_detects_usb_activity(monkeypatch):
+    monkeypatch.setattr(
+        ac,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess([], 0, stdout="...UsbDebuggingActivity...", stderr=""),
+    )
+    assert ac.debugging_dialog_present("serial") is True
+
+
+def test_debugging_dialog_present_detects_wifi_activity(monkeypatch):
+    monkeypatch.setattr(
+        ac,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess([], 0, stdout="...WifiDebuggingActivity...", stderr=""),
+    )
+    assert ac.debugging_dialog_present("serial") is True
+
+
+def test_debugging_dialog_present_false_when_absent(monkeypatch):
+    monkeypatch.setattr(
+        ac,
+        "run",
+        lambda *a, **k: subprocess.CompletedProcess([], 0, stdout="nothing interesting", stderr=""),
+    )
+    assert ac.debugging_dialog_present("serial") is False
+
+
+def test_debugging_dialog_present_never_sends_keyevents(monkeypatch):
+    """The old dismiss function sent 'input keyevent' — the detector must never do this."""
+    sent = []
+
+    def fake_run(cmd, **kwargs):
+        sent.append(cmd)
+        return subprocess.CompletedProcess([], 0, stdout="...WifiDebuggingActivity...", stderr="")
+
+    monkeypatch.setattr(ac, "run", fake_run)
+    ac.debugging_dialog_present("serial")
+    assert not any("keyevent" in part for cmd in sent for part in cmd)


### PR DESCRIPTION
## Summary
- `fleet_health_monitor.py` called `dismiss_usb_debugging_dialog()` unconditionally on every ~15-min health check, which sent blind TAB/SPACE/ENTER keyevent sequences guessing at dialog layout to accept the "Allow USB/wireless debugging?" dialog.
- This is a per-network human consent gate Android does not allow granting programmatically — the automation raced with an actual human tapping the real dialog on hd8 and cancelled their in-progress interaction (live-confirmed during issue #43 investigation, 2026-07-31).
- Replaced the blind-tap function with a pure detector (`debugging_dialog_present()`) and notify a human instead of touching the dialog, matching the project's existing "no screen automation, use human notifications" policy.

## Test plan
- [x] All 552 python tests pass (`tests/python/`)
- [x] `ruff check`/`ruff format --check` clean
- [x] `mypy` clean
- [x] Live-verified: hd8 was rebooted with fleet-health paused via the existing maintenance-file mechanism (this fix not yet deployed), then again with the fix logic confirmed not to interfere with the same dialog appearing naturally — human tap succeeded cleanly both times once automation was out of the way

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notifications when USB or Wi‑Fi debugging consent is required.
  * Notifications prompt users to select “Allow” and “Always allow.”
  * Added cooldowns to prevent repeated notifications.

* **Bug Fixes**
  * Debugging consent dialogs are no longer dismissed automatically, while compatibility dialogs continue to be handled automatically.

* **Tests**
  * Added coverage for detecting USB, Wi‑Fi, and absent debugging dialogs.
  * Verified that no automated key events are sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->