### PR TITLE
feat: notify on Termux apt package updates (#152)

### DIFF
--- a/control/bin/check_termux_pkg_updates.py
+++ b/control/bin/check_termux_pkg_updates.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Notify when Termux apt packages on fleet devices have upgrades available.
+
+Parallel to ``check_apk_updates.py`` (pinned Android APKs vs GitHub tags), but
+for the Termux apt/pkg layer: SSH to each device, refresh package indexes,
+parse ``apt list --upgradable``, and ``hermes send`` when anything is pending.
+
+Why a separate checker (not only the nightly upgrade log):
+  - Nightly ``termux_pkg_nightly.py`` upgrades everything with only an Ansible
+    changed=true/false line — no package names, no hermes path (#152).
+  - This script reports *available* upgrades (names + old → new versions) so
+    the operator sees what is pending even if the nightly job is disabled,
+    fails, or has not run yet.
+
+Usage:
+  python3 control/bin/check_termux_pkg_updates.py
+  python3 control/bin/check_termux_pkg_updates.py --limit s24,p7a
+  HOSTS=s24 python3 control/bin/check_termux_pkg_updates.py
+
+Scheduled via Jobber (site overlay, same jobber as check-apk-updates) and
+optionally invoked by ``termux_pkg_nightly.py`` before the upgrade playbook.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+_LIB = _REPO / "control" / "lib"
+for _p in (str(_LIB), str(_REPO)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import stayturgid_device as dev  # noqa: E402
+
+HERMES_TARGET = "telegram:838808636:22082"
+STATE_PATH = os.path.expanduser("~/.local/state/stayturgid/termux-pkg-updates.json")
+
+TERMUX_PREFIX = "/data/data/com.termux/files/usr"
+SSH_TIMEOUT_SEC = int(os.environ.get("STAYTURGID_TERMUX_PKG_CHECK_TIMEOUT", "180"))
+
+# apt list --upgradable line, e.g.:
+#   curl/stable 8.12.1 aarch64 [upgradable from: 8.11.0]
+#   libandroid-support/stable 29-1 aarch64 [upgradable from: 28-3]
+_UPGRADABLE_RE = re.compile(
+    r"^([^/\s]+)/\S+\s+(\S+)\s+\S+\s+\[upgradable from:\s*([^\]]+)\]\s*$"
+)
+
+
+def parse_apt_upgradable(text: str) -> list[dict[str, str]]:
+    """Parse ``apt list --upgradable`` stdout into [{name, current, latest}, ...]."""
+    found: list[dict[str, str]] = []
+    for line in (text or "").splitlines():
+        line = line.strip()
+        if not line or line.startswith("Listing"):
+            continue
+        m = _UPGRADABLE_RE.match(line)
+        if not m:
+            continue
+        found.append(
+            {
+                "name": m.group(1),
+                "latest": m.group(2),
+                "current": m.group(3).strip(),
+            }
+        )
+    return found
+
+
+def format_package_line(pkg: dict[str, str]) -> str:
+    return f"{pkg['name']}: {pkg['current']} -> {pkg['latest']}"
+
+
+def list_hosts(limit: str | None = None) -> list[str]:
+    """Fleet aliases from devices.conf, optionally restricted by --limit/HOSTS."""
+    all_hosts = [name for name, *_rest in dev.iter_devices_conf()]
+    if not limit:
+        return all_hosts
+    wanted = {h.strip() for h in limit.replace(" ", ",").split(",") if h.strip()}
+    return [h for h in all_hosts if h in wanted]
+
+
+def ssh_upgradable(host: str, *, refresh: bool = True) -> tuple[list[dict[str, str]], str | None]:
+    """SSH to *host* and return (upgradable packages, error_or_None).
+
+    When *refresh* is True (default), runs ``pkg update`` first so the check
+    sees current indexes — same first step as the nightly upgrade path.
+    """
+    ssh_host = dev.resolve_ssh_host(host) or host
+    refresh_cmd = "pkg update -y >/dev/null 2>&1 || true\n" if refresh else ""
+    remote = (
+        f"export PATH={TERMUX_PREFIX}/bin:$PATH\n"
+        f"export TMPDIR={TERMUX_PREFIX}/tmp\n"
+        "export DEBIAN_FRONTEND=noninteractive\n"
+        f"{refresh_cmd}"
+        "apt list --upgradable 2>/dev/null\n"
+    )
+    try:
+        result = subprocess.run(
+            ["ssh", *dev.SSH_OPTS, "-o", "ConnectTimeout=10", ssh_host, remote],
+            capture_output=True,
+            text=True,
+            timeout=SSH_TIMEOUT_SEC,
+        )
+    except subprocess.TimeoutExpired:
+        return [], f"{host}: ssh timed out after {SSH_TIMEOUT_SEC}s"
+    except OSError as exc:
+        return [], f"{host}: ssh failed: {exc}"
+
+    if result.returncode != 0:
+        err = (result.stderr or result.stdout or "").strip().splitlines()
+        detail = err[-1] if err else f"rc={result.returncode}"
+        return [], f"{host}: ssh/apt failed ({detail})"
+
+    return parse_apt_upgradable(result.stdout or ""), None
+
+
+def collect_updates(
+    hosts: list[str],
+    *,
+    refresh: bool = True,
+) -> tuple[dict[str, list[dict[str, str]]], list[str]]:
+    """Probe each host. Returns (host -> packages, error messages)."""
+    by_host: dict[str, list[dict[str, str]]] = {}
+    errors: list[str] = []
+    for host in hosts:
+        packages, err = ssh_upgradable(host, refresh=refresh)
+        if err:
+            errors.append(err)
+            print(err, file=sys.stderr)
+            continue
+        if packages:
+            by_host[host] = packages
+    return by_host, errors
+
+
+def build_update_lines(by_host: dict[str, list[dict[str, str]]]) -> list[str]:
+    """Flatten host→packages into notification lines."""
+    lines: list[str] = []
+    for host in sorted(by_host):
+        for pkg in by_host[host]:
+            lines.append(f"{host}: {format_package_line(pkg)}")
+    return lines
+
+
+def write_state(
+    path: str,
+    *,
+    updates: list[str],
+    by_host: dict[str, list[dict[str, str]]],
+    errors: list[str],
+    hosts_checked: list[str],
+) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    payload = {
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "hosts_checked": hosts_checked,
+        "updates": updates,
+        "by_host": {h: [dict(p) for p in pkgs] for h, pkgs in by_host.items()},
+        "errors": errors,
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+        f.write("\n")
+
+
+def hermes_notify(message: str) -> None:
+    subprocess.run(["hermes", "send", "-t", HERMES_TARGET, message], check=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--limit",
+        default=os.environ.get("HOSTS", "").replace(" ", ",") or None,
+        help="Comma-separated device aliases (devices.conf); or HOSTS env",
+    )
+    ap.add_argument(
+        "--no-refresh",
+        action="store_true",
+        help="Skip pkg update (use cached indexes only; faster, may be stale)",
+    )
+    ap.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Do not hermes-notify; still write state and print",
+    )
+    args = ap.parse_args(argv)
+
+    hosts = list_hosts(args.limit)
+    if not hosts:
+        print("No hosts to check (empty devices.conf or --limit matched nothing)", file=sys.stderr)
+        return 2
+
+    by_host, errors = collect_updates(hosts, refresh=not args.no_refresh)
+    updates = build_update_lines(by_host)
+    write_state(
+        STATE_PATH,
+        updates=updates,
+        by_host=by_host,
+        errors=errors,
+        hosts_checked=hosts,
+    )
+
+    if updates:
+        message = "Stayturgid Termux package updates available:\n" + "\n".join(updates)
+        print(message)
+        if not args.dry_run:
+            hermes_notify(message)
+    else:
+        print(
+            "No Termux package updates available on %s"
+            % (", ".join(hosts) if hosts else "(none)")
+        )
+
+    # Errors contacting hosts are non-fatal for the "updates available" path
+    # (same spirit as check_apk_updates treating one bad GitHub repo as skip),
+    # but exit 1 if *every* host failed so Jobber/notifyOnError can fire.
+    if errors and not by_host and len(errors) >= len(hosts):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/control/bin/check_termux_pkg_updates.py
+++ b/control/bin/check_termux_pkg_updates.py
@@ -158,7 +158,7 @@ def write_state(
     errors: list[str],
     hosts_checked: list[str],
 ) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    """Write state atomically; failures are non-fatal so notify can still run."""
     payload = {
         "checked_at": datetime.now(timezone.utc).isoformat(),
         "hosts_checked": hosts_checked,
@@ -166,9 +166,19 @@ def write_state(
         "by_host": {h: [dict(p) for p in pkgs] for h, pkgs in by_host.items()},
         "errors": errors,
     }
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(payload, f, indent=2)
-        f.write("\n")
+    tmp = f"{path}.tmp"
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+            f.write("\n")
+        os.replace(tmp, path)
+    except OSError as exc:
+        print(f"WARN: could not write state {path}: {exc}", file=sys.stderr)
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
 
 
 def hermes_notify(message: str) -> None:

--- a/control/bin/termux_pkg_nightly.py
+++ b/control/bin/termux_pkg_nightly.py
@@ -31,6 +31,7 @@ from control.lib.ansible_context import AnsibleConfigError, require_inventory, r
 from control.lib.fleet_deploy_lock import FleetLockHeld, fleet_lock
 
 PLAYBOOK = REPO_ROOT / "ansible" / "playbooks" / "fleet" / "termux-pkg-upgrade.yml"
+CHECK_UPDATES = REPO_ROOT / "control" / "bin" / "check_termux_pkg_updates.py"
 LOG_DIR = Path.home() / ".config" / "stayturgid" / "logs"
 LOG = LOG_DIR / "termux-pkg-nightly.log"
 MAX_LOG_LINES = 4000
@@ -106,6 +107,32 @@ def main(argv: list[str] | None = None) -> int:
     log("start: config=%s (%s) inventory=%s" % (context.config, context.source, context.inventory))
     log("start: %s" % " ".join(cmd))
     label = "termux_pkg_nightly.py %s" % (args.limit or "(whole fleet)")
+
+    # Pre-upgrade visibility (#152): hermes-notify which packages are about to
+    # be upgraded. Skip in ansible --check mode so dry-runs stay silent.
+    # Failures here must not block the upgrade itself.
+    if not check and CHECK_UPDATES.is_file():
+        pre_cmd = [sys.executable, str(CHECK_UPDATES)]
+        if args.limit:
+            pre_cmd.extend(["--limit", args.limit])
+        log("pre-check: %s" % " ".join(pre_cmd))
+        try:
+            pre = subprocess.run(
+                pre_cmd,
+                cwd=str(REPO_ROOT),
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=int(os.environ.get("STAYTURGID_TERMUX_PKG_CHECK_TIMEOUT", "600")),
+            )
+            pre_out = ((pre.stdout or "") + (pre.stderr or "")).strip()
+            if pre_out:
+                for line in pre_out.splitlines()[-40:]:
+                    log("  | %s" % line)
+            log("pre-check rc=%s" % pre.returncode)
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            log("WARN: pre-check failed (continuing upgrade): %s" % exc)
+
     try:
         with fleet_lock(label):
             r = subprocess.run(

--- a/tests/python/test_check_termux_pkg_updates.py
+++ b/tests/python/test_check_termux_pkg_updates.py
@@ -143,6 +143,19 @@ def test_ssh_upgradable_returns_error_on_nonzero(monkeypatch: pytest.MonkeyPatch
     assert "s24" in err
 
 
+def test_ssh_upgradable_returns_error_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(*a, **k):
+        raise ctu.subprocess.TimeoutExpired(cmd=a[0] if a else "ssh", timeout=180)
+
+    monkeypatch.setattr(ctu.subprocess, "run", fake_run)
+    monkeypatch.setattr(ctu.dev, "resolve_ssh_host", lambda h, conf_path=None: h)
+    pkgs, err = ctu.ssh_upgradable("s24")
+    assert pkgs == []
+    assert err is not None
+    assert "timed out" in err
+    assert "s24" in err
+
+
 def test_main_notifies_on_updates(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     state_path = tmp_path / "termux-pkg-updates.json"
     monkeypatch.setattr(ctu, "STATE_PATH", str(state_path))

--- a/tests/python/test_check_termux_pkg_updates.py
+++ b/tests/python/test_check_termux_pkg_updates.py
@@ -1,0 +1,217 @@
+"""Unit tests for control/bin/check_termux_pkg_updates.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[2]
+_MOD = REPO / "control" / "bin" / "check_termux_pkg_updates.py"
+_spec = importlib.util.spec_from_file_location("check_termux_pkg_updates", _MOD)
+assert _spec is not None
+ctu = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(ctu)
+
+
+# --- parse_apt_upgradable -----------------------------------------------------
+
+
+def test_parse_apt_upgradable_extracts_name_and_versions() -> None:
+    text = """\
+Listing...
+curl/stable 8.12.1 aarch64 [upgradable from: 8.11.0]
+libandroid-support/stable 29-1 aarch64 [upgradable from: 28-3]
+"""
+    pkgs = ctu.parse_apt_upgradable(text)
+    assert pkgs == [
+        {"name": "curl", "latest": "8.12.1", "current": "8.11.0"},
+        {"name": "libandroid-support", "latest": "29-1", "current": "28-3"},
+    ]
+
+
+def test_parse_apt_upgradable_empty_listing() -> None:
+    assert ctu.parse_apt_upgradable("Listing...\n") == []
+    assert ctu.parse_apt_upgradable("") == []
+
+
+def test_parse_apt_upgradable_ignores_noise() -> None:
+    text = """\
+WARNING: apt does not have a stable CLI interface
+Listing... Done
+something-weird without brackets
+openssh/stable 10.4p1 aarch64 [upgradable from: 9.9p1]
+"""
+    pkgs = ctu.parse_apt_upgradable(text)
+    assert len(pkgs) == 1
+    assert pkgs[0]["name"] == "openssh"
+    assert pkgs[0]["current"] == "9.9p1"
+    assert pkgs[0]["latest"] == "10.4p1"
+
+
+def test_build_update_lines_sorted_by_host() -> None:
+    by_host = {
+        "p7a": [{"name": "curl", "current": "1", "latest": "2"}],
+        "s24": [
+            {"name": "git", "current": "2.40", "latest": "2.50"},
+            {"name": "wget", "current": "1.0", "latest": "1.1"},
+        ],
+    }
+    lines = ctu.build_update_lines(by_host)
+    assert lines == [
+        "p7a: curl: 1 -> 2",
+        "s24: git: 2.40 -> 2.50",
+        "s24: wget: 1.0 -> 1.1",
+    ]
+
+
+# --- list_hosts ---------------------------------------------------------------
+
+
+def test_list_hosts_respects_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        ctu.dev,
+        "iter_devices_conf",
+        lambda conf_path=None: [
+            ("s24", "usb1", "1.1.1.1", "-", "-"),
+            ("p7a", "usb2", "1.1.1.2", "-", "-"),
+            ("hd8", "usb3", "1.1.1.3", "-", "-"),
+        ],
+    )
+    assert ctu.list_hosts(None) == ["s24", "p7a", "hd8"]
+    assert ctu.list_hosts("p7a,hd8") == ["p7a", "hd8"]
+    assert ctu.list_hosts("missing") == []
+
+
+# --- ssh_upgradable / main ----------------------------------------------------
+
+
+class _Result:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def test_ssh_upgradable_parses_remote_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(args, **kwargs):
+        assert args[0] == "ssh"
+        assert "s24" in args
+        remote = args[-1]
+        assert "apt list --upgradable" in remote
+        assert "pkg update" in remote
+        return _Result(
+            0,
+            stdout="Listing...\ncurl/stable 2.0 aarch64 [upgradable from: 1.0]\n",
+        )
+
+    monkeypatch.setattr(ctu.subprocess, "run", fake_run)
+    monkeypatch.setattr(ctu.dev, "resolve_ssh_host", lambda h, conf_path=None: h)
+    pkgs, err = ctu.ssh_upgradable("s24")
+    assert err is None
+    assert pkgs == [{"name": "curl", "latest": "2.0", "current": "1.0"}]
+
+
+def test_ssh_upgradable_no_refresh_skips_pkg_update(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen = {}
+
+    def fake_run(args, **kwargs):
+        seen["remote"] = args[-1]
+        return _Result(0, stdout="Listing...\n")
+
+    monkeypatch.setattr(ctu.subprocess, "run", fake_run)
+    monkeypatch.setattr(ctu.dev, "resolve_ssh_host", lambda h, conf_path=None: h)
+    pkgs, err = ctu.ssh_upgradable("s24", refresh=False)
+    assert err is None
+    assert pkgs == []
+    assert "pkg update" not in seen["remote"]
+
+
+def test_ssh_upgradable_returns_error_on_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        ctu.subprocess,
+        "run",
+        lambda *a, **k: _Result(255, stderr="Connection refused"),
+    )
+    monkeypatch.setattr(ctu.dev, "resolve_ssh_host", lambda h, conf_path=None: h)
+    pkgs, err = ctu.ssh_upgradable("s24")
+    assert pkgs == []
+    assert err is not None
+    assert "s24" in err
+
+
+def test_main_notifies_on_updates(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    state_path = tmp_path / "termux-pkg-updates.json"
+    monkeypatch.setattr(ctu, "STATE_PATH", str(state_path))
+    monkeypatch.setattr(ctu, "list_hosts", lambda limit=None: ["s24", "p7a"])
+
+    def fake_collect(hosts, *, refresh=True):
+        return (
+            {
+                "s24": [{"name": "curl", "current": "1", "latest": "2"}],
+            },
+            [],
+        )
+
+    monkeypatch.setattr(ctu, "collect_updates", fake_collect)
+
+    sent: dict[str, list[str]] = {}
+    monkeypatch.setattr(ctu, "hermes_notify", lambda msg: sent.setdefault("msg", msg))
+
+    assert ctu.main([]) == 0
+    assert "Stayturgid Termux package updates available" in sent["msg"]
+    assert "s24: curl: 1 -> 2" in sent["msg"]
+    state = json.loads(state_path.read_text())
+    assert state["updates"]
+    assert state["hosts_checked"] == ["s24", "p7a"]
+
+
+def test_main_does_not_notify_when_current(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    state_path = tmp_path / "termux-pkg-updates.json"
+    monkeypatch.setattr(ctu, "STATE_PATH", str(state_path))
+    monkeypatch.setattr(ctu, "list_hosts", lambda limit=None: ["s24"])
+    monkeypatch.setattr(ctu, "collect_updates", lambda hosts, *, refresh=True: ({}, []))
+
+    called: list[str] = []
+    monkeypatch.setattr(ctu, "hermes_notify", lambda msg: called.append(msg))
+
+    assert ctu.main([]) == 0
+    assert called == []
+    state = json.loads(state_path.read_text())
+    assert state["updates"] == []
+
+
+def test_main_dry_run_skips_hermes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    state_path = tmp_path / "termux-pkg-updates.json"
+    monkeypatch.setattr(ctu, "STATE_PATH", str(state_path))
+    monkeypatch.setattr(ctu, "list_hosts", lambda limit=None: ["s24"])
+    monkeypatch.setattr(
+        ctu,
+        "collect_updates",
+        lambda hosts, *, refresh=True: (
+            {"s24": [{"name": "git", "current": "a", "latest": "b"}]},
+            [],
+        ),
+    )
+    called: list[str] = []
+    monkeypatch.setattr(ctu, "hermes_notify", lambda msg: called.append(msg))
+
+    assert ctu.main(["--dry-run"]) == 0
+    assert called == []
+    assert json.loads(state_path.read_text())["updates"]
+
+
+def test_main_all_hosts_failed_exits_1(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    state_path = tmp_path / "termux-pkg-updates.json"
+    monkeypatch.setattr(ctu, "STATE_PATH", str(state_path))
+    monkeypatch.setattr(ctu, "list_hosts", lambda limit=None: ["s24", "p7a"])
+    monkeypatch.setattr(
+        ctu,
+        "collect_updates",
+        lambda hosts, *, refresh=True: ({}, ["s24: down", "p7a: down"]),
+    )
+    monkeypatch.setattr(ctu, "hermes_notify", lambda msg: None)
+    assert ctu.main([]) == 1

--- a/tests/python/test_termux_pkg_nightly.py
+++ b/tests/python/test_termux_pkg_nightly.py
@@ -135,3 +135,42 @@ def test_nightly_runs_precheck_before_upgrade(monkeypatch, tmp_path):
     assert pre_idx < ap_idx
     assert "--limit" in calls[pre_idx]
     assert "s24" in calls[pre_idx]
+
+
+def test_nightly_continues_when_precheck_times_out(monkeypatch, tmp_path):
+    """Pre-check TimeoutExpired must not block the upgrade playbook (#152)."""
+    context = AnsibleContext(
+        config=tmp_path / "site" / "ansible.cfg",
+        inventory=tmp_path / "site" / "inventory" / "hosts.yml",
+        collections_path=tmp_path / "collections",
+        source="site overlay",
+    )
+    calls = []
+    fake_check = tmp_path / "check_termux_pkg_updates.py"
+    fake_check.write_text("# stub\n")
+    logged = []
+
+    monkeypatch.setattr(nightly, "resolve_ansible_context", lambda repo: context)
+    monkeypatch.setattr(
+        nightly,
+        "resolved_env",
+        lambda repo: {"ANSIBLE_CONFIG": str(context.config), "STAYTURGID_ROOT": str(repo), "PATH": "/usr/bin:/bin"},
+    )
+    monkeypatch.setattr(nightly, "require_inventory", lambda selected: None)
+    monkeypatch.setattr(nightly, "LOG_DIR", tmp_path / "logs")
+    monkeypatch.setattr(nightly, "LOG", tmp_path / "logs" / "nightly.log")
+    monkeypatch.setattr(nightly, "trim_log", lambda: None)
+    monkeypatch.setattr(nightly, "CHECK_UPDATES", fake_check)
+    monkeypatch.setattr(nightly, "log", lambda msg: logged.append(msg))
+
+    def fake_run(command, **kwargs):
+        calls.append(list(command))
+        if any("check_termux_pkg_updates.py" in str(part) for part in command):
+            raise nightly.subprocess.TimeoutExpired(cmd=command, timeout=600)
+        return _Result(0)
+
+    monkeypatch.setattr(nightly.subprocess, "run", fake_run)
+
+    assert nightly.main(["--limit", "s24"]) == 0
+    assert any(c and c[0] == "ansible-playbook" for c in calls)
+    assert any("pre-check failed" in msg for msg in logged)

--- a/tests/python/test_termux_pkg_nightly.py
+++ b/tests/python/test_termux_pkg_nightly.py
@@ -1,7 +1,16 @@
 """The nightly launchd runner must use the same site-overlay precedence."""
 
+from pathlib import Path
+
 import termux_pkg_nightly as nightly
 from ansible_context import AnsibleContext
+
+
+class _Result:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
 
 
 def test_nightly_runner_uses_resolved_site_config(monkeypatch, tmp_path):
@@ -27,16 +36,11 @@ def test_nightly_runner_uses_resolved_site_config(monkeypatch, tmp_path):
     def fake_run(command, **kwargs):
         seen["command"] = command
         seen["env"] = kwargs["env"]
-
-        class Result:
-            returncode = 0
-            stdout = ""
-            stderr = ""
-
-        return Result()
+        return _Result()
 
     monkeypatch.setattr(nightly.subprocess, "run", fake_run)
 
+    # --check skips the #152 pre-check so subprocess.run is only ansible-playbook.
     assert nightly.main(["--check", "--limit", "oneui-device"]) == 0
     assert seen["command"] == [
         "ansible-playbook",
@@ -64,11 +68,19 @@ def test_nightly_blocked_by_concurrent_deploy(monkeypatch, tmp_path):
     logged = []
 
     monkeypatch.setattr(nightly, "resolve_ansible_context", lambda repo: context)
+    monkeypatch.setattr(
+        nightly,
+        "resolved_env",
+        lambda repo: {"ANSIBLE_CONFIG": str(context.config), "STAYTURGID_ROOT": str(repo), "PATH": "/usr/bin:/bin"},
+    )
     monkeypatch.setattr(nightly, "require_inventory", lambda selected: None)
     monkeypatch.setattr(nightly, "LOG_DIR", tmp_path / "logs")
     monkeypatch.setattr(nightly, "LOG", tmp_path / "logs" / "nightly.log")
     monkeypatch.setattr(nightly, "trim_log", lambda: None)
     monkeypatch.setattr(nightly, "log", lambda msg: logged.append(msg))
+    # Pre-check (#152) must not block or race the fleet lock; stub the script
+    # path so the pre-step is skipped and only the locked ansible path runs.
+    monkeypatch.setattr(nightly, "CHECK_UPDATES", Path("/nonexistent/check_termux_pkg_updates.py"))
 
     def fake_run(command, **kwargs):
         raise AssertionError("ansible-playbook must not run while the fleet lock is held")
@@ -80,3 +92,46 @@ def test_nightly_blocked_by_concurrent_deploy(monkeypatch, tmp_path):
 
     assert rc == 3
     assert any("already running" in msg for msg in logged)
+
+
+def test_nightly_runs_precheck_before_upgrade(monkeypatch, tmp_path):
+    """Issue #152: pre-upgrade check_termux_pkg_updates.py runs (and may
+    hermes-notify) before ansible-playbook when not in --check mode."""
+    context = AnsibleContext(
+        config=tmp_path / "site" / "ansible.cfg",
+        inventory=tmp_path / "site" / "inventory" / "hosts.yml",
+        collections_path=tmp_path / "collections",
+        source="site overlay",
+    )
+    calls = []
+    fake_check = tmp_path / "check_termux_pkg_updates.py"
+    fake_check.write_text("# stub\n")
+
+    monkeypatch.setattr(nightly, "resolve_ansible_context", lambda repo: context)
+    monkeypatch.setattr(
+        nightly,
+        "resolved_env",
+        lambda repo: {"ANSIBLE_CONFIG": str(context.config), "STAYTURGID_ROOT": str(repo), "PATH": "/usr/bin:/bin"},
+    )
+    monkeypatch.setattr(nightly, "require_inventory", lambda selected: None)
+    monkeypatch.setattr(nightly, "LOG_DIR", tmp_path / "logs")
+    monkeypatch.setattr(nightly, "LOG", tmp_path / "logs" / "nightly.log")
+    monkeypatch.setattr(nightly, "trim_log", lambda: None)
+    monkeypatch.setattr(nightly, "CHECK_UPDATES", fake_check)
+
+    def fake_run(command, **kwargs):
+        calls.append(list(command))
+        return _Result(0, stdout="No Termux package updates available on s24")
+
+    monkeypatch.setattr(nightly.subprocess, "run", fake_run)
+
+    assert nightly.main(["--limit", "s24"]) == 0
+    assert len(calls) >= 2
+    assert any("check_termux_pkg_updates.py" in str(c) for c in calls)
+    assert any(c and c[0] == "ansible-playbook" for c in calls)
+    # Pre-check before ansible.
+    pre_idx = next(i for i, c in enumerate(calls) if "check_termux_pkg_updates.py" in str(c))
+    ap_idx = next(i for i, c in enumerate(calls) if c and c[0] == "ansible-playbook")
+    assert pre_idx < ap_idx
+    assert "--limit" in calls[pre_idx]
+    assert "s24" in calls[pre_idx]


### PR DESCRIPTION
## Summary

- Adds `control/bin/check_termux_pkg_updates.py`, the Termux apt/pkg counterpart to `check_apk_updates.py`: SSH each devices.conf host, `pkg update`, parse `apt list --upgradable`, write `~/.local/state/stayturgid/termux-pkg-updates.json`, and `hermes send` when anything is pending.
- Invokes that checker as a pre-step inside `termux_pkg_nightly.py` (skipped for `--check`) so the existing 04:15 launchd upgrade path reports package names + old→new versions instead of only Ansible `changed=true/false`.
- Unit tests for the parser, host limiting, hermes notify/skip, and nightly pre-check ordering.

## Live verification

Ran against s24, p7a, hd8:

```
No Termux package updates available on s24, p7a, hd8
```

State file wrote `hosts_checked: [s24, p7a, hd8]`, `updates: []`, `errors: []` — matches manual `apt list --upgradable` on each device (all currently current after nightly upgrades).

## Scheduling

- **In-repo:** nightly launchd already runs `termux_pkg_nightly.py` → now pre-checks + notifies.
- **Site overlay (follow-up):** Jobber entry `check-termux-pkg-updates` at 10:00 (same cadence as `check-apk-updates`) for mid-day residual if nightly was skipped/failed — lands in site-djbclark.

## Test plan

- [x] `bash tests/run.sh code` PASS
- [x] pytest for new tests + nightly pre-check
- [x] Live dry-run on s24/p7a/hd8
- [ ] CI green
- [ ] Merge + close #152

Closes #152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line check for available Termux package updates across selected devices.
  * Supports host filtering, optional package index refreshes, dry-run mode, notifications, and persisted results.
  * Nightly package upgrades now display update availability before proceeding.

* **Bug Fixes**
  * Reports SSH, operating system, and command failures without stopping checks for other devices.
  * Preserves check mode and fleet-lock behavior in nightly runs.

* **Tests**
  * Added coverage for update detection, host selection, notifications, state storage, failures, and nightly execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->