### PR TITLE
fix: stop reporting Tailscale down on shell-less hosts (hd8)

### DIFF
--- a/device/termux/py/stayturgid_repair.py
+++ b/device/termux/py/stayturgid_repair.py
@@ -342,7 +342,7 @@ def _tailscale_installed(have_sh=False):
     return rc == 0 and "package:" in out
 
 
-def _tailscale_runtime_up():
+def _tailscale_runtime_up(have_sh=False):
     """Require both a tunnel interface and Tailscale control-plane reachability.
 
     The tunnel-interface check must run under the device shell (uid 2000 via
@@ -352,33 +352,65 @@ def _tailscale_runtime_up():
     absent -> runtime reported "down" every cycle -> the foreground activity
     fallback fired ~every 15 min even with a perfectly healthy tunnel. The
     native agent reads the same file fine precisely because it runs as uid 2000.
+
+    Without a privileged shell (``have_sh=False`` — Fire OS/split-storage
+    hosts where ``STAYTURGID_NO_LOCAL_ADB=1`` and localhost:5555 is not the
+    privileged-shell mechanism at all, or any host that has momentarily lost
+    port 5555), ``sh_adb`` has no uid-2000 shell to reach and would always
+    fail — the exact same false-"down" failure mode described above, just via
+    an unreachable path instead of an EACCES read. Returns ``None`` ("cannot
+    verify") instead of ``False`` in that case, so callers don't mistake
+    "couldn't check" for "confirmed down" and fire disruptive repairs
+    (foregrounding Tailscale's UI) against a tunnel that is actually healthy.
+    Confirmed live on hd8 (2026-07-31): the Shizuku-privileged on-device
+    comonitor probe reported tailscale up at the same moment this check, run
+    without a shell, could only ever read "down" — a guaranteed false
+    negative, not a real outage.
     """
+    if not have_sh:
+        return None
     rc, out = sh_adb("grep -oE '(tun0|tailscale0)' /proc/net/dev 2>/dev/null | sort -u")
     tunnel = rc == 0 and ("tun0" in out or "tailscale0" in out)
     return tunnel and run(["ping", "-c", "2", "-W", "3", TAILSCALE_CONTROL_HOST], timeout=8)[0] == 0
 
 
 def _tailscale_policy_up(have_sh=False):
+    """Returns ``None`` ("cannot verify") instead of ``False`` when
+    ``have_sh`` is false: Android's ``settings get/put secure ...`` requires
+    shell-level privilege to resolve the current user
+    (``INTERACT_ACROSS_USERS``); an unprivileged Termux process always throws
+    a SecurityException there, which would otherwise look indistinguishable
+    from a genuinely misconfigured policy. See ``_tailscale_runtime_up``.
+    """
+    if not have_sh:
+        return None
     app = _device_command(["settings", "get", "secure", "always_on_vpn_app"], have_sh)[1].strip()
     lockdown = _device_command(["settings", "get", "secure", "always_on_vpn_lockdown"], have_sh)[1].strip()
     return app == TAILSCALE_PACKAGE and lockdown == "0"
 
 
 def _tailscale_status(have_sh=False):
-    """Return normalized runtime and always-on policy states."""
+    """Return normalized runtime and always-on policy states.
+
+    Reports "unknown" (not "down") when ``have_sh`` is false — neither check
+    can be verified from an unprivileged Termux process, so treating that as
+    "down" would be a false negative, not a real finding.
+    """
     if read_device_profile().get("tailscaleEnabled") is False:
         return "skip", "skip"
     if not _tailscale_installed(have_sh):
         return "skip", "skip"
-    runtime = "up" if _tailscale_runtime_up() else "down"
-    policy = "up" if _tailscale_policy_up(have_sh) else "down"
+    runtime_up = _tailscale_runtime_up(have_sh)
+    policy_up = _tailscale_policy_up(have_sh)
+    runtime = "unknown" if runtime_up is None else ("up" if runtime_up else "down")
+    policy = "unknown" if policy_up is None else ("up" if policy_up else "down")
     return runtime, policy
 
 
-def _wait_for_tailscale(attempts=3):
+def _wait_for_tailscale(attempts=3, have_sh=False):
     for _ in range(attempts):
         time.sleep(2)
-        if _tailscale_runtime_up():
+        if _tailscale_runtime_up(have_sh):
             return True
     return False
 
@@ -408,11 +440,25 @@ def ensure_tailscale(have_sh=False):
     the runtime down (~one extra cycle's delay, ~15 min), tracked via
     state.json rather than in-process state since each cycle is a fresh
     process invocation.
+
+    Every check and repair action below requires a privileged (uid 2000)
+    shell — the settings get/put calls throw SecurityException without one,
+    and the tunnel-interface read needs uid 2000 to see ``/proc/net/dev``.
+    Without one (``have_sh=False``: Fire OS/split-storage hosts with
+    ``STAYTURGID_NO_LOCAL_ADB=1``, or a host that's momentarily lost
+    localhost:5555), every one of those calls is guaranteed to fail — not
+    because Tailscale is down, but because this process cannot see it.
+    Returns "unknown" and does nothing in that case, rather than reporting a
+    false "FAILED" and forcing Tailscale's MainActivity into the foreground
+    against a tunnel that may be perfectly healthy (confirmed live on hd8,
+    2026-07-31: see ``_tailscale_runtime_up``).
     """
     if read_device_profile().get("tailscaleEnabled") is False:
         return "skip"
     if not _tailscale_installed(have_sh):
         return "skip"
+    if not have_sh:
+        return "unknown"
 
     _device_command(
         ["settings", "put", "secure", "always_on_vpn_app", TAILSCALE_PACKAGE],
@@ -423,7 +469,7 @@ def ensure_tailscale(have_sh=False):
         have_sh,
     )
     policy_ok = _tailscale_policy_up(have_sh)
-    if _tailscale_runtime_up():
+    if _tailscale_runtime_up(have_sh):
         if policy_ok:
             return "up"
         log("Tailscale runtime up but always-on policy repair FAILED", ERR)
@@ -441,11 +487,11 @@ def ensure_tailscale(have_sh=False):
         ],
         have_sh,
     )
-    restored = _wait_for_tailscale()
+    restored = _wait_for_tailscale(have_sh=have_sh)
     if not restored:
         if _previous_repair_field("tailscale") == "down":
             _device_command(["am", "start", "-n", TAILSCALE_ACTIVITY], have_sh)
-            restored = _wait_for_tailscale(attempts=2)
+            restored = _wait_for_tailscale(attempts=2, have_sh=have_sh)
         else:
             log(
                 "Tailscale still down after CONNECT_VPN broadcast; deferring "

--- a/tests/python/test_stayturgid_repair.py
+++ b/tests/python/test_stayturgid_repair.py
@@ -89,7 +89,7 @@ def _setup_tailscale(monkeypatch):
 def test_tailscale_healthy_still_enforces_policy(monkeypatch):
     commands = _setup_tailscale(monkeypatch)
     monkeypatch.setattr(repair, "_tailscale_policy_up", lambda _have_sh=False: True)
-    monkeypatch.setattr(repair, "_tailscale_runtime_up", lambda: True)
+    monkeypatch.setattr(repair, "_tailscale_runtime_up", lambda _have_sh=False: True)
 
     assert repair.ensure_tailscale(have_sh=True) == "up"
     assert [command[:5] for command, _have_sh in commands] == [
@@ -102,10 +102,10 @@ def test_tailscale_healthy_still_enforces_policy(monkeypatch):
 def test_tailscale_reconnect_receiver_is_verified(monkeypatch):
     commands = _setup_tailscale(monkeypatch)
     monkeypatch.setattr(repair, "_tailscale_policy_up", lambda _have_sh=False: True)
-    monkeypatch.setattr(repair, "_tailscale_runtime_up", lambda: False)
-    monkeypatch.setattr(repair, "_wait_for_tailscale", lambda attempts=3: True)
+    monkeypatch.setattr(repair, "_tailscale_runtime_up", lambda _have_sh=False: False)
+    monkeypatch.setattr(repair, "_wait_for_tailscale", lambda attempts=3, have_sh=False: True)
 
-    assert repair.ensure_tailscale() == "repaired"
+    assert repair.ensure_tailscale(have_sh=True) == "repaired"
     assert any(command[:2] == ["am", "broadcast"] for command, _have_sh in commands)
     assert not any(command[:2] == ["am", "start"] for command, _have_sh in commands)
 
@@ -115,11 +115,11 @@ def test_tailscale_first_failure_defers_activity_fallback(monkeypatch):
     only a second consecutive cycle (tracked via state.json) escalates."""
     commands = _setup_tailscale(monkeypatch)
     monkeypatch.setattr(repair, "_tailscale_policy_up", lambda _have_sh=False: True)
-    monkeypatch.setattr(repair, "_tailscale_runtime_up", lambda: False)
-    monkeypatch.setattr(repair, "_wait_for_tailscale", lambda attempts=3: False)
+    monkeypatch.setattr(repair, "_tailscale_runtime_up", lambda _have_sh=False: False)
+    monkeypatch.setattr(repair, "_wait_for_tailscale", lambda attempts=3, have_sh=False: False)
     monkeypatch.setattr(repair, "_previous_repair_field", lambda _key: "up")
 
-    assert repair.ensure_tailscale() == "FAILED"
+    assert repair.ensure_tailscale(have_sh=True) == "FAILED"
     assert any(command[:2] == ["am", "broadcast"] for command, _have_sh in commands)
     assert not any(command[:2] == ["am", "start"] for command, _have_sh in commands)
 
@@ -127,18 +127,35 @@ def test_tailscale_first_failure_defers_activity_fallback(monkeypatch):
 def test_tailscale_failed_receiver_and_activity_report_failure(monkeypatch):
     commands = _setup_tailscale(monkeypatch)
     monkeypatch.setattr(repair, "_tailscale_policy_up", lambda _have_sh=False: True)
-    monkeypatch.setattr(repair, "_tailscale_runtime_up", lambda: False)
-    monkeypatch.setattr(repair, "_wait_for_tailscale", lambda attempts=3: False)
+    monkeypatch.setattr(repair, "_tailscale_runtime_up", lambda _have_sh=False: False)
+    monkeypatch.setattr(repair, "_wait_for_tailscale", lambda attempts=3, have_sh=False: False)
     monkeypatch.setattr(repair, "_previous_repair_field", lambda _key: "down")
 
-    assert repair.ensure_tailscale() == "FAILED"
+    assert repair.ensure_tailscale(have_sh=True) == "FAILED"
     assert any(command[:2] == ["am", "broadcast"] for command, _have_sh in commands)
     assert any(command[:2] == ["am", "start"] for command, _have_sh in commands)
 
 
+def test_tailscale_no_shell_reports_unknown_without_side_effects(monkeypatch):
+    """Fire OS / split-storage hosts (STAYTURGID_NO_LOCAL_ADB=1) never have a
+    privileged shell from Termux — have_sh is always False there. Every
+    settings/proc check ensure_tailscale would otherwise attempt is
+    guaranteed to fail (SecurityException / EACCES / no adb transport), so
+    it must report "unknown" and take no repair action at all rather than
+    logging a false "FAILED" and forcing Tailscale's UI into the foreground.
+    Regression test for the hd8 false-negative confirmed live 2026-07-31."""
+    commands = _setup_tailscale(monkeypatch)
+    logs = []
+    monkeypatch.setattr(repair, "log", lambda msg, level=repair.INFO: logs.append((msg, level)))
+
+    assert repair.ensure_tailscale(have_sh=False) == "unknown"
+    assert commands == []
+    assert not any("FAILED" in msg for msg, _level in logs)
+
+
 def test_tailscale_status_normalizes_runtime_and_policy(monkeypatch):
     _setup_tailscale(monkeypatch)
-    monkeypatch.setattr(repair, "_tailscale_runtime_up", lambda: False)
+    monkeypatch.setattr(repair, "_tailscale_runtime_up", lambda _have_sh=False: False)
     monkeypatch.setattr(repair, "_tailscale_policy_up", lambda _have_sh=False: False)
 
     assert repair._tailscale_status(have_sh=True) == ("down", "down")
@@ -150,6 +167,37 @@ def test_tailscale_status_skips_disabled_profile(monkeypatch):
     assert repair._tailscale_status() == ("skip", "skip")
 
 
+def test_tailscale_status_reports_unknown_without_shell(monkeypatch):
+    """Without a privileged shell neither check can be verified — reporting
+    "down" would be a false negative (see hd8, 2026-07-31)."""
+    monkeypatch.setattr(repair, "read_device_profile", lambda: {})
+    monkeypatch.setattr(repair, "_tailscale_installed", lambda _have_sh=False: True)
+
+    assert repair._tailscale_status(have_sh=False) == ("unknown", "unknown")
+
+
+def test_tailscale_runtime_up_without_shell_is_unknown(monkeypatch):
+    """_tailscale_runtime_up must not touch sh_adb at all when have_sh is
+    False — on hosts like hd8 there is no localhost:5555 daemon to reach, so
+    even attempting it is a wasted, always-failing call."""
+
+    def _boom(_command, timeout=15):
+        raise AssertionError("sh_adb should not be called when have_sh is False")
+
+    monkeypatch.setattr(repair, "sh_adb", _boom)
+
+    assert repair._tailscale_runtime_up(have_sh=False) is None
+
+
+def test_tailscale_policy_up_without_shell_is_unknown(monkeypatch):
+    def _boom(_args, have_sh=False, timeout=15):
+        raise AssertionError("_device_command should not be called when have_sh is False")
+
+    monkeypatch.setattr(repair, "_device_command", _boom)
+
+    assert repair._tailscale_policy_up(have_sh=False) is None
+
+
 def test_tailscale_runtime_probes_remote_control_plane(monkeypatch):
     commands = []
     monkeypatch.setattr(repair, "sh_adb", lambda _command: (0, "tun0\n"))
@@ -159,7 +207,7 @@ def test_tailscale_runtime_probes_remote_control_plane(monkeypatch):
         lambda args, timeout=15: commands.append((args, timeout)) or (0, ""),
     )
 
-    assert repair._tailscale_runtime_up() is True
+    assert repair._tailscale_runtime_up(have_sh=True) is True
     assert commands == [
         (
             ["ping", "-c", "2", "-W", "3", "controlplane.tailscale.com"],


### PR DESCRIPTION
## Summary
hd8 (Fire OS, \`STAYTURGID_NO_LOCAL_ADB=1\`, no localhost:5555 privileged shell) has been logging \`Tailscale repair FAILED (runtime=down policy=down)\` every ~15-30 min for over a day, each occurrence forcing Tailscale's MainActivity into the foreground — a real, disruptive false negative, not an actual outage.

\`_tailscale_runtime_up()\` ignored \`have_sh\` entirely and always called \`sh_adb()\` (needs a uid-2000 shell hd8 doesn't have); \`_tailscale_policy_up()\` fell back to a plain \`settings get secure ...\` call that throws \`SecurityException\` (\`INTERACT_ACROSS_USERS\`) without shell privilege. Both were therefore guaranteed to read "down" on hd8 regardless of actual state.

**Confirmed live** (not just from code reading): the Shizuku-privileged on-device comonitor probe reported \`tailscale up\` at the same moment this unprivileged check could only ever read \`down\`; and Mac-side adb confirmed \`tun0\` present + \`always_on_vpn_app\`/\`lockdown\` correctly configured on hd8 the whole time.

Both functions (and \`ensure_tailscale\`/\`_tailscale_status\`/\`_wait_for_tailscale\`) now respect \`have_sh\` and return \`"unknown"\`/\`None\` — not \`"down"\`/\`False\` — when no privileged shell is available, matching every other \`have_sh\`-gated check already in this file. \`ensure_tailscale\` takes no repair action at all in that case, eliminating both the log spam and the on-device UI disruption.

## Test plan
- [x] Full \`tests/python/\` suite passes
- [x] \`ruff check\`/\`ruff format --check\`/\`mypy\` clean
- [x] New regression tests assert \`sh_adb\`/\`_device_command\` are never even called when \`have_sh=False\`, and that no repair action/log fires
- [x] Root cause confirmed via live SSH investigation on hd8 (comonitor-vs-Python probe contradiction resolved, Mac-side adb ground truth checked directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tailscale health checks when privileged shell access is unavailable.
  * Reports an indeterminate status instead of falsely indicating an outage.
  * Prevents repair actions and related commands from running without the required access.
  * Improved reliability of runtime polling and fallback checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->