### PR TITLE
Manage Termux:X11 as a checksum-pinned nightly snapshot

### DIFF
--- a/.github/workflows/termux-x11-stable-release-check.yml
+++ b/.github/workflows/termux-x11-stable-release-check.yml
@@ -1,0 +1,55 @@
+---
+name: Termux X11 stable-release check
+
+on:
+  schedule:
+    - cron: "17 3 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-for-stable-release:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - name: File one issue when Termux:X11 publishes a stable release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          stable_release="$({
+            gh api --paginate repos/termux/termux-x11/releases |
+              jq -c '[.[] | select(.tag_name != "nightly" and (.draft | not) and (.prerelease | not))] | first // empty'
+          })"
+
+          if [[ -z "$stable_release" ]]; then
+            exit 0
+          fi
+
+          title="Termux:X11 stable release available: consider upgrading from pinned nightly"
+          existing_count="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "$title in:title" --json number --jq 'length')"
+          if [[ "$existing_count" -gt 0 ]]; then
+            echo "An open stable-release decision issue already exists; not creating a duplicate."
+            exit 0
+          fi
+
+          tag="$(jq -r '.tag_name' <<<"$stable_release")"
+          name="$(jq -r '.name // "(unnamed release)"' <<<"$stable_release")"
+          published_at="$(jq -r '.published_at // "(not published)"' <<<"$stable_release")"
+          release_url="$(jq -r '.html_url' <<<"$stable_release")"
+
+          gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body-file - <<EOF
+          Termux:X11 has published a non-nightly stable release.
+
+          - Tag: \`$tag\`
+          - Name: $name
+          - Published: $published_at
+          - Release: $release_url
+
+          The fleet is deliberately pinned to a checksum-verified nightly snapshot.
+          Please make an explicit operator decision before changing that lock.
+          EOF

--- a/.github/workflows/termux-x11-stable-release-check.yml
+++ b/.github/workflows/termux-x11-stable-release-check.yml
@@ -10,6 +10,10 @@ permissions:
   contents: read
   issues: write
 
+concurrency:
+  group: termux-x11-stable-release-check
+  cancel-in-progress: false
+
 jobs:
   check-for-stable-release:
     runs-on: ubuntu-latest
@@ -30,20 +34,23 @@ jobs:
             exit 0
           fi
 
-          title="Termux:X11 stable release available: consider upgrading from pinned nightly"
-          existing_count="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "$title in:title" --json number --jq 'length')"
+          tag="$(jq -r '.tag_name' <<<"$stable_release")"
+          marker="termux-x11-stable-release:$tag"
+          title="Termux:X11 stable release available: $tag — consider upgrading from pinned nightly"
+          existing_count="$(gh issue list --repo "$GITHUB_REPOSITORY" --state all --search "$marker in:body" --json number --jq 'length')"
           if [[ "$existing_count" -gt 0 ]]; then
-            echo "An open stable-release decision issue already exists; not creating a duplicate."
+            echo "A stable-release decision issue for $tag already exists; not creating a duplicate."
             exit 0
           fi
 
-          tag="$(jq -r '.tag_name' <<<"$stable_release")"
           name="$(jq -r '.name // "(unnamed release)"' <<<"$stable_release")"
           published_at="$(jq -r '.published_at // "(not published)"' <<<"$stable_release")"
           release_url="$(jq -r '.html_url' <<<"$stable_release")"
 
           gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body-file - <<EOF
           Termux:X11 has published a non-nightly stable release.
+
+          <!-- $marker -->
 
           - Tag: \`$tag\`
           - Name: $name

--- a/ansible_collections/stayturgid/android_common/plugins/modules/android_apk.py
+++ b/ansible_collections/stayturgid/android_common/plugins/modules/android_apk.py
@@ -52,6 +52,14 @@ options:
     description: Install even when the package is already present.
     type: bool
     default: false
+  verify_on_current:
+    description:
+      - Download and verify the configured artifact even when C(version_name)
+        already matches, without reinstalling it.
+      - This makes a checksum-pinned mutable release alias fail closed if its
+        upstream asset is replaced.
+    type: bool
+    default: false
   clean:
     description:
       - Uninstall the package before installing (only when an install is
@@ -312,6 +320,7 @@ def main():
             version_name=dict(type="str"),
             checksum=dict(type="str"),
             force=dict(type="bool", default=False),
+            verify_on_current=dict(type="bool", default=False),
             clean=dict(type="bool", default=False),
             clean_on_incompatible=dict(type="bool", default=True),
             installer=dict(type="str"),
@@ -339,11 +348,14 @@ def main():
         adb_connect(module.run_command, device)
 
     present = package_installed(module.run_command, device, package)
+    verify_current = False
     if present and not module.params["force"]:
         if module.params["version_name"]:
             current = installed_version(module.run_command, device, package)
             if current == module.params["version_name"]:
-                module.exit_json(changed=False, reason="version %s already installed" % current)
+                if not module.params["verify_on_current"]:
+                    module.exit_json(changed=False, reason="version %s already installed" % current)
+                verify_current = True
         else:
             module.exit_json(changed=False, reason="already installed")
 
@@ -365,6 +377,9 @@ def main():
         )
 
     verify_sha256(module, apk, module.params["checksum"])
+
+    if verify_current:
+        module.exit_json(changed=False, reason="version %s and checksum verified" % current)
 
     if module.params["resign"]:
         resign_apk(module, apk)

--- a/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
+++ b/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
@@ -19,6 +19,7 @@
 #   gh_pattern  — Asset glob for `gh release download --pattern` (required)
 #   version_name — exact Android versionName expected after install (required)
 #   checksum    — SHA-256 of the release asset before optional resigning (required)
+#   mutable_tag_snapshot — Explicitly approved mutable-tag checksum snapshot
 #   resign      — Resign with debug keystore before install (fork debug builds)
 #   monkey      — Launch app via monkey after install (Termux:Boot)
 #   start_broadcast_* — headless application-context trigger after install
@@ -82,6 +83,7 @@ stayturgid_bootstrap_apks:
     gh_pattern: termux-x11-universal-debug.apk
     version_name: 1.03.01-aa482f4-31.07.26
     checksum: "sha256:d5235ee5ed03431a76f4b3d79d02d139e76887e1fe717cfcdc6581f7ee0eb777"
+    mutable_tag_snapshot: true
   - id: moe.shizuku.privileged.api
     gh_repo: djbclark/Shizuku
     gh_tag: "v13.7.0-thedjchi+stayturgid-release25"

--- a/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
+++ b/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
@@ -2,7 +2,8 @@
 # Bootstrap APK list — installed over ADB from the Mac before Termux SSH exists.
 # These are the minimum set needed for the stayturgid fleet to bootstrap itself.
 #
-# Release-locked: every APK names an immutable GitHub release tag, exact asset,
+# Release-locked: every APK names an immutable GitHub release tag (except the
+# explicitly documented Termux:X11 nightly snapshot below), exact asset,
 # expected installed versionName, and SHA-256 digest. A coordinated ops release
 # therefore keeps deploying the same desired state even when a repository
 # publishes another release or has several independent release streams.
@@ -72,24 +73,15 @@ stayturgid_bootstrap_apks:
     gh_pattern: "termux-api-app_v0.53.0+github.debug.apk"
     version_name: 0.53.0
     checksum: "sha256:ecf916ff80ae751e65c092f51c055cce4de417ebeea8e449cd0f294afdbde39a"
-  - id: com.termux.tasker
-    gh_repo: termux/termux-tasker
-    gh_tag: v0.9.0
-    gh_pattern: "termux-tasker-app_v0.9.0+github.debug.apk"
-    version_name: 0.9.0
-    checksum: "sha256:4dd14de5f18791b3594256a9ead6bfddafa0434f11e0d39c3b551dda53db2fff"
-  - id: com.termux.styling
-    gh_repo: termux/termux-styling
-    gh_tag: v0.32.1
-    gh_pattern: "termux-styling-app_v0.32.1+github.debug.apk"
-    version_name: 0.32.1
-    checksum: "sha256:df607437476581c40d94ce6a222ca900e35163fdb0ac7dde3e2eb8cdcda18e08"
-  - id: com.termux.widget
-    gh_repo: termux/termux-widget
-    gh_tag: v0.15.0
-    gh_pattern: "termux-widget-app_v0.15.0+github.debug.apk"
-    version_name: 0.15.0
-    checksum: "sha256:780ae459be479bedef2146eb00f7bc79f2a4f89dba2bffa7b55c470165bc66ed"
+  # Intentional point-in-time snapshot pin against the mutable nightly tag.
+  # A future nightly fails checksum verification safely rather than auto-updating;
+  # re-pin only by deliberately re-fetching the asset and updating this checksum.
+  - id: com.termux.x11
+    gh_repo: termux/termux-x11
+    gh_tag: nightly
+    gh_pattern: termux-x11-universal-debug.apk
+    version_name: 1.03.01-aa482f4-31.07.26
+    checksum: "sha256:d5235ee5ed03431a76f4b3d79d02d139e76887e1fe717cfcdc6581f7ee0eb777"
   - id: moe.shizuku.privileged.api
     gh_repo: djbclark/Shizuku
     gh_tag: "v13.7.0-thedjchi+stayturgid-release25"

--- a/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
+++ b/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
@@ -76,7 +76,8 @@ stayturgid_bootstrap_apks:
     checksum: "sha256:ecf916ff80ae751e65c092f51c055cce4de417ebeea8e449cd0f294afdbde39a"
   # Intentional point-in-time snapshot pin against the mutable nightly tag.
   # A future nightly fails checksum verification safely rather than auto-updating;
-  # re-pin only by deliberately re-fetching the asset and updating this checksum.
+  # re-pin only by deliberately re-fetching the asset and updating this checksum
+  # and version_name.
   - id: com.termux.x11
     gh_repo: termux/termux-x11
     gh_tag: nightly

--- a/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/install_apk.yml
+++ b/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/install_apk.yml
@@ -60,6 +60,7 @@
       ansible.builtin.set_fact:
         _version_current: >-
           {{ not stayturgid_bootstrap_apks_force
+             and not (_apk.mutable_tag_snapshot | default(false) | bool)
              and _installed_version == _apk.version_name }}
 
     - name: Report immutable APK comparison — {{ _apk.id }}
@@ -82,6 +83,7 @@
         resign: "{{ _apk.resign | default(false) }}"
         clean: "{{ _apk.clean | default(false) }}"
         force: "{{ stayturgid_bootstrap_apks_force | default(false) }}"
+        verify_on_current: "{{ _apk.mutable_tag_snapshot | default(false) }}"
         version_name: "{{ _apk.version_name }}"
         apksigner_bin: "{{ stayturgid_apksigner_bin | default(omit) }}"
         keystore: "{{ stayturgid_debug_keystore | default(omit) }}"

--- a/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/main.yml
+++ b/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/main.yml
@@ -20,6 +20,10 @@
       - _locked_apk.gh_repo | length > 0
       - _locked_apk.gh_tag is string
       - _locked_apk.gh_tag | length > 0
+      - >-
+        _locked_apk.gh_tag not in ['latest', 'nightly'] or
+        (_locked_apk.id == 'com.termux.x11' and
+         (_locked_apk.mutable_tag_snapshot | default(false) | bool))
       - _locked_apk.gh_pattern is string
       - _locked_apk.gh_pattern | length > 0
       - _locked_apk.version_name is string
@@ -28,7 +32,8 @@
     fail_msg: >-
       Bootstrap APK {{ _locked_apk.id | default('(missing id)') }} is not
       release-locked. Every entry requires id, gh_repo, gh_tag, gh_pattern,
-      version_name, and sha256 checksum.
+      version_name, and sha256 checksum; mutable release aliases are forbidden
+      except for the explicitly approved com.termux.x11 snapshot.
     quiet: true
   loop: "{{ stayturgid_bootstrap_apks }}"
   loop_control:

--- a/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/main.yml
+++ b/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/main.yml
@@ -22,7 +22,7 @@
       - _locked_apk.gh_tag | length > 0
       - >-
         _locked_apk.gh_tag not in ['latest', 'nightly'] or
-        (_locked_apk.id == 'com.termux.x11' and
+        (_locked_apk.id == 'com.termux.x11' and _locked_apk.gh_tag == 'nightly' and
          (_locked_apk.mutable_tag_snapshot | default(false) | bool))
       - _locked_apk.gh_pattern is string
       - _locked_apk.gh_pattern | length > 0

--- a/tests/python/test_bootstrap_apk_lock.py
+++ b/tests/python/test_bootstrap_apk_lock.py
@@ -22,12 +22,29 @@ def test_every_github_apk_is_immutably_locked():
 
 
 def test_only_x11_has_the_explicit_mutable_tag_snapshot_exception():
-    mutable_aliases = {"latest", "nightly"}
+    mutable_aliases = {"nightly"}
     snapshots = [apk for apk in _catalog() if apk["gh_tag"] in mutable_aliases]
     assert snapshots == [
         next(apk for apk in _catalog() if apk["id"] == "com.termux.x11")
     ]
     assert snapshots[0]["mutable_tag_snapshot"] is True
+
+
+def test_x11_snapshot_policy_is_limited_and_verified_on_every_deploy():
+    role_tasks = (
+        ROOT / "ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/main.yml"
+    ).read_text(encoding="utf-8")
+    install_tasks = (
+        ROOT / "ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/install_apk.yml"
+    ).read_text(encoding="utf-8")
+    module = (
+        ROOT / "ansible_collections/stayturgid/android_common/plugins/modules/android_apk.py"
+    ).read_text(encoding="utf-8")
+
+    assert "_locked_apk.id == 'com.termux.x11' and _locked_apk.gh_tag == 'nightly'" in role_tasks
+    assert 'verify_on_current: "{{ _apk.mutable_tag_snapshot | default(false) }}"' in install_tasks
+    assert 'verify_on_current=dict(type="bool", default=False)' in module
+    assert 'reason="version %s and checksum verified" % current' in module
 
 
 def test_native_agent_uses_its_release_stream_and_real_asset_name():

--- a/tests/python/test_bootstrap_apk_lock.py
+++ b/tests/python/test_bootstrap_apk_lock.py
@@ -21,6 +21,15 @@ def test_every_github_apk_is_immutably_locked():
         assert re.fullmatch(r"sha256:[0-9a-f]{64}", apk["checksum"])
 
 
+def test_only_x11_has_the_explicit_mutable_tag_snapshot_exception():
+    mutable_aliases = {"latest", "nightly"}
+    snapshots = [apk for apk in _catalog() if apk["gh_tag"] in mutable_aliases]
+    assert snapshots == [
+        next(apk for apk in _catalog() if apk["id"] == "com.termux.x11")
+    ]
+    assert snapshots[0]["mutable_tag_snapshot"] is True
+
+
 def test_native_agent_uses_its_release_stream_and_real_asset_name():
     agent = next(apk for apk in _catalog() if apk["id"] == "org.stayturgid.agent")
     assert agent["gh_tag"] == "agent-v0.9.4"


### PR DESCRIPTION
Closes none; continues #151.

- removes the three Termux companion-app locks added in #192 (Tasker, Styling, Widget)
- adds the operator-approved `com.termux.x11` mutable-tag snapshot lock, with current-asset SHA-256 verification and explicit re-pin guidance
- adds a low-noise monthly workflow that files one decision issue only if upstream publishes a non-nightly stable release

Validation:
- `bash tests/run.sh code`
- live release-check logic against `termux/termux-x11` (no stable release found)
- live ADB verification: p7a remains on `1.03.01-b8a63db-23.06.26`; current upstream nightly asset pinned here is `1.03.01-aa482f4-31.07.26`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated checks for new stable Termux:X11 releases, with issue creation when an upgrade requires review.
  * Added support for installing a pinned Termux:X11 nightly build during Android environment bootstrapping.

* **Changes**
  * Updated the default bootstrap APK set to include Termux:X11 instead of Termux:Tasker, Termux:Styling, and Termux:Widget.
  * Documented the Termux:X11 nightly build as an approved release-lock exception.
  * Permitted explicitly approved mutable Termux:X11 release tags during validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->