### PR TITLE
agent: resize logd ring buffers on Shizuku bind (v0.9.1)

### DIFF
--- a/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
+++ b/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
@@ -41,10 +41,10 @@ stayturgid_debug_key_alias: "androiddebugkey"
 stayturgid_bootstrap_apks:
   - id: org.stayturgid.agent
     gh_repo: djbclark/stayturgid
-    gh_tag: agent-v0.9.0
+    gh_tag: agent-v0.9.1
     gh_pattern: app-release.apk
-    version_name: 0.9.0-new-icon
-    checksum: "sha256:ef1639ca449bc8510be370ce38df36f0185d79966f1b7117ee96beec03e5a19b"
+    version_name: 0.9.1-logbuffer
+    checksum: "sha256:d9bab219b2870a3348927d4e9535849f745bf96ed2540fe48ca179a7b29c7e7f"
     resign: false
     start_broadcast_action: org.stayturgid.agent.action.PEER_START_NOW
     start_broadcast_component: org.stayturgid.agent/org.stayturgid.agent.PeerStartReceiver

--- a/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
+++ b/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
@@ -41,10 +41,10 @@ stayturgid_debug_key_alias: "androiddebugkey"
 stayturgid_bootstrap_apks:
   - id: org.stayturgid.agent
     gh_repo: djbclark/stayturgid
-    gh_tag: agent-v0.9.1
+    gh_tag: agent-v0.9.2
     gh_pattern: app-release.apk
-    version_name: 0.9.1-logbuffer
-    checksum: "sha256:d9bab219b2870a3348927d4e9535849f745bf96ed2540fe48ca179a7b29c7e7f"
+    version_name: 0.9.2-logbuffer
+    checksum: "sha256:21dac038f48ad2eda6e31cf36b39c604fbe1f6614272ee2289abe6b54e751de5"
     resign: false
     start_broadcast_action: org.stayturgid.agent.action.PEER_START_NOW
     start_broadcast_component: org.stayturgid.agent/org.stayturgid.agent.PeerStartReceiver

--- a/device/native-agent/app/build.gradle.kts
+++ b/device/native-agent/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "org.stayturgid.agent"
         minSdk = 26
         targetSdk = 36
-        versionCode = 18
-        versionName = "0.9.0-new-icon"
+        versionCode = 19
+        versionName = "0.9.1-logbuffer"
         val buildTimeUtc =
             System.getenv("SOURCE_DATE_EPOCH")?.toLongOrNull()?.let { Instant.ofEpochSecond(it) }
                 ?: Instant.now().truncatedTo(ChronoUnit.SECONDS)

--- a/device/native-agent/app/build.gradle.kts
+++ b/device/native-agent/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "org.stayturgid.agent"
         minSdk = 26
         targetSdk = 36
-        versionCode = 19
-        versionName = "0.9.1-logbuffer"
+        versionCode = 20
+        versionName = "0.9.2-logbuffer"
         val buildTimeUtc =
             System.getenv("SOURCE_DATE_EPOCH")?.toLongOrNull()?.let { Instant.ofEpochSecond(it) }
                 ?: Instant.now().truncatedTo(ChronoUnit.SECONDS)

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/ShizukuUserService.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/ShizukuUserService.kt
@@ -25,6 +25,7 @@ class ShizukuUserService : IStayTurgidService.Stub {
     constructor() {
         Log.i(TAG, "constructor")
         reapStaleUserServices()
+        ensureLogBufferSize()
     }
 
     /**
@@ -36,6 +37,7 @@ class ShizukuUserService : IStayTurgidService.Stub {
         appContext = context.applicationContext ?: context
         Log.i(TAG, "constructor with Context: $context")
         reapStaleUserServices()
+        ensureLogBufferSize()
     }
 
     override fun destroy() {
@@ -223,6 +225,35 @@ class ShizukuUserService : IStayTurgidService.Stub {
         }
     }
 
+    // logcat's ring buffers default to 256 KiB, which rotates out in seconds under normal
+    // SELinux avc-audit volume (each subprocess spawn logs several "granted" lines) — too small
+    // to catch the sequence around a boot/repair event by the time a human or a Mac-side script
+    // goes looking. `logcat -G` needs shell/root (a plain app UID cannot resize logd's buffers),
+    // so this can only run here, inside the Shizuku-bound UserService — and since Shizuku itself
+    // has to be up before this constructor runs, this is the earliest point in the boot sequence
+    // this process can reach with the privilege to do it. Idempotent: resizing to the same size
+    // again is a cheap no-op, so this runs unconditionally on every UserService (re)start rather
+    // than tracking a "did we already do this" flag.
+    private fun ensureLogBufferSize() {
+        try {
+            val p =
+                ProcessBuilder("logcat", "-b", "all", "-G", LOG_BUFFER_SIZE)
+                    .redirectErrorStream(true)
+                    .start()
+            if (!p.waitFor(LOG_BUFFER_RESIZE_TIMEOUT_SEC, TimeUnit.SECONDS)) {
+                p.destroyForcibly()
+                Log.w(TAG, "logcat -G timed out")
+                return
+            }
+            if (p.exitValue() != 0) {
+                val out = p.inputStream.bufferedReader().use { it.readText().trim() }
+                Log.w(TAG, "logcat -G exited ${p.exitValue()}: $out")
+            }
+        } catch (t: Throwable) {
+            Log.w(TAG, "ensureLogBufferSize failed: ${t.message}")
+        }
+    }
+
     private fun runPidof(pkg: String): String {
         val p = ProcessBuilder("pidof", "$pkg:userservice").redirectErrorStream(true).start()
         if (!p.waitFor(2, TimeUnit.SECONDS)) {
@@ -254,6 +285,11 @@ class ShizukuUserService : IStayTurgidService.Stub {
 
     companion object {
         private const val TAG = "StayTurgidUS"
+
+        // 8 MiB per buffer (main/system/crash/kernel) — comfortably outlasts a boot+repair
+        // sequence even under hd8's heavy avc-audit log volume; well under logd's device-wide cap.
+        private const val LOG_BUFFER_SIZE = "8M"
+        private const val LOG_BUFFER_RESIZE_TIMEOUT_SEC = 5L
 
         /** Pure: pidof output -> pids that are stale (not this process) and should be reaped. */
         internal fun stalePidsToReap(pidofOutput: String, myPid: Int): List<Int> =

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/ShizukuUserService.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/ShizukuUserService.kt
@@ -286,8 +286,10 @@ class ShizukuUserService : IStayTurgidService.Stub {
     companion object {
         private const val TAG = "StayTurgidUS"
 
-        // 8 MiB per buffer (main/system/crash/kernel) — comfortably outlasts a boot+repair
-        // sequence even under hd8's heavy avc-audit log volume; well under logd's device-wide cap.
+        // Requested size per buffer (main/system/crash/kernel) — comfortably outlasts a
+        // boot+repair sequence even under hd8's heavy avc-audit log volume. logd enforces its own
+        // device-specific hard cap and silently clamps down to it (verified live: hd8 accepts the
+        // full 8M, s24's cap is only 5M) — that's a benign, expected outcome, not a failure.
         private const val LOG_BUFFER_SIZE = "8M"
         private const val LOG_BUFFER_RESIZE_TIMEOUT_SEC = 5L
 

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/ShizukuUserService.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/ShizukuUserService.kt
@@ -235,13 +235,17 @@ class ShizukuUserService : IStayTurgidService.Stub {
     // again is a cheap no-op, so this runs unconditionally on every UserService (re)start rather
     // than tracking a "did we already do this" flag.
     private fun ensureLogBufferSize() {
+        // Fully qualified: android.os.Process (imported above for Process.myPid()/myUid()) would
+        // otherwise shadow java.lang.Process here.
+        var p: java.lang.Process? = null
         try {
-            val p =
+            p =
                 ProcessBuilder("logcat", "-b", "all", "-G", LOG_BUFFER_SIZE)
                     .redirectErrorStream(true)
                     .start()
             if (!p.waitFor(LOG_BUFFER_RESIZE_TIMEOUT_SEC, TimeUnit.SECONDS)) {
                 p.destroyForcibly()
+                p.waitFor()
                 Log.w(TAG, "logcat -G timed out")
                 return
             }
@@ -251,6 +255,13 @@ class ShizukuUserService : IStayTurgidService.Stub {
             }
         } catch (t: Throwable) {
             Log.w(TAG, "ensureLogBufferSize failed: ${t.message}")
+        } finally {
+            // Explicit close rather than try-with-resources: destroyForcibly() above already
+            // tears the process down on the timeout path, but its streams (stdin/stdout, merged
+            // stderr) still need closing on every path — success, non-zero exit, or timeout — to
+            // avoid leaking file descriptors from an unread/unclosed stream.
+            p?.inputStream?.close()
+            p?.outputStream?.close()
         }
     }
 

--- a/tests/python/test_bootstrap_apk_lock.py
+++ b/tests/python/test_bootstrap_apk_lock.py
@@ -23,9 +23,9 @@ def test_every_github_apk_is_immutably_locked():
 
 def test_native_agent_uses_its_release_stream_and_real_asset_name():
     agent = next(apk for apk in _catalog() if apk["id"] == "org.stayturgid.agent")
-    assert agent["gh_tag"] == "agent-v0.9.1"
+    assert agent["gh_tag"] == "agent-v0.9.2"
     assert agent["gh_pattern"] == "app-release.apk"
-    assert agent["version_name"] == "0.9.1-logbuffer"
+    assert agent["version_name"] == "0.9.2-logbuffer"
     assert agent["remove_packages"] == ["org.stayturgid.agent.debug"]
     assert agent["service_component"] == "org.stayturgid.agent/.HostService"
     assert agent["start_broadcast_action"] == "org.stayturgid.agent.action.PEER_START_NOW"

--- a/tests/python/test_bootstrap_apk_lock.py
+++ b/tests/python/test_bootstrap_apk_lock.py
@@ -23,9 +23,9 @@ def test_every_github_apk_is_immutably_locked():
 
 def test_native_agent_uses_its_release_stream_and_real_asset_name():
     agent = next(apk for apk in _catalog() if apk["id"] == "org.stayturgid.agent")
-    assert agent["gh_tag"] == "agent-v0.9.0"
+    assert agent["gh_tag"] == "agent-v0.9.1"
     assert agent["gh_pattern"] == "app-release.apk"
-    assert agent["version_name"] == "0.9.0-new-icon"
+    assert agent["version_name"] == "0.9.1-logbuffer"
     assert agent["remove_packages"] == ["org.stayturgid.agent.debug"]
     assert agent["service_component"] == "org.stayturgid.agent/.HostService"
     assert agent["start_broadcast_action"] == "org.stayturgid.agent.action.PEER_START_NOW"


### PR DESCRIPTION
## Summary
- logd's per-buffer default (256 KiB) rotates out in seconds under normal SELinux avc-audit volume — made it hard to catch the log sequence around a boot/repair event during the #43 CLOSED_NO_SHELL investigation on hd8.
- `logcat -G` needs shell/root, which only the Shizuku-bound UserService has — resize all buffers to 8 MiB there, on every (re)bind (idempotent no-op if already sized).
- Bumped to agent-v0.9.1, published GitHub release, updated bootstrap_apks lock + test expectations.

## Test plan
- [x] `:app:testDebugUnitTest`, `spotlessCheck`, `detekt` all pass
- [x] Release build signed with `CN=StayTurgid` (matches existing release cert)
- [x] `tests/python/test_bootstrap_apk_lock.py` passes with updated lock values
- [ ] Live device verification (deploy + confirm buffer resize takes effect) — pending, will do before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved log availability by configuring an 8 MB Android log buffer when the native agent starts.
  * Updated the native agent to version 0.9.1.

* **Bug Fixes**
  * Added safeguards so log buffer configuration failures do not interrupt agent startup.

* **Tests**
  * Updated regression coverage for the new agent release and version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->