### PR TITLE
K1 (#43): bump stale Shizuku bootstrap pin + verification doc updates

### DIFF
--- a/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
+++ b/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
@@ -74,10 +74,10 @@ stayturgid_bootstrap_apks:
     checksum: "sha256:ecf916ff80ae751e65c092f51c055cce4de417ebeea8e449cd0f294afdbde39a"
   - id: moe.shizuku.privileged.api
     gh_repo: djbclark/Shizuku
-    gh_tag: "v13.7.0-thedjchi+stayturgid-release23"
-    gh_pattern: "shizuku-v13.7.0-thedjchi+stayturgid-release23-universal.apk"
-    version_name: "13.7.0-thedjchi+stayturgid-release23"
-    checksum: "sha256:b6864f697c16038cba1d165d01439225d05279f32b431a27def8eca7e6e028bb"
+    gh_tag: "v13.7.0-thedjchi+stayturgid-release25"
+    gh_pattern: "shizuku-v13.7.0-thedjchi+stayturgid-release25-universal.apk"
+    version_name: "13.7.0-thedjchi+stayturgid-release25"
+    checksum: "sha256:0d7a313c75eb4b14dfec71a1034a3f014e8a33848c18a1cdda7c07d6821af049"
     resign: true
     monkey: true
     battery_unrestricted: true


### PR DESCRIPTION
## Summary

Verification pass on issue #43's 5 remaining acceptance items, live against
the fleet (s24/hd8/p7a).

- Bumped the `moe.shizuku.privileged.api` bootstrap-APK pin from release23 to
  release25 — release23 predates the `BootRetryWorker` indefinite-retry fix
  (djbclark/Shizuku PR #7), and all three fleet devices were confirmed live
  (via `dumpsys package`) to still be running release23 despite PR #7 having
  been merged. The fix was never actually deployed to any device through the
  normal bootstrap_apks path because this pin was never bumped after PR #7
  landed.
- Doc updates to follow in this same branch once the forced `CLOSED_NO_SHELL`
  soak against the now-current build concludes.

More detail to follow as additional commits land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bundled Shizuku APK to release 25.
  * Added matching version and integrity verification details for the updated release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->