### PR TITLE
fix(deploy): make deploy-check dry-run impossible to confuse with real deploy

### DIFF
--- a/control/bin/deploy_fleet.py
+++ b/control/bin/deploy_fleet.py
@@ -310,6 +310,16 @@ def deploy(scope: Scope, hosts: list[str], *, check: bool, verbose: int = 0, dev
     # both normal deploys and dry runs.
     skip_bootstrap = "bootstrap"
     label = "deploy_fleet.py %s" % (",".join(targets) or "(whole fleet)")
+    if check:
+        # #184: dry-run recaps look like real deploys (ok/changed/failed=0) and
+        # were misread as "fleet is current" after ops-v1.2.0. Banner both ends.
+        print(
+            "NOTE: CHECK MODE (ansible --check --diff) — no APK installs, no "
+            "device writes, no Mac control_node apply. A green recap here does "
+            "NOT mean the fleet converged; run `just deploy` (without "
+            "deploy-check) to apply.",
+            file=sys.stderr,
+        )
     with fleet_lock(label):
         rc = run_playbook(
             SITE_PLAYBOOK,
@@ -334,8 +344,22 @@ def deploy(scope: Scope, hosts: list[str], *, check: bool, verbose: int = 0, dev
         return rc if rc != 0 else mac_rc
 
 
-def print_footer(rc: int, scope: Scope) -> None:
+def print_footer(rc: int, scope: Scope, *, check: bool = False) -> None:
     print()
+    if check:
+        if rc != 0:
+            print(
+                f"Fleet deploy-check (DRY RUN) finished with errors (exit {rc}). No changes were applied.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                "Fleet deploy-check (DRY RUN) complete — no changes were applied "
+                "to devices or the Mac. A green Ansible recap in check mode only "
+                "means the plan was valid, not that APKs/config converged. "
+                "Apply with: just deploy"
+            )
+        return
     if rc != 0:
         print(f"Fleet deploy finished with errors (exit {rc}). Failed hosts are listed above.", file=sys.stderr)
     elif scope is Scope.FDROID:
@@ -377,12 +401,13 @@ def main(argv: list[str] | None = None) -> int:
         print("ERROR: fdroidcl not found (brew install fdroidcl)", file=sys.stderr)
         return 1
 
+    check = check_mode(args.check)
     try:
-        rc = deploy(scope, args.hosts, check=check_mode(args.check), verbose=verbose, devices_only=args.devices_only)
+        rc = deploy(scope, args.hosts, check=check, verbose=verbose, devices_only=args.devices_only)
     except FleetLockHeld as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 3
-    print_footer(rc, scope)
+    print_footer(rc, scope, check=check)
     return rc
 
 

--- a/just/fleet.just
+++ b/just/fleet.just
@@ -22,7 +22,10 @@ deploy-apks:
     python3 control/bin/deploy_fleet.py {{ deploy_args }} --scope bootstrap-apks --devices-only
 
 # ---------- Deploy Check (dry‑run) ----------
+# Ansible --check only: no APK installs, no device writes. A green recap is
+# NOT fleet convergence (#184). Apply with `just deploy`.
 _deploy_check_impl:
+    @echo "NOTE: just deploy-check is a DRY RUN (CHECK=1 / ansible --check). Nothing will be applied." >&2
     CHECK=1 python3 control/bin/deploy_fleet.py {{ deploy_args }} {{ deploy_scope_arg }}
 
 deploy-check-legacy:

--- a/tests/python/test_deploy_fleet.py
+++ b/tests/python/test_deploy_fleet.py
@@ -96,6 +96,30 @@ def test_check_mode_env(monkeypatch):
     assert df.check_mode(True) is True
 
 
+def test_print_footer_check_mode_success(capsys):
+    """#184: dry-run footer must not claim the fleet converged."""
+    df.print_footer(0, df.Scope.FULL, check=True)
+    out = capsys.readouterr().out
+    assert "DRY RUN" in out
+    assert "no changes were applied" in out
+    assert "just deploy" in out
+    assert "Fleet deploy complete." not in out
+
+
+def test_print_footer_check_mode_error(capsys):
+    df.print_footer(2, df.Scope.FULL, check=True)
+    err = capsys.readouterr().err
+    assert "DRY RUN" in err
+    assert "No changes were applied" in err
+
+
+def test_print_footer_real_deploy_success(capsys):
+    df.print_footer(0, df.Scope.FULL, check=False)
+    out = capsys.readouterr().out
+    assert "Fleet deploy complete." in out
+    assert "DRY RUN" not in out
+
+
 def test_scope_ansible_tags():
     assert df.Scope.FULL.ansible_tags is None
     assert df.Scope.FDROID.ansible_tags == "fdroid"


### PR DESCRIPTION
## Summary

- Root cause of #184: the green full-fleet recap (`p7a ok=151 changed=10 failed=0`) was from **`just deploy-check`** (Ansible `--check`), not a real deploy. No APKs were installed; verify intentionally allows stale versions in check mode. No real full-fleet `just deploy` ran after ops-v1.2.0.
- Ruled out: ADB “lock” contention (emoji lines are announcements only; `resolve_adb` is stable under concurrent load), full-`site.yml` skip (live unscoped p7a deploy correctly upgraded stale `0.9.0` → `0.9.4`), wall-clock timeout.
- Fix: loud CHECK-MODE banner at start/end of `deploy_fleet.py` and a dry-run note on `just deploy-check` so a green recap cannot be misread as convergence.

## Test plan

- [x] Live: full unscoped `deploy_fleet.py p7a --devices-only -vv` after installing stale agent-v0.9.0 → installed 0.9.4, verify passed, recap ok
- [x] Live: `deploy_fleet.py hd8 --scope bootstrap-apks` → upgraded remaining stale 0.9.0 → 0.9.4
- [x] Unit: `test_print_footer_*` for dry-run vs real messaging
- [x] `bash tests/run.sh code` PASS

Closes #184