### PR TITLE
Centralize offline fleet targeting

### DIFF
--- a/control/bin/cf_run.py
+++ b/control/bin/cf_run.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Run the CFEngine repair policy over SSH for selected fleet targets."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from control.lib.fleet_targets import resolve_hosts
+
+CF_AGENT = "/data/data/com.termux/files/usr/bin/cf-agent"
+CF_POLICY = "~/.stayturgid/cfengine/stayturgid.cf"
+
+
+def cf_command(host: str) -> list[str]:
+    """Build the SSH command for one inventory-derived SSH alias."""
+
+    return [
+        "ssh",
+        "-o",
+        "ConnectTimeout=8",
+        "-o",
+        "BatchMode=yes",
+        host,
+        f"export PATH=/data/data/com.termux/files/usr/bin:$PATH; {CF_AGENT} -Kf {CF_POLICY} -D android,linux",
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("hosts", nargs="*", help="inventory SSH aliases; explicit hosts override offline status")
+    parser.add_argument("--dry-run", action="store_true", help="print selected targets without SSH")
+    args = parser.parse_args(argv)
+
+    targets = resolve_hosts(args.hosts, repo_root=REPO_ROOT, command_name="cf-run")
+    if not targets:
+        print("cf-run: no eligible targets.", file=sys.stderr)
+        return 0
+    if args.dry_run:
+        print("cf-run targets: " + ", ".join(targets))
+        return 0
+
+    failed = 0
+    for host in targets:
+        print(f"=== {host} ===")
+        result = subprocess.run(cf_command(host), text=True)
+        if result.returncode:
+            failed += 1
+        print("---")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/control/bin/deploy_fleet.py
+++ b/control/bin/deploy_fleet.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import json
 import os
 import shutil
 import subprocess
@@ -48,6 +47,8 @@ from control.lib.ansible_context import (
     resolved_env,
 )
 from control.lib.fleet_deploy_lock import FleetLockHeld, fleet_lock
+from control.lib.fleet_targets import FLEET_STATUS_VAR, inventory_list as _inventory_list
+from control.lib.fleet_targets import offline_hosts, parse_inventory_hosts
 
 SITE_PLAYBOOK = REPO_ROOT / "ansible" / "playbooks" / "site.yml"
 MAC_SITE_PLAYBOOK = REPO_ROOT / "ansible" / "playbooks" / "control_node" / "site.yml"
@@ -58,12 +59,6 @@ REQUIREMENTS = REPO_ROOT / "ansible" / "requirements.yml"
 # letting a hung or endlessly-retrying rollout run indefinitely (see #104).
 # Override with STAYTURGID_DEPLOY_TIMEOUT_SECONDS for unusually large fleets.
 DEPLOY_TIMEOUT_SECONDS = int(os.environ.get("STAYTURGID_DEPLOY_TIMEOUT_SECONDS", "1800"))
-
-# Inventory field marking a fleet device excluded from deploys by default
-# (see #104). Distinct from site_litellm's site_host_status, which is that
-# group's own unrelated scheme.
-FLEET_STATUS_VAR = "stayturgid_fleet_status"
-
 
 class Scope(str, Enum):
     FULL = "full"
@@ -117,35 +112,14 @@ def check_mode(cli_check: bool) -> bool:
     return cli_check or os.environ.get("CHECK", "0") == "1"
 
 
-def parse_inventory_hosts(data: dict, group: str = "stayturgid") -> list[str]:
-    hosts = data[group]["hosts"]
-    if isinstance(hosts, list):
-        return list(hosts)
-    return list(hosts.keys())
-
-
 def inventory_list(group: str = "stayturgid") -> dict:
-    context = resolve_ansible_context(REPO_ROOT)
-    require_inventory(context)
-    result = subprocess.run(
-        ["ansible-inventory", *context.inventory_args(), "--list"],
-        capture_output=True,
-        text=True,
-        check=True,
-        env=repo_env(),
-        cwd=REPO_ROOT,
-    )
-    return json.loads(result.stdout)
+    """Compatibility wrapper for callers and tests of this entry point."""
+
+    return _inventory_list(REPO_ROOT, group)
 
 
 def inventory_hosts(group: str = "stayturgid") -> list[str]:
     return parse_inventory_hosts(inventory_list(group), group)
-
-
-def offline_hosts(data: dict, hosts: list[str]) -> list[str]:
-    """Hosts among `hosts` whose FLEET_STATUS_VAR is 'offline'."""
-    hostvars = data.get("_meta", {}).get("hostvars", {})
-    return [h for h in hosts if hostvars.get(h, {}).get(FLEET_STATUS_VAR) == "offline"]
 
 
 def resolve_hosts(hosts: list[str]) -> list[str]:

--- a/control/lib/fleet_targets.py
+++ b/control/lib/fleet_targets.py
@@ -1,0 +1,75 @@
+"""Resolve fleet targets from the active Ansible inventory.
+
+The inventory is the authoritative source for a device's fleet status.  Entry
+points with a default "all devices" mode use this module so an ``offline``
+mark excludes a device consistently.  Explicit command-line hosts are an
+intentional operator override.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from .ansible_context import require_inventory, resolve_ansible_context, resolved_env
+
+FLEET_STATUS_VAR = "stayturgid_fleet_status"
+
+
+def parse_inventory_hosts(data: dict, group: str = "stayturgid") -> list[str]:
+    """Return host names in *group* while preserving inventory order."""
+
+    hosts = data[group]["hosts"]
+    if isinstance(hosts, list):
+        return list(hosts)
+    return list(hosts.keys())
+
+
+def inventory_list(repo_root: Path, group: str = "stayturgid") -> dict:
+    """Load the selected site's evaluated Ansible inventory."""
+
+    context = resolve_ansible_context(repo_root)
+    require_inventory(context)
+    result = subprocess.run(
+        ["ansible-inventory", *context.inventory_args(), "--list"],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=resolved_env(repo_root),
+        cwd=repo_root,
+    )
+    return json.loads(result.stdout)
+
+
+def offline_hosts(data: dict, hosts: list[str]) -> list[str]:
+    """Return hosts whose authoritative fleet status is ``offline``."""
+
+    hostvars = data.get("_meta", {}).get("hostvars", {})
+    return [host for host in hosts if hostvars.get(host, {}).get(FLEET_STATUS_VAR) == "offline"]
+
+
+def resolve_hosts(
+    explicit_hosts: list[str],
+    *,
+    repo_root: Path,
+    command_name: str,
+) -> list[str]:
+    """Resolve default targets, omitting offline inventory hosts.
+
+    Explicit hosts retain deploy_fleet.py's established override contract.
+    """
+
+    if explicit_hosts:
+        return explicit_hosts
+    data = inventory_list(repo_root)
+    hosts = parse_inventory_hosts(data)
+    skipped = offline_hosts(data, hosts)
+    if skipped:
+        print(
+            f"{command_name}: skipping offline host(s) {', '.join(skipped)} "
+            f"({FLEET_STATUS_VAR}: offline) — pass explicitly to override",
+            file=sys.stderr,
+        )
+    return [host for host in hosts if host not in skipped]

--- a/control/tools/native-agent/rollout.py
+++ b/control/tools/native-agent/rollout.py
@@ -10,8 +10,8 @@ AutoJs6 was already removed fleet-wide before this script's introduction
 (OPTIONS K1); this only handles the native-agent APK itself.
 
 Usage:
-  ./rollout.py                     # all hosts from devices.conf
-  ./rollout.py device1 device2     # named aliases
+  ./rollout.py                     # all eligible inventory hosts
+  ./rollout.py device1 device2     # explicit aliases (offline override)
   ./rollout.py --serial 100.x:5555 # raw serial only
 """
 
@@ -25,8 +25,10 @@ import time
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO))
 sys.path.insert(0, str(REPO / "control" / "lib"))
 import stayturgid_device as dev  # noqa: E402
+from control.lib.fleet_targets import resolve_hosts  # noqa: E402
 
 APK = REPO / "device" / "native-agent" / "app" / "build" / "outputs" / "apk" / "debug" / "app-debug.apk"
 GRANT = REPO / "control" / "tools" / "native-agent" / "grant_shizuku.py"
@@ -234,39 +236,35 @@ def rollout_one(label: str, serial: str) -> bool:
 
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("hosts", nargs="*", help="device aliases from devices.conf")
+    p.add_argument("hosts", nargs="*", help="inventory SSH aliases; explicit hosts override offline status")
     p.add_argument("--serial", action="append", default=[], help="raw adb serial(s)")
+    p.add_argument("--dry-run", action="store_true", help="print selected targets without ADB interaction")
     args = p.parse_args(argv)
 
     targets: list[tuple[str, str]] = []
     for s in args.serial:
-        serial = resolve_serial(s) or s
-        targets.append((s, serial))
+        targets.append((s, s))
     for h in args.hosts:
-        serial = resolve_serial(h)
+        targets.append((h, h))
+    if not args.serial and not args.hosts:
+        targets = [(host, host) for host in resolve_hosts([], repo_root=REPO, command_name="rollout.py")]
+
+    if not targets:
+        print("No reachable targets.")
+        return 1
+
+    if args.dry_run:
+        print("rollout.py targets: " + ", ".join(label for label, _serial in targets))
+        return 0
+
+    resolved_targets: list[tuple[str, str]] = []
+    for label, target in targets:
+        serial = resolve_serial(target)
         if serial:
-            targets.append((h, serial))
+            resolved_targets.append((label, serial))
         else:
-            print(f"=== {h} ===\n  SKIP: could not resolve adb serial")
-    if not targets and not args.serial and not args.hosts:
-        conf = os.environ.get(
-            "STAYTURGID_DEVICES_CONF",
-            os.path.join(os.path.expanduser("~"), ".config", "stayturgid", "devices.conf"),
-        )
-        for name, ts_ip, _lan in dev.iter_monitor_hosts(conf):
-            # Prefer ts:5555 then resolve_adb
-            serial = None
-            if ts_ip and ts_ip != "-":
-                cand = f"{ts_ip}:5555"
-                _run(["adb", "connect", cand], timeout=15)
-                if device_online(cand):
-                    serial = cand
-            if not serial:
-                serial = resolve_serial(name)
-            if serial:
-                targets.append((name, serial))
-            else:
-                print(f"=== {name} ===\n  SKIP: unreachable / no adb")
+            print(f"=== {label} ===\n  SKIP: unreachable / no adb")
+    targets = resolved_targets
 
     if not targets:
         print("No reachable targets.")

--- a/just/cfengine.just
+++ b/just/cfengine.just
@@ -26,8 +26,16 @@ cfbs-build: cfbs-validate
     cd device/termux/cfengine && cfbs build
     diff -r --exclude=cfbs.json device/termux/cfengine/policy device/termux/cfengine/out/masterfiles
 
-# Run CFEngine repair bundles on device(s) via SSH replacement for cf-runagent.
-# cf-serverd can't bind ports on Termux/Android (seccomp blocks listen).
-# Usage: just cf-run [hosts=oneui-device,stock-android-device,fireos-device]
+# Run CFEngine repair bundles on inventory-derived SSH aliases.  Default
+# targeting excludes hosts marked stayturgid_fleet_status: offline; naming a
+# host explicitly remains the operator override (matching deploy_fleet.py).
+# Usage: just cf-run [hosts="p7a s24"]
 cf-run:
-    @if [ "{{ hosts }}" = "" ]; then for h in oneui-device stock-android-device fireos-device; do echo "=== $h ==="; ssh -o ConnectTimeout=8 -o BatchMode=yes "$h" "export PATH=/data/data/com.termux/files/usr/bin:\$PATH; /data/data/com.termux/files/usr/bin/cf-agent -Kf ~/.stayturgid/cfengine/stayturgid.cf -D android,linux 2>&1" | grep -E "^R:|^   error:" | head -10; echo "---"; done; else ssh -o ConnectTimeout=8 "{{ hosts }}" "export PATH=/data/data/com.termux/files/usr/bin:\$PATH; /data/data/com.termux/files/usr/bin/cf-agent -Kf ~/.stayturgid/cfengine/stayturgid.cf -D android,linux 2>&1" | grep -E "^R:|^   error:" | head -15; fi
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ -z "{{ hosts }}" ]]; then
+      python3 "{{ repo }}/control/bin/cf_run.py"
+    else
+      # shellcheck disable=SC2086
+      python3 "{{ repo }}/control/bin/cf_run.py" {{ hosts }}
+    fi

--- a/tests/python/test_cf_run.py
+++ b/tests/python/test_cf_run.py
@@ -1,0 +1,29 @@
+"""Offline-target behavior for the CFEngine SSH entry point."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = ROOT / "control" / "bin" / "cf_run.py"
+SPEC = importlib.util.spec_from_file_location("cf_run", MODULE_PATH)
+cf_run = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(cf_run)
+
+
+def test_dry_run_uses_shared_eligible_targets(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(cf_run, "resolve_hosts", lambda hosts, **_kwargs: ["s24", "hd8"])
+
+    assert cf_run.main(["--dry-run"]) == 0
+    assert capsys.readouterr().out.strip() == "cf-run targets: s24, hd8"
+
+
+def test_explicit_host_is_passed_as_override(monkeypatch, capsys) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(cf_run, "resolve_hosts", lambda hosts, **_kwargs: calls.append(hosts) or hosts)
+
+    assert cf_run.main(["p7a", "--dry-run"]) == 0
+    assert calls == [["p7a"]]
+    assert capsys.readouterr().out.strip() == "cf-run targets: p7a"

--- a/tests/python/test_fleet_targets.py
+++ b/tests/python/test_fleet_targets.py
@@ -1,0 +1,28 @@
+"""Regression coverage for inventory-backed offline target selection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from control.lib import fleet_targets
+
+
+def test_resolve_hosts_default_skips_offline(monkeypatch, capsys) -> None:
+    data = {
+        "stayturgid": {"hosts": {"s24": {}, "p7a": {}, "hd8": {}}},
+        "_meta": {"hostvars": {"p7a": {"stayturgid_fleet_status": "offline"}}},
+    }
+    monkeypatch.setattr(fleet_targets, "inventory_list", lambda _root: data)
+
+    assert fleet_targets.resolve_hosts([], repo_root=Path("."), command_name="cf-run") == ["s24", "hd8"]
+    assert "cf-run: skipping offline host(s) p7a" in capsys.readouterr().err
+
+
+def test_resolve_hosts_explicit_is_override(monkeypatch) -> None:
+    monkeypatch.setattr(
+        fleet_targets,
+        "inventory_list",
+        lambda _root: (_ for _ in ()).throw(AssertionError("explicit target must not load inventory")),
+    )
+
+    assert fleet_targets.resolve_hosts(["p7a"], repo_root=Path("."), command_name="rollout.py") == ["p7a"]

--- a/tests/python/test_native_agent_rollout.py
+++ b/tests/python/test_native_agent_rollout.py
@@ -66,3 +66,10 @@ def test_rollout_announces_using_and_free_on_failure(monkeypatch, capsys) -> Non
     output = capsys.readouterr().out
     assert output.count("🚨📱🚨 USING — hd8 — deploy and verify native agent — ~2 min") == 1
     assert output.count("🟢📱🟢 FREE — hd8 — native-agent rollout interaction complete") == 1
+
+
+def test_default_dry_run_uses_shared_eligible_targets(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(rollout, "resolve_hosts", lambda hosts, **_kwargs: ["s24", "hd8"])
+
+    assert rollout.main(["--dry-run"]) == 0
+    assert capsys.readouterr().out.strip() == "rollout.py targets: s24, hd8"


### PR DESCRIPTION
Closes #155\n\n- extract deploy_fleet.py inventory/offline selection into a shared target resolver\n- derive default cf-run and native-agent rollout targets from the active inventory\n- preserve explicit-host override semantics\n- add dry-run coverage using an isolated inventory with p7a marked offline\n\nValidation: ### tier a: code checks
# interpreters: bash 5.3.15(1)-release | Python 3.14.6 | node v26.5.0 | ansible-playbook [core 2.21.2]
ok 1 - bash -n: all shell scripts parse
ok 2 - py_compile: all Python sources
ok 3 - shfmt: shell scripts formatted
ok 4 - json: all catalogs/configs valid
ok 5 - cf-promises: standalone CFEngine policy sources parse
PASS: healing coverage — 32 states, 7 mechanisms (ansible_deploy=19, cfengine=4, firerpa=3, fleet_health=8, mac_heal=3, native_agent=4, termux_repair=17)
ok 6 - healing coverage: all must_cover IDs declared across mechanisms
ok 7 - plutil -lint: launchd plists valid
ok 8 - ansible-playbook --syntax-check: site.yml
ok 9 - ansible-playbook --syntax-check: site.yml
ok 10 - ansible-playbook --syntax-check: termux-userland.yml
ok 11 - ansible-playbook --syntax-check: bootstrap.yml
ok 12 - shellcheck -S warning: clean
ok 13 - ansible-lint: clean # SKIP .ansible/collections missing — run 'just worktree-setup'
ok 14 - yamllint: clean
ok 15 - just --fmt --check: standalone FIRERPA justfile
ok 16 - markdownlint: clean
ok 17 - prettier: markdown formatted # SKIP node_modules missing — run 'just worktree-setup'
ok 18 - pytest: tests collect cleanly # SKIP .venv-test missing — run 'just worktree-setup'
1..18

RESULT: PASS (code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fleet repair command that supports dry runs, explicit host selection, per-host status reporting, and failure detection.
  * Updated rollout tooling to support inventory aliases and dry-run target previews.
  * Automatically excludes hosts marked offline from default operations while allowing explicit overrides.
* **Bug Fixes**
  * Standardized fleet target resolution across deployment and rollout commands.
* **Tests**
  * Added coverage for offline-host filtering, explicit overrides, dry-run behavior, and target resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->