### PR TITLE
control: ship device log failures to central logging (OpenObserve)

### DIFF
--- a/control/bin/fleet_health_monitor.py
+++ b/control/bin/fleet_health_monitor.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import datetime
 import os
+import re
 import subprocess
 import sys
 import time
@@ -70,6 +71,7 @@ REPAIR_HEAL_COOLDOWN_SEC = 30 * 60
 REPAIR_HEAL_AFTER = 2
 DEBUGGING_DIALOG_STATE_DIR = os.path.join(ROOT, "state", "debugging-dialog-notify")
 DEBUGGING_DIALOG_NOTIFY_COOLDOWN_SEC = 30 * 60
+DEVLOG_STATE_DIR = os.path.join(ROOT, "state", "device-log-failure")
 
 
 def _stats_event(event_type: str, device: str, **details: str | int | float) -> None:
@@ -484,6 +486,93 @@ def _record_soft_health_snapshot(
     )
 
 
+# stayturgid_repair.py's log() severity token — "TS [repair] ERR: msg" /
+# "TS [repair] WARNING: msg" (see device/termux/py/stayturgid_repair.py's
+# _SEV_LABEL). agent.log has no such token; fleet_health.py's
+# _DEVLOG_TAIL_BODY already filtered agent.log lines down to FAILED/error=/
+# still-down content before they ever reach us, so anything tagged
+# source="agent.log" here is a failure by construction — treat it as ERR.
+_WATCHDOG_SEVERITY_RE = re.compile(r"\[repair\] (ERR|WARNING):")
+
+
+def _devlog_severity(source: str, line: str) -> str | None:
+    if source == "watchdog.log":
+        m = _WATCHDOG_SEVERITY_RE.search(line)
+        return m.group(1) if m else None
+    if source == "agent.log":
+        return "ERR"
+    return None
+
+
+def _devlog_state_path(name: str, source: str) -> str:
+    return os.path.join(DEVLOG_STATE_DIR, "%s__%s" % (name, source.replace("/", "_")))
+
+
+def _report_device_log_failures(name: str, report: dict) -> None:
+    """Forward NEW Termux/native-agent failure lines to stats (central-logging
+    gap found live-debugging hd8, 2026-07-31 — these only ever existed in
+    on-device log files nobody happened to SSH in and grep).
+
+    fleet_health.py's SSH/adb probe already tails watchdog.log/agent.log for
+    ERR/WARNING-ish lines every cycle (see extract_devlog_lines /
+    _DEVLOG_TAIL_BODY) and hands them back on report["_devlog"]. This is
+    purely the Mac-side dedup + stats.record_event step.
+
+    Dedup design: one last-reported-epoch state file per (device, source),
+    alongside the other fleet-health state dirs. A line is reported only if
+    its embedded timestamp is strictly newer than the last one reported for
+    that device+source — so a long-lived historical backlog (the exact
+    failure mode _audit_scraped_errors below already had to guard against
+    once, 2026-07-19: 55 old lines alerting forever) gets reported once and
+    never again.
+
+    This intentionally has no *separate* re-notify cooldown on top of that.
+    A persistent, still-unresolved failure keeps producing genuinely NEW
+    timestamped lines on its own — stayturgid_repair.py re-logs a fresh ERR
+    every cycle it still sees the condition (e.g. ensure_tailscale's
+    "Tailscale repair FAILED" line), and CatastrophicRepair does the same in
+    agent.log — so the epoch dedup naturally lets each new occurrence back
+    through without a manual timer, while a one-off resolved blip stays
+    quiet. If a source ever went quiet while still broken (no fresh line),
+    this would miss it — not a concern for any log covered here today.
+    """
+    devlog = report.get("_devlog") or []
+    if not devlog:
+        return
+    os.makedirs(DEVLOG_STATE_DIR, exist_ok=True)
+    by_source: dict[str, list[str]] = {}
+    for entry in devlog:
+        by_source.setdefault(entry.get("source", "unknown"), []).append(entry.get("line", ""))
+
+    for source, lines in by_source.items():
+        state_path = _devlog_state_path(name, source)
+        last = read_state(state_path)
+        newest = last
+        for line in lines:
+            severity = _devlog_severity(source, line)
+            if severity is None:
+                continue
+            epoch = _device_log_epoch(line)
+            if epoch is None:
+                # Can't age it — same rule _audit_scraped_errors uses: never
+                # let an unparseable timestamp inflate/duplicate reporting.
+                continue
+            epoch_i = int(epoch)
+            if epoch_i <= last:
+                continue
+            _stats_event(
+                "device_log_failure",
+                name,
+                source=source,
+                severity=severity,
+                message=line.strip()[:500],
+            )
+            if epoch_i > newest:
+                newest = epoch_i
+        if newest > last:
+            write_state(state_path, newest)
+
+
 def check_device(name: str, ts_ip: str, lan_ip: str) -> None:
     state_file = os.path.join(STATE_DIR, name)
     maintenance_file = os.path.join(STATE_DIR, f"{name}.maintenance")
@@ -549,6 +638,9 @@ def check_device(name: str, ts_ip: str, lan_ip: str) -> None:
         _stats_event("issue_detected", name, issue=issue)
     # Long-term dual-run / pre-cutover telemetry (JSONL forever under stats/).
     _record_soft_health_snapshot(name, path, report, issues)
+    # New ERR/WARNING lines the same probe already tailed from watchdog.log /
+    # agent.log (central-logging gap, 2026-07-31) -> stats -> OpenObserve.
+    _report_device_log_failures(name, report)
 
     _scrape_device_errors(name, ts_ip)
 

--- a/control/lib/fleet_health.py
+++ b/control/lib/fleet_health.py
@@ -70,6 +70,32 @@ print("unknown")
   echo "$age"
 """
 
+# Central-logging gap (found live-debugging hd8, 2026-07-31): Termux-side
+# repair failures and native-agent catastrophic-repair outcomes previously
+# only existed in on-device log files, never reaching the Mac. Tail both
+# during the SSH probe that's already happening (no second connection) and
+# emit each candidate line as a "DEVLOG_<SRC>|<line>" marker so the Mac side
+# (extract_devlog_lines) can split it out *before* parse_kv ever sees it — a
+# raw log line can itself contain "=" (e.g. "runtime=down policy=down") and
+# would otherwise be mis-split into a bogus top-level report field.
+#
+# watchdog.log: stayturgid_repair.py's log() writes an explicit syslog-style
+# severity token — "TS [repair] ERR: msg" / "TS [repair] WARNING: msg" (see
+# device/termux/py/stayturgid_repair.py's _SEV_LABEL) — so we can grep on
+# that token directly.
+#
+# agent.log: CatastrophicRepair/ComonitorProbes (Kotlin) have no severity
+# token, just free-text appendLog() calls. Classify by content instead:
+# "FAILED"/"error=" catches the catastrophic-repair failure paths, and
+# "still down" catches repairTailscale's post-fallback failure line (which
+# says "tailscale still down after ..." without the word FAILED). STATUS
+# lines are excluded — that telemetry already flows through the normal
+# soft_health snapshot and would otherwise be double-counted as noise.
+_DEVLOG_TAIL_BODY = r"""
+grep -h -E '\[repair\] (ERR|WARNING):' "$SD/logs/watchdog.log" /sdcard/stayturgid/logs/watchdog.log 2>/dev/null | tail -20 | while IFS= read -r l; do echo "DEVLOG_WATCHDOG|$l"; done
+grep -h '\[agent\]' "$SD/logs/agent.log" /sdcard/stayturgid/logs/agent.log 2>/dev/null | grep -v ' STATUS ' | grep -iE 'FAILED|error=|still down' | tail -20 | while IFS= read -r l; do echo "DEVLOG_AGENT|$l"; done
+"""
+
 HEALTH_GATHER = (
     r"""
 export PATH=/data/data/com.termux/files/usr/bin:$PATH
@@ -173,6 +199,7 @@ else
   echo "cfengine=down"
 fi
 """
+    + _DEVLOG_TAIL_BODY
 )
 
 
@@ -187,6 +214,35 @@ def parse_kv(text: str) -> dict[str, str]:
     return out
 
 
+# Marker prefixes _DEVLOG_TAIL_BODY emits -> the report["source"] we file them under.
+_DEVLOG_MARKERS = {
+    "DEVLOG_WATCHDOG": "watchdog.log",
+    "DEVLOG_AGENT": "agent.log",
+}
+
+
+def extract_devlog_lines(text: str) -> tuple[str, list[dict[str, str]]]:
+    """Split _DEVLOG_TAIL_BODY's ``DEVLOG_<SRC>|<line>`` markers out of *text*.
+
+    Must run before parse_kv: a raw device log line can itself contain "="
+    (e.g. "runtime=down policy=down"), which parse_kv's naive split would
+    otherwise turn into a bogus top-level report field.
+
+    Returns (remaining_text_for_parse_kv, [{"source": ..., "line": ...}, ...]),
+    in the order the on-device tail emitted them (oldest matched line first).
+    """
+    kept: list[str] = []
+    found: list[dict[str, str]] = []
+    for line in text.splitlines():
+        marker, sep, rest = line.partition("|")
+        source = _DEVLOG_MARKERS.get(marker) if sep else None
+        if source:
+            found.append({"source": source, "line": rest})
+        else:
+            kept.append(line)
+    return "\n".join(kept), found
+
+
 def _int_age(raw: str | None) -> int | None:
     if raw is None or raw in ("missing", "unknown", ""):
         return None
@@ -196,7 +252,7 @@ def _int_age(raw: str | None) -> int | None:
         return None
 
 
-def _normalize_status_fields(report: dict[str, str]) -> None:
+def _normalize_status_fields(report: dict[str, Any]) -> None:
     if "status_line" not in report:
         return
     for field in ("a11y", "port", "shizuku", "tailscale", "tailscale_policy"):
@@ -222,7 +278,7 @@ def a11y_profile_missing(alias: str, a11y_list: str | None) -> list[str]:
     return [s for s in expected if s not in live]
 
 
-def evaluate_health(report: dict[str, str], *, alias: str | None = None) -> list[str]:
+def evaluate_health(report: dict[str, Any], *, alias: str | None = None) -> list[str]:
     """Return sorted issue tags (empty = healthy / inconclusive-ok)."""
     issues: list[str] = []
     # Structured probe failures (Mac adb missing/timeout) — not device soft state.
@@ -286,7 +342,7 @@ def evaluate_health(report: dict[str, str], *, alias: str | None = None) -> list
     return sorted(set(issues))
 
 
-def summarize(report: dict[str, str], issues: list[str]) -> str:
+def summarize(report: dict[str, Any], issues: list[str]) -> str:
     bits = [
         "sshd=%s" % report.get("sshd", "?"),
         "bootloop=%s" % report.get("bootloop", "?"),
@@ -312,7 +368,7 @@ def summarize(report: dict[str, str], issues: list[str]) -> str:
     return " ".join(bits)
 
 
-def ssh_health(host: str, *, timeout: int = 30) -> dict[str, str]:
+def ssh_health(host: str, *, timeout: int = 30) -> dict[str, Any]:
     """Run HEALTH_GATHER over SSH. On failure return ssh_echo=fail."""
     try:
         r = subprocess.run(
@@ -341,16 +397,19 @@ def ssh_health(host: str, *, timeout: int = 30) -> dict[str, str]:
         return {"ssh_echo": "fail"}
     if r.returncode != 0:
         return {"ssh_echo": "fail"}
-    report = parse_kv(r.stdout or "")
+    text, devlog = extract_devlog_lines(r.stdout or "")
+    report: dict[str, Any] = parse_kv(text)
+    if devlog:
+        report["_devlog"] = devlog
     if "ssh_echo" not in report:
         report["ssh_echo"] = "ok"
     _normalize_status_fields(report)
     return report
 
 
-def adb_health(serial: str, *, timeout: int = 30) -> dict[str, str]:
+def adb_health(serial: str, *, timeout: int = 30) -> dict[str, Any]:
     """Best-effort Mac-side scrape when SSH is down but adb works (e.g. Fire)."""
-    report: dict[str, str] = {"ssh_echo": "skip", "sshd": "unknown", "bootloop": "unknown"}
+    report: dict[str, Any] = {"ssh_echo": "skip", "sshd": "unknown", "bootloop": "unknown"}
     script = (
         r"""
 now=$(date +%s)
@@ -423,6 +482,12 @@ echo "$st" | grep -oE 'shizuku=[^ ]+' || echo "shizuku=unknown"
 echo "$st" | grep -oE 'a11y=[^ ]+' || echo "a11y=unknown"
 echo "shell5555=skip"
 echo "bootloop=unknown"
+# Same DEVLOG_<SRC>|<line> markers as HEALTH_GATHER's _DEVLOG_TAIL_BODY (see
+# its comment for the ERR/WARNING and FAILED/error=/still-down rationale) —
+# this fallback path uses this script's own hardcoded $LOGS paths instead of
+# $SD since that variable isn't defined here.
+grep -h -E '\[repair\] (ERR|WARNING):' $LOGS 2>/dev/null | tail -20 | while IFS= read -r l; do echo "DEVLOG_WATCHDOG|$l"; done
+grep -h '\[agent\]' /sdcard/stayturgid/logs/agent.log 2>/dev/null | grep -v ' STATUS ' | grep -iE 'FAILED|error=|still down' | tail -20 | while IFS= read -r l; do echo "DEVLOG_AGENT|$l"; done
 """
     )
     try:
@@ -432,7 +497,10 @@ echo "bootloop=unknown"
             text=True,
             timeout=timeout,
         )
-        report.update(parse_kv(r.stdout or ""))
+        text, devlog = extract_devlog_lines(r.stdout or "")
+        report.update(parse_kv(text))
+        if devlog:
+            report["_devlog"] = devlog
         _normalize_status_fields(report)
     except FileNotFoundError:
         report["probe"] = "adb_missing"

--- a/control/lib/stats.py
+++ b/control/lib/stats.py
@@ -1,16 +1,28 @@
 """Long-term statistics — JSONL events kept forever (no 30-day rotation).
 
 All stayturgid monitors and heal scripts should call record_event() for:
-  - connection_path:  which transport was used for a probe
-  - heal_triggered:   which self-heal fired
-  - device_status:    online / offline transitions
-  - issue_detected:   per-issue occurrence
-  - soft_health:      full dual-run probe snapshot (agent_age, watchdog_age, port, …)
+  - connection_path:   which transport was used for a probe
+  - heal_triggered:     which self-heal fired
+  - device_status:      online / offline transitions
+  - issue_detected:     per-issue occurrence
+  - soft_health:        full dual-run probe snapshot (agent_age, watchdog_age, port, …)
+  - device_log_failure: an ERR/WARNING-severity line freshly seen in an
+    on-device log (Termux ``watchdog.log`` or native-agent ``agent.log``)
+    during a fleet-health SSH probe — fields: ``source`` (watchdog.log /
+    agent.log), ``severity`` (ERR / WARNING), ``message`` (the raw log
+    line, truncated). See ``control/lib/fleet_health.py``'s
+    ``extract_devlog_lines()`` and
+    ``control/bin/fleet_health_monitor.py``'s
+    ``_report_device_log_failures()``.
 
 Primary durable files under ``~/.config/stayturgid/stats/``:
 
   - ``events.jsonl`` — all event types (local query_events)
-  - ``soft_health.jsonl`` — soft_health only, for Vector → OpenObserve
+  - ``soft_health.jsonl`` — soft_health + device_log_failure, for Vector →
+    OpenObserve (device_log_failure rides the same file/stream deliberately —
+    Vector's file source only tails soft_health.jsonl, so dual-writing here
+    reaches OpenObserve with zero Vector config changes; query by the
+    ``type`` field to distinguish rows)
 
 Writers use whole-line append + flush + fsync so a crash mid-write at worst
 leaves one corrupt last line (Vector drops parse errors). Vector tails
@@ -106,7 +118,9 @@ def record_event(event_type: str, device: str, **details: object) -> None:
 
     # Dedicated file for Vector micro-batch → OpenObserve stream soft_health.
     # Keeps OO ingest independent of other event types and easy to re-tail.
-    if event_type == "soft_health":
+    # device_log_failure rides the same file (see module docstring) so it
+    # reaches OpenObserve through the existing pipe with no new Vector config.
+    if event_type in ("soft_health", "device_log_failure"):
         _append_jsonl_line(soft_health_path(), event)
 
 

--- a/device/termux/py/stayturgid_repair.py
+++ b/device/termux/py/stayturgid_repair.py
@@ -869,6 +869,119 @@ def ensure_pkg_upgrade_daily():
         return "FAILED"
 
 
+# --- On-device fallback anomaly detection (issue: central-logging gap, 2026-07-31) ---
+#
+# fleet_health_monitor.py now ships new ERR/WARNING watchdog.log lines to
+# stats/OpenObserve every SSH probe cycle — but that whole path (Mac reachable
+# over SSH/Tailscale, OpenObserve up) can be down at exactly the moment a
+# device is unhealthy. This is the fallback that doesn't depend on any of it:
+# count our own recent ERR lines and, past a threshold, poke the operator
+# directly via termux-notification. Deliberately simple — a counter + a
+# threshold, not a general anomaly detector.
+ERROR_RATE_WINDOW_SEC = 3600  # rolling window: last hour
+# ensure_tailscale (and other checks) log a fresh ERR every repair cycle
+# (~STAYTURGID_INTERVAL_SEC=300s in start_adb.py) they still see the same
+# failure, so a *sustained* problem produces ~12 ERR lines/hour. Threshold=3
+# (~15 min of consecutive failing cycles) is high enough that one or two
+# transient blips don't page a human, low enough to catch a real outage well
+# before the old "nobody happened to SSH in today" discovery path.
+ERROR_RATE_THRESHOLD = 3
+ERROR_RATE_NOTIFY_COOLDOWN_SEC = 3600  # re-notify at most once/hour while still bad
+ERROR_RATE_NOTIFY_STAMP = os.path.join(STG, "state", "watchdog-error-rate-notify")
+
+
+def _parse_watchdog_line_epoch(line):
+    """Return epoch seconds for a 'YYYY-MM-DD HH:MM:SS [repair] ...' line, or None."""
+    try:
+        return datetime.datetime.strptime(line[:19], "%Y-%m-%d %H:%M:%S").timestamp()
+    except ValueError:
+        return None
+
+
+def count_recent_watchdog_errors(path=None, now=None, window_sec=ERROR_RATE_WINDOW_SEC):
+    """Count '[repair] ERR:' lines within window_sec of now in watchdog.log.
+
+    path/now are injectable for tests; production calls use SDLOG/real time.
+    """
+    path = path or SDLOG
+    now = now if now is not None else time.time()
+    count = 0
+    try:
+        with open(path) as f:
+            lines = f.readlines()
+    except OSError:
+        return 0
+    for line in lines:
+        if "[repair] ERR:" not in line:
+            continue
+        epoch = _parse_watchdog_line_epoch(line)
+        if epoch is None:
+            continue
+        if 0 <= now - epoch <= window_sec:
+            count += 1
+    return count
+
+
+def maybe_notify_error_rate(tapi_module=None):
+    """termux-notification fallback for when the Mac pipe might be unreachable too.
+
+    Uses ONLY the safe termux_api wrapper (control/lib/termux_api.py, deployed
+    to ~/.stayturgid/lib) — never a bare subprocess call to termux-notification.
+    A bare timeout+kill on a termux-api client causes a loud "Error in
+    ResultReturner" toast (the exact bug already fixed once this session, in
+    start_adb.py) — termux_api.notify()/run_ff() orphan instead of killing so
+    the socket can still complete.
+
+    Returns "ok" (below threshold), "cooldown" (already notified recently),
+    or "notified".
+    """
+    count = count_recent_watchdog_errors()
+    if count < ERROR_RATE_THRESHOLD:
+        return "ok"
+    last = 0.0
+    try:
+        with open(ERROR_RATE_NOTIFY_STAMP) as f:
+            last = float(f.read().strip() or 0)
+    except (OSError, ValueError):
+        last = 0.0
+    now = time.time()
+    if now - last < ERROR_RATE_NOTIFY_COOLDOWN_SEC:
+        return "cooldown"
+
+    tapi = tapi_module
+    if tapi is None:
+        try:
+            import stayturgid_shell as _sh
+
+            _sh.ensure_lib_path()
+            import termux_api as tapi
+        except ImportError:
+            tapi = None
+    if tapi is not None:
+        tapi.notify(
+            [
+                "termux-notification",
+                "--id",
+                "stayturgid-error-rate",
+                "--title",
+                "stayturgid: repeated errors",
+                "--content",
+                "%d repair ERR lines in the last hour - check watchdog.log" % count,
+            ]
+        )
+    log(
+        "watchdog error-rate fallback: %d ERR lines in last %ds — notified operator (Mac pipe may be down too)"
+        % (count, ERROR_RATE_WINDOW_SEC),
+        WARNING,
+    )
+    try:
+        with open(ensure_parent(ERROR_RATE_NOTIFY_STAMP), "w") as f:
+            f.write(str(int(now)))
+    except OSError:
+        pass
+    return "notified"
+
+
 def main():
     try:
         os.makedirs(TMPDIR, exist_ok=True)
@@ -1161,6 +1274,11 @@ def main():
     tailscale, tailscale_policy = _tailscale_status(have_sh=have_sh)
     if tailscale_repair == "FAILED" or tailscale == "down" or tailscale_policy == "down":
         rc = 1
+
+    # --- 11. Fallback anomaly detection: notify a human directly if this
+    # cycle (or a recent one) is part of a sustained error spike, independent
+    # of whether the Mac control node / OpenObserve is reachable at all.
+    maybe_notify_error_rate()
 
     status = (
         "STATUS port=%s shizuku=%s sshd=%s a11y=%s shell=%s wifi=%s tailscale=%s tailscale_policy=%s et_cfg=%s os_release=%s pkg_upgrade=%s auto_profile=%s shizuku_profile=%s device_profile=%s env=%s"

--- a/tests/python/test_fleet_health.py
+++ b/tests/python/test_fleet_health.py
@@ -33,6 +33,69 @@ def test_health_gather_reads_native_agent_log():
     assert r"\[agent\] STATUS" in fh.HEALTH_GATHER
 
 
+def test_health_gather_tails_devlog_failures():
+    """Central-logging gap (2026-07-31): the same probe now also tails
+    watchdog.log ERR/WARNING lines and agent.log failure lines."""
+    assert "DEVLOG_WATCHDOG|" in fh.HEALTH_GATHER
+    assert "DEVLOG_AGENT|" in fh.HEALTH_GATHER
+    assert r"\[repair\] (ERR|WARNING):" in fh.HEALTH_GATHER
+
+
+def test_extract_devlog_lines_splits_markers_and_keeps_rest():
+    text = (
+        "sshd=ok\n"
+        "DEVLOG_WATCHDOG|2026-07-31 17:42:21 [repair] ERR: Tailscale repair FAILED "
+        "(runtime=down policy=down); unlocked operator action may be required\n"
+        "watchdog_age=10\n"
+        "DEVLOG_AGENT|2026-07-31 17:43:00 [agent] catastrophic FAILED steps=shell_wireless\n"
+    )
+    remaining, devlog = fh.extract_devlog_lines(text)
+    kv = fh.parse_kv(remaining)
+    assert kv == {"sshd": "ok", "watchdog_age": "10"}
+    assert devlog == [
+        {
+            "source": "watchdog.log",
+            "line": (
+                "2026-07-31 17:42:21 [repair] ERR: Tailscale repair FAILED "
+                "(runtime=down policy=down); unlocked operator action may be required"
+            ),
+        },
+        {
+            "source": "agent.log",
+            "line": "2026-07-31 17:43:00 [agent] catastrophic FAILED steps=shell_wireless",
+        },
+    ]
+
+
+def test_extract_devlog_lines_no_markers_is_passthrough():
+    text = "sshd=ok\nwatchdog_age=10\n"
+    remaining, devlog = fh.extract_devlog_lines(text)
+    assert remaining == "sshd=ok\nwatchdog_age=10"
+    assert devlog == []
+
+
+def test_ssh_health_surfaces_devlog_without_corrupting_report(monkeypatch):
+    class MockResult:
+        returncode = 0
+        stdout = (
+            "sshd=ok\n"
+            "DEVLOG_WATCHDOG|2026-07-31 17:42:21 [repair] ERR: Tailscale repair FAILED "
+            "(runtime=down policy=down)\n"
+        )
+        stderr = ""
+
+    monkeypatch.setattr(fh.subprocess, "run", lambda *a, **k: MockResult())
+    report = fh.ssh_health("oneui-device")
+    assert report["sshd"] == "ok"
+    assert "runtime" not in report  # the raw '=' inside the log line must not leak in
+    assert report["_devlog"] == [
+        {
+            "source": "watchdog.log",
+            "line": "2026-07-31 17:42:21 [repair] ERR: Tailscale repair FAILED (runtime=down policy=down)",
+        }
+    ]
+
+
 def test_device_log_epoch():
     parsed = fhm._device_log_epoch("2026-07-13 12:38:56 [watchdog] example failure")
     expected = datetime.datetime(2026, 7, 13, 12, 38, 56).timestamp()
@@ -419,3 +482,133 @@ def test_monitor_heals_stale_agent(tmp_path, monkeypatch):
     fhm.check_device("oneui-device", "100.1", "192.1")
     agent_calls = [call for call in calls if any("start_agent.py" in str(part) for part in call)]
     assert len(agent_calls) == 1
+
+
+# ── device_log_failure (central-logging gap, 2026-07-31) ───────────────────
+
+
+def test_devlog_severity_watchdog_reads_explicit_token():
+    assert (
+        fhm._devlog_severity(
+            "watchdog.log",
+            "2026-07-31 17:42:21 [repair] ERR: Tailscale repair FAILED (runtime=down policy=down)",
+        )
+        == "ERR"
+    )
+    assert (
+        fhm._devlog_severity(
+            "watchdog.log",
+            "2026-07-31 17:42:21 [repair] WARNING: wireless debugging re-enable FAILED",
+        )
+        == "WARNING"
+    )
+    assert fhm._devlog_severity("watchdog.log", "2026-07-31 17:42:21 [repair] NOTICE: Tailscale restored") is None
+
+
+def test_devlog_severity_agent_log_is_always_err():
+    # agent.log lines only reach us after HEALTH_GATHER's FAILED/error=/still-down
+    # grep already filtered out anything that isn't a failure.
+    assert fhm._devlog_severity("agent.log", "2026-07-31 [agent] catastrophic FAILED steps=x") == "ERR"
+
+
+def test_report_device_log_failures_dedups_by_epoch(tmp_path, monkeypatch):
+    monkeypatch.setattr(fhm, "DEVLOG_STATE_DIR", str(tmp_path / "device-log-failure"))
+    events = []
+    monkeypatch.setattr(fhm, "_stats_event", lambda etype, device, **d: events.append((etype, device, d)))
+
+    report = {
+        "_devlog": [
+            {
+                "source": "watchdog.log",
+                "line": "2026-07-31 17:42:21 [repair] ERR: Tailscale repair FAILED (runtime=down policy=down)",
+            },
+        ]
+    }
+    fhm._report_device_log_failures("hd8", report)
+    assert len(events) == 1
+    assert events[0][0] == "device_log_failure"
+    assert events[0][1] == "hd8"
+    assert events[0][2]["source"] == "watchdog.log"
+    assert events[0][2]["severity"] == "ERR"
+    assert "Tailscale repair FAILED" in events[0][2]["message"]
+
+    # Same line again (e.g. still within HEALTH_GATHER's tail -20 window on the
+    # next cycle) must NOT be re-reported — epoch dedup.
+    fhm._report_device_log_failures("hd8", report)
+    assert len(events) == 1
+
+    # A genuinely NEW, later timestamped line for the same persistent failure
+    # (stayturgid_repair.py re-logs a fresh ERR every cycle it's still down)
+    # must be reported — this is the "re-notify while unresolved" path.
+    report2 = {
+        "_devlog": [
+            {
+                "source": "watchdog.log",
+                "line": "2026-07-31 17:47:21 [repair] ERR: Tailscale repair FAILED (runtime=down policy=down)",
+            },
+        ]
+    }
+    fhm._report_device_log_failures("hd8", report2)
+    assert len(events) == 2
+
+
+def test_report_device_log_failures_ignores_non_failure_lines(tmp_path, monkeypatch):
+    monkeypatch.setattr(fhm, "DEVLOG_STATE_DIR", str(tmp_path / "device-log-failure"))
+    events = []
+    monkeypatch.setattr(fhm, "_stats_event", lambda etype, device, **d: events.append((etype, device, d)))
+    report = {
+        "_devlog": [
+            {"source": "watchdog.log", "line": "2026-07-31 17:42:21 [repair] NOTICE: Tailscale restored"},
+        ]
+    }
+    fhm._report_device_log_failures("hd8", report)
+    assert events == []
+
+
+def test_report_device_log_failures_noop_without_devlog():
+    # No "_devlog" key at all (e.g. a healthy probe with nothing to report) —
+    # must not raise or touch state.
+    fhm._report_device_log_failures("hd8", {})
+
+
+def test_check_device_forwards_devlog_to_stats(tmp_path, monkeypatch):
+    monkeypatch.setattr(fhm, "STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(fhm, "DEVLOG_STATE_DIR", str(tmp_path / "device-log-failure"))
+    monkeypatch.setattr(fhm, "SKIP_HEALTH", False)
+    monkeypatch.setattr(fhm, "SKIP_WATCHDOG_HEAL", True)
+    monkeypatch.setattr(fhm, "_scrape_device_errors", lambda *a, **k: None)
+    monkeypatch.setattr(fhm, "notify", lambda *a, **k: None)
+    monkeypatch.setattr(fhm, "_fleet_log", lambda *_: None)
+    events = []
+    monkeypatch.setattr(fhm, "_stats_event", lambda etype, device, **d: events.append((etype, device, d)))
+    monkeypatch.setattr(
+        fhm.fh,
+        "probe_device",
+        lambda name, ts, lan: (
+            "adb:1.1.1.1:5555",
+            {
+                "ssh_echo": "ok",
+                "sshd": "ok",
+                "bootloop": "ok",
+                "shell5555": "ok",
+                "watchdog_age": "10",
+                "repair_age": "10",
+                "agent_heartbeat_age": "10",
+                "a11y": "ok",
+                "autojs6_a11y": "ok",
+                "port": "open",
+                "shizuku": "up",
+                "_devlog": [
+                    {
+                        "source": "watchdog.log",
+                        "line": "2026-07-31 17:42:21 [repair] ERR: Tailscale repair FAILED (runtime=down)",
+                    }
+                ],
+            },
+        ),
+    )
+    fhm.check_device("p7a", "100.1", "192.1")
+    devlog_events = [e for e in events if e[0] == "device_log_failure"]
+    assert len(devlog_events) == 1
+    assert devlog_events[0][1] == "p7a"
+    assert devlog_events[0][2]["severity"] == "ERR"

--- a/tests/python/test_stats.py
+++ b/tests/python/test_stats.py
@@ -1,0 +1,68 @@
+"""Unit tests for control/lib/stats.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "control" / "lib"))
+
+import stats
+
+
+def _read_jsonl(path):
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_record_event_default_only_goes_to_events_jsonl(tmp_path, monkeypatch):
+    monkeypatch.setattr(stats, "ROOT", tmp_path)
+    monkeypatch.setattr(stats, "STATS_DIR", tmp_path / "stats")
+
+    stats.record_event("connection_path", "p7a", via="adb:1.1.1.1:5555")
+
+    events = _read_jsonl(tmp_path / "stats" / "events.jsonl")
+    assert len(events) == 1
+    assert events[0]["type"] == "connection_path"
+    # soft_health.jsonl must not be touched for unrelated event types.
+    assert not (tmp_path / "stats" / "soft_health.jsonl").is_file()
+
+
+def test_record_event_device_log_failure_rides_soft_health_pipe(tmp_path, monkeypatch):
+    """device_log_failure must dual-write to soft_health.jsonl so it reaches
+    OpenObserve through the existing Vector file source with no new Vector
+    config — Vector's file source only tails soft_health.jsonl (see
+    control/site_contract/sync_templates/fragments/vector/stayturgid_sources.yaml.j2)."""
+    monkeypatch.setattr(stats, "ROOT", tmp_path)
+    monkeypatch.setattr(stats, "STATS_DIR", tmp_path / "stats")
+
+    stats.record_event(
+        "device_log_failure",
+        "hd8",
+        source="watchdog.log",
+        severity="ERR",
+        message="Tailscale repair FAILED (runtime=down policy=down)",
+    )
+
+    events = _read_jsonl(tmp_path / "stats" / "events.jsonl")
+    soft_health = _read_jsonl(tmp_path / "stats" / "soft_health.jsonl")
+    assert len(events) == 1
+    assert len(soft_health) == 1
+    assert soft_health[0]["type"] == "device_log_failure"
+    assert soft_health[0]["device"] == "hd8"
+    assert soft_health[0]["source"] == "watchdog.log"
+    assert soft_health[0]["severity"] == "ERR"
+
+
+def test_record_event_soft_health_still_dual_writes(tmp_path, monkeypatch):
+    monkeypatch.setattr(stats, "ROOT", tmp_path)
+    monkeypatch.setattr(stats, "STATS_DIR", tmp_path / "stats")
+
+    stats.record_event("soft_health", "p7a", port="open")
+
+    soft_health = _read_jsonl(tmp_path / "stats" / "soft_health.jsonl")
+    assert len(soft_health) == 1
+    assert soft_health[0]["type"] == "soft_health"

--- a/tests/python/test_stayturgid_repair.py
+++ b/tests/python/test_stayturgid_repair.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import time
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -166,3 +167,96 @@ def test_tailscale_runtime_probes_remote_control_plane(monkeypatch):
             8,
         )
     ]
+
+
+# ── On-device fallback anomaly detection (issue: central-logging gap, 2026-07-31) ──
+
+
+def _write_watchdog_log(path, lines):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _ts(seconds_ago, now=None):
+    """Format a 'YYYY-MM-DD HH:MM:SS' watchdog-log timestamp N seconds before now."""
+    import datetime as _dt
+
+    now = now if now is not None else time.time()
+    return _dt.datetime.fromtimestamp(now - seconds_ago).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def test_count_recent_watchdog_errors_only_counts_err_within_window(tmp_path):
+    log = tmp_path / "watchdog.log"
+    _write_watchdog_log(
+        log,
+        [
+            # 3 ERR lines inside the 1h window (10, 30, 50 min ago).
+            "%s [repair] ERR: Tailscale repair FAILED (runtime=down policy=down)" % _ts(10 * 60),
+            "%s [repair] ERR: Tailscale repair FAILED (runtime=down policy=down)" % _ts(30 * 60),
+            "%s [repair] ERR: Tailscale repair FAILED (runtime=down policy=down)" % _ts(50 * 60),
+            # Outside the window (2h ago) — must not count.
+            "%s [repair] ERR: Tailscale repair FAILED (runtime=down policy=down)" % _ts(2 * 3600),
+            # WARNING/NOTICE lines must not count as ERR.
+            "%s [repair] WARNING: wireless debugging re-enable FAILED" % _ts(5 * 60),
+            "%s [repair] NOTICE: Tailscale restored" % _ts(4 * 60),
+        ],
+    )
+    assert repair.count_recent_watchdog_errors(path=str(log)) == 3
+
+
+def test_count_recent_watchdog_errors_missing_file_is_zero(tmp_path):
+    assert repair.count_recent_watchdog_errors(path=str(tmp_path / "missing.log"), now=time.time()) == 0
+
+
+class _FakeTapi:
+    def __init__(self):
+        self.calls = []
+
+    def notify(self, args, **kwargs):
+        self.calls.append(args)
+
+
+def test_maybe_notify_error_rate_below_threshold_is_noop(tmp_path, monkeypatch):
+    monkeypatch.setattr(repair, "SDLOG", str(tmp_path / "watchdog.log"))
+    monkeypatch.setattr(repair, "ERROR_RATE_NOTIFY_STAMP", str(tmp_path / "state" / "notify-stamp"))
+    monkeypatch.setattr(repair, "log", lambda *_a, **_k: None)
+    _write_watchdog_log(
+        tmp_path / "watchdog.log",
+        ["%s [repair] ERR: Tailscale repair FAILED (runtime=down policy=down)" % _ts(60)],
+    )
+    tapi = _FakeTapi()
+    assert repair.maybe_notify_error_rate(tapi_module=tapi) == "ok"
+    assert tapi.calls == []
+
+
+def test_maybe_notify_error_rate_notifies_via_termux_api_wrapper_only(tmp_path, monkeypatch):
+    """Must go through the safe termux_api wrapper (notify()), never a bare
+    subprocess call to termux-notification — a bare timeout+kill on a
+    termux-api client causes a loud ResultReturner-error toast (the exact bug
+    already fixed once this session, in start_adb.py)."""
+    monkeypatch.setattr(repair, "SDLOG", str(tmp_path / "watchdog.log"))
+    monkeypatch.setattr(repair, "ERROR_RATE_NOTIFY_STAMP", str(tmp_path / "state" / "notify-stamp"))
+    monkeypatch.setattr(repair, "log", lambda *_a, **_k: None)
+    _write_watchdog_log(
+        tmp_path / "watchdog.log",
+        [
+            "%s [repair] ERR: Tailscale repair FAILED (runtime=down policy=down)" % _ts(20 * 60),
+            "%s [repair] ERR: Tailscale repair FAILED (runtime=down policy=down)" % _ts(10 * 60),
+            "%s [repair] ERR: Tailscale repair FAILED (runtime=down policy=down)" % _ts(60),
+        ],
+    )
+
+    def _no_subprocess_run(*_a, **_k):
+        raise AssertionError("must not call subprocess.run directly for termux-notification")
+
+    monkeypatch.setattr(repair.subprocess, "run", _no_subprocess_run)
+
+    tapi = _FakeTapi()
+    assert repair.maybe_notify_error_rate(tapi_module=tapi) == "notified"
+    assert len(tapi.calls) == 1
+    assert tapi.calls[0][0] == "termux-notification"
+    assert (tmp_path / "state" / "notify-stamp").is_file()
+
+    # A second call right away must respect the re-notify cooldown.
+    assert repair.maybe_notify_error_rate(tapi_module=tapi) == "cooldown"
+    assert len(tapi.calls) == 1


### PR DESCRIPTION
## Summary
- Termux-side repair failures (`stayturgid_repair.py`'s `watchdog.log` ERR/WARNING lines, e.g. today's undetected "Tailscale repair FAILED" on hd8) and native-agent catastrophic-repair outcomes (`agent.log`) only ever existed in on-device log files — nobody noticed until someone happened to SSH in and grep them.
- `fleet_health.py`'s existing per-cycle SSH/adb probe now also tails both files for ERR/WARNING-ish lines (no second connection), splitting matches out of the report *before* `parse_kv` runs — a raw log line can itself contain `=` (e.g. `runtime=down policy=down`) and would otherwise corrupt an unrelated field.
- `fleet_health_monitor.py` forwards genuinely new lines (epoch-based per-device-per-source dedup — a historical backlog reports once, not every cycle forever) via `stats.record_event("device_log_failure", ...)`, which dual-writes to `soft_health.jsonl` — the file Vector already tails — so this reaches OpenObserve with **zero Vector config changes**.
- Added an on-device fallback that doesn't depend on the Mac pipeline being reachable at all: `stayturgid_repair.py` counts recent `watchdog.log` ERR lines and fires a `termux-notification` (via the existing safe `termux_api` wrapper, never a bare subprocess call) once a sustained error rate is detected.

Initial implementation was drafted by a sub-agent; I reviewed the full diff myself, traced the timestamp-parsing path end-to-end against the actual Kotlin `appendLog()` format to confirm agent.log lines parse correctly, and independently re-ran the full test/lint/type-check suite before opening this.

## Test plan
- [x] Full `tests/python/` suite passes (642 passed, 1 skipped)
- [x] `ruff check`/`ruff format --check`/`mypy` clean on all touched files
- [x] New `test_stats.py` covers the exact real scenario found today (Tailscale repair FAILED → `device_log_failure` → dual-write to `soft_health.jsonl`)
- [ ] Live end-to-end verification against a real device once merged (deferred — this is additive/read-only against existing SSH probes, low risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)