### PR TITLE
docs: fix stale AutoJs6 references in termux.md

### DIFF
--- a/docs/architecture/components/termux.md
+++ b/docs/architecture/components/termux.md
@@ -49,7 +49,7 @@ pkg update && pkg upgrade -y && pkg install -y openssh android-tools termux-api 
 sshd
 ```
 
-Open **Termux:Boot** once after install. `start-adb.sh` runs repair every 5 min; for watchdog notifications and Shizuku UI repair, add [AutoJs6](autojs6.md).
+Open **Termux:Boot** once after install. `start-adb.sh` runs repair every 5 min; watchdog notifications and Shizuku UI repair are handled by the native agent (`device/native-agent/`) — AutoJs6, which previously owned this, was retired fleet-wide (see [autojs6.md](autojs6.md)).
 
 **Phone → Mac Eternal Terminal:** fleet deploy installs `Host mac` SSH config
 (passphrase-less `id_ed25519_fleet`) and the `et` package. From Termux:
@@ -60,7 +60,7 @@ Open **Termux:Boot** once after install. `start-adb.sh` runs repair every 5 min;
 
 **Repo version check:** `stayturgid_check_repo_version.py` runs at most once per day from the boot loop (notify only; deploy from Mac).
 
-**Callers:** [AutoJs6](autojs6.md) (`RUN_COMMAND` → `stayturgid_repair.py`), [Ansible](../../../control/lib/README.md) over SSH.
+**Callers:** `device/termux/py/start_adb.py`'s boot daemon loop (invokes `stayturgid_repair.py` directly every 5 min — AutoJs6's `RUN_COMMAND` path that used to call this was retired, see [autojs6.md](autojs6.md)), [Ansible](../../../control/lib/README.md) over SSH.
 
 ## Deploy with Ansible (recommended)
 


### PR DESCRIPTION
## Summary
- `docs/architecture/components/termux.md` still described AutoJs6 as the active owner of watchdog notifications/Shizuku UI repair and as the caller of `stayturgid_repair.py` via `RUN_COMMAND`.
- AutoJs6 was fully deleted from the repo tonight (#162 / #168 / #170) in favor of the native-agent (Shizuku-based) approach. This doc-only PR corrects those two lines to reflect current ownership: the native agent (`device/native-agent/`) now handles watchdog notifications/Shizuku UI repair, and `device/termux/py/start_adb.py`'s boot daemon loop directly invokes `stayturgid_repair.py` (verified in code, ~line 352).
- No behavior change — documentation staleness fix only, found during a cross-repo docs audit.

## Test plan
- [x] Read-only doc change, no code/build affected
- [x] Verified current callers directly in code (`start_adb.py` daemon_loop invokes `stayturgid_repair.py`; native-agent owns Shizuku/boot handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)