### PR TITLE
docs: refresh #62 agent-function migration audit (post-#121)

### DIFF
--- a/docs/operations/agent-apk-migration-candidates.md
+++ b/docs/operations/agent-apk-migration-candidates.md
@@ -1,61 +1,174 @@
 # Candidates for moving control-node/Termux functions into the agent APK
 
-**Issue:** `#62`. **Status:** investigation only, per the issue's own
-"Deliverable" section — no code in this doc's PR. Template: `#61`
-(external-ADB Shizuku peer-starter moved into `device/native-agent/`,
-mirroring `control/bin/fire_peer_help.py:cmd_shizuku_start` as
-`PeerStarter.ensureShizuku`/`PeerStartCommands`).
+**Issue:** [#62](https://github.com/djbclark/stayturgid/issues/62).  
+**Status:** investigation only — no move code in the PR that ships this
+doc. Template pattern: [#61](https://github.com/djbclark/stayturgid/issues/61)
+(external-ADB Shizuku peer-starter → `PeerStarter` /
+`PeerStartCommands`).  
+**Audit date:** 2026-08-01 (refresh of the 2026-07-28 snapshot from
+PR #122 — several of that snapshot's "move next" items have already
+shipped).
 
 ## Method
 
-Read `control/bin/`, `device/termux/py/`, `device/termux/boot/`, and the
-current agent (`device/native-agent/app/src/main/kotlin/org/stayturgid/agent/`)
-looking for: (a) the three candidate classes the issue names explicitly, and
-(b) anything else in the same "needs a Mac / needs Termux+SSH to function"
-shape. Cross-referenced against what `#61`, `#65`, `#86` (PR `#113`,
-unmerged) and `#60`'s follow-up (PR `#116`, unmerged) have already moved
-agent-side, so this doesn't re-propose work that's already landed or already
-in flight.
+Read current owners under `control/bin/`, `device/termux/py/`,
+`device/termux/boot/`, and
+`device/native-agent/app/src/main/kotlin/org/stayturgid/agent/`, plus the
+healing-coverage matrix in `tests/healing_registry.json` and ADR-003 /
+ADR-004 / ADR-006. Focus:
 
-## Candidates
+1. Functions that **fail entirely** when the Mac is offline or Termux+SSH
+   is down (the single points of failure #61's pattern eliminates).
+2. The issue's named classes: peer-help verbs beyond Shizuku,
+   SSH/Tailscale/sshd co-monitor split, Mac/Termux-gated repairs.
+3. What has **already moved** so this doc does not re-propose shipped
+   work.
 
-| Candidate                              | Current owner                                                                                                                                                                                                                                                                                                                                                                                          | Benefit of moving                                                                                                                                                                                                                                                                                                                                                                             | Effort / risk                                                                                                                                                                                                                                                                                                                                                                                                       | Recommendation                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `handsets-start` verb                  | `control/bin/fire_peer_help.py:cmd_handsets_start` (Mac) / `device/termux/py/stayturgid_peer_help.py` (Termux peer). Pushes `hs.jar`, launches `dev.handsets.daemon.Main` via `app_process`, polls the port.                                                                                                                                                                                           | Same class of win as `#61`: Mac-independent, embedded-ADB path already exists in `PeerStarter`/`PeerStartCommands` for the `shizuku-start` verb — `handsets-start` is a near-identical shape (push a file, launch a process, poll a port) that never got ported when `#61` did the Shizuku verb.                                                                                              | **Low-medium.** `PeerStarter`'s `startAll()`/`ensureShizuku()` pattern (adb-client `push` + `shell` over the embedded key, poll-with-timeout) is directly reusable — this is closer to "port the second verb through the door `#61` already opened" than new design work. Main new piece: bundling `hs.jar` as an APK asset (currently a Mac-side file at `~/.handsets/hs.jar`) so the agent has something to push. | **Move.** Best next candidate — smallest gap between "what exists" and "what's needed," highest leverage (removes the last Mac dependency for peer-provisioning a fresh Fire OS target's Handsets daemon).                                                                                                                                                                                                                                                                               |
-| ADB wireless-debugging repair          | Split: `device/termux/py/stayturgid_repair.py:ensure_wireless_debugging()` (checks/toggles `adb_wifi_enabled` via Termux's own loopback shell) **and** `device/native-agent/.../CatastrophicRepair.kt:tryShellWirelessRepair()` (agent-side, opens the port via `adb connect 127.0.0.1:5555` from inside the UserService, gated on `privilegedShellExpected` — landed in `#60`'s PR `#116`, unmerged). | The agent side already does the higher-value half (actually opening the port). The Termux side additionally toggles the `adb_wifi_enabled` _setting_ itself, which the agent could also do directly (`Settings.Global.putString` via Shizuku, no shell-out needed) rather than shelling `settings put`.                                                                                       | **Low**, but only once `#116` merges — don't build on top of an unmerged, unreviewed PR. Genuinely small: one more `Settings` write, same privilege level the agent already has.                                                                                                                                                                                                                                    | **Move, but blocked.** Wait for `#116` to merge, then fold the `adb_wifi_enabled` toggle into `CatastrophicRepair` alongside `tryShellWirelessRepair()` so there's one code path instead of two.                                                                                                                                                                                                                                                                                         |
-| Tailscale reconnect/always-on repair   | Already mostly agent-side: `CatastrophicRepair.kt:repairTailscale()` (CONNECT_VPN intent → activity fallback → always-on policy enforcement, `ComonitorProbes` for detection). Termux's `stayturgid_repair.py:ensure_tailscale()`/`_wait_for_tailscale()` duplicates a chunk of this from the Termux side.                                                                                             | The agent's version is strictly more capable (it can launch activities/send intents Termux can't). Termux's copy may now be dead weight rather than a genuine fallback.                                                                                                                                                                                                                       | **Medium — needs verification, not just deletion.** Before touching `stayturgid_repair.py`'s copy, need to confirm the agent's `repairTailscale()` actually fires reliably _before_ Termux's boot-time loop would otherwise kick in — i.e. is Termux's version still doing real work in the boot-time window before the agent's FGS is even up?                                                                     | **Investigate before moving.** Not a clean "port it" case like `handsets-start` — this is "audit for redundancy," a different kind of follow-up. Spin a narrower sub-issue if pursued; don't fold into a broad move.                                                                                                                                                                                                                                                                     |
-| sshd stale-`down`-file repair          | `device/termux/py/stayturgid_repair.py:ensure_sshd_down_file()` — removes a stale `runsv` `down` file at `$PREFIX/var/service/sshd/down` that silently blocks sshd.                                                                                                                                                                                                                                    | sshd itself is a Termux userland process (`runsv`-supervised) — there's no equivalent concept inside the Android agent process to "move" this to. The agent _could_ issue the same `rm`/`sv up` commands via its own privileged-shell capability (same mechanism `tryShellWirelessRepair()` already uses), but sshd would still be running _in Termux_, just restarted by a different caller. | **Low mechanically** (same shell-out pattern as other agent repairs) but **conceptually thin** — doesn't remove the Termux dependency, just relocates who pokes it.                                                                                                                                                                                                                                                 | **Don't move.** Not a genuine Mac/Termux-independence win like `handsets-start` — sshd only exists because Termux exists. Leave as Termux-side; the "survives with no Termux" framing from `#61`'s pattern doesn't apply here.                                                                                                                                                                                                                                                           |
-| Shizuku watchdog loop                  | `device/termux/py/stayturgid_repair.py:ensure_shizuku_watchdog()` — spawns a detached UID-2000 shell loop that restarts `shizuku_server` if it dies, explicitly independent of Shizuku's own app-level `WatchdogService`.                                                                                                                                                                              | None — see recommendation.                                                                                                                                                                                                                                                                                                                                                                    | N/A                                                                                                                                                                                                                                                                                                                                                                                                                 | **Do not move — this one's a deliberate negative example.** Its own docstring explains why: it requires `privileged_shell()` (i.e. Shizuku) to already be up, so it "cannot help bootstrap Shizuku from nothing, only keep it running once it's up once." Moving it into the agent would make it circular — the agent can't use Shizuku to restart Shizuku if Shizuku is what's down. This is the textbook case of "gated on Termux+SSH being up" being the _correct_ design, not a gap. |
-| SSH key bootstrap (`bootstrap_ssh.py`) | `control/bin/bootstrap_ssh.py` (Mac-only) — installs Mac `~/.ssh/*.pub` keys into Termux `authorized_keys`, starts sshd, verifies.                                                                                                                                                                                                                                                                     | None.                                                                                                                                                                                                                                                                                                                                                                                         | N/A                                                                                                                                                                                                                                                                                                                                                                                                                 | **Do not move.** Its own docstring: "Keys are read from the Mac only — never committed to git." Bundling SSH key material into an installable APK would be a real security regression, not a robustness win. Correctly Mac-gated by design.                                                                                                                                                                                                                                              |
-| Dead-man's-switch reachability monitor | `control/bin/access_monitor.py` (Mac, launchd, every 5 min) — alerts the _operator_ (macOS notification) when a device is unreachable on every access path.                                                                                                                                                                                                                                            | None.                                                                                                                                                                                                                                                                                                                                                                                         | N/A                                                                                                                                                                                                                                                                                                                                                                                                                 | **Do not move.** Structurally can't run on-device — it's an external-reachability check by definition; a device can't monitor "am I reachable from outside" about itself in any way that provides new information when the answer is no. Correctly Mac-side.                                                                                                                                                                                                                             |
+### Already agent-side (do not re-propose)
+
+| Capability                               | Where it landed                                                                                            | Source         |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------- |
+| Peer `shizuku-start` (push model)        | `PeerStarter` + `HostService` peer-start loop (`peer.json`, ~20 min + stagger)                             | #61            |
+| Peer `handsets-start` **implementation** | `HandsetsStarter` + APK asset `hs.jar`; **manual** trigger only (`HandsetsStartReceiver`)                  | #121 #156/#159 |
+| Port-5555 catastrophic shell repair      | `CatastrophicRepair.tryShellWirelessRepair` (incl. `adb_wifi_enabled`; gated on `privilegedShellExpected`) | #60 / #116     |
+| ADB baseline                             | `CatastrophicRepair.ensureAdbBaseline` from co-monitor                                                     | native-agent   |
+| Shizuku HEADLESS_START                   | `CatastrophicRepair.headlessStart`                                                                         | agent          |
+| Tailscale reconnect + always-on policy   | `CatastrophicRepair.repairTailscale` + `ComonitorProbes`                                                   | native-agent   |
+| Co-monitor STATUS                        | `ComonitorProbes` (port / shizuku / sshd **probe-only** / wifi / tailscale)                                | HostService    |
+
+## Candidates (remaining)
+
+Summary table first; each row is expanded below with ownership detail.
+
+| Candidate                           | Current owner (short)                        | Benefit of moving                    | Effort / risk       | Recommendation         |
+| ----------------------------------- | -------------------------------------------- | ------------------------------------ | ------------------- | ---------------------- |
+| Periodic peer handsets-start        | Agent impl + Mac/Termux auto only            | Mac/SSH-free Fire Handsets keepalive | Low                 | **Move — top**         |
+| Peer re-assert `adb_wifi_enabled`   | Mac `fire_help_monitor` only                 | Steady-state Fire toggle without Mac | Low                 | **Move** (with above)  |
+| Local Handsets ensure (self)        | Termux `stayturgid_handsets`                 | Termux-independent local daemon      | Medium              | **Defer**              |
+| FIRERPA process keepalive           | Termux `start_adb` / Mac `firerpa_heal`      | Out-of-band path if Termux dies      | Medium–high         | **Investigate**        |
+| Tailscale repair (Termux copy)      | Agent primary + Termux duplicate             | Cleanup only, not independence       | Verification        | **Audit redundancy**   |
+| Termux wireless-debug ensure        | Termux + agent (agent already primary)       | Consolidation only                   | Low                 | **Don't move further** |
+| sshd restart / stale `down` file    | Termux `stayturgid_repair`                   | None (sshd is Termux userland)       | Easy but empty      | **Don't move**         |
+| Shizuku UID-2000 watchdog loop      | Termux via privileged shell                  | Circular bootstrap                   | N/A                 | **Don't move**         |
+| SSH key bootstrap                   | Mac `bootstrap_ssh.py`                       | None (keys must stay Mac-only)       | Security regression | **Don't move**         |
+| Dead-man's reachability monitor     | Mac `access_monitor.py`                      | Impossible on-device                 | N/A                 | **Don't move**         |
+| Mac adb reconnect / fleet soft-heal | Mac launchd agents                           | Mac control-plane concerns           | N/A                 | **Don't move**         |
+| Termux userland ensure\_\* helpers  | Termux repair (mirror, PATH, pkg, ET config) | Pure Termux filesystem/apt           | N/A                 | **Don't move**         |
+| Screen / battery / agent-presence   | Termux boot-loop helpers                     | UX, not catastrophic connectivity    | Medium              | **Don't move** (#62)   |
+| Legacy peer pull bootstrap          | Termux SSH → peer help                       | Superseded by ADR-006 push           | —                   | **Keep fallback only** |
+
+### Detail: move / investigate
+
+#### Periodic peer handsets-start — **Move (top priority)**
+
+- **Current owner:** `HandsetsStarter` / `HandsetsStartCommands` are agent-side
+  but **on-demand only** (`HandsetsStartReceiver` →
+  `HostService.handsetsStartNow`). Automatic keep-alive still lives in Mac
+  `control/bin/fire_help_monitor.py` (launchd →
+  `fire_peer_help.cmd_handsets_start`) and Termux
+  `stayturgid_peer_keepalive` / `stayturgid_peer_bootstrap` (SSH pull). The
+  agent peer loop only runs `PeerStarter.startAll` (Shizuku).
+- **Benefit:** Closes the last Mac/SSH dependency for the verb #121 already
+  ported. Fire Handsets still dies when Mac is offline **and** peer Termux
+  SSH is down, even though a healthy peer APK could restart it with code that
+  already exists. Same push model as ADR-006.
+- **Effort / risk:** **Low.** Call `HandsetsStarter.ensureHandsets` from the
+  existing peer-start job (or a sibling loop). Optional `handsets_port` in
+  `peer.json` (default 9012). Mitigate adb load with poll-before-start
+  (`ALREADY_UP` style). No new privilege model.
+
+#### Peer re-assert `adb_wifi_enabled` on Fire — **Move** (fold into peer path)
+
+- **Current owner:** Mac-only
+  `fire_help_monitor.ensure_wireless_debugging` (settings get/put over Mac
+  adb). Fire cannot self-heal wireless ADB (`privilegedShellExpected=false`).
+  Agent peer path connects externally but does not touch the toggle.
+- **Benefit:** When a peer already has an authorized adbd session, keep the
+  toggle from drifting off without the Mac — the gap
+  `fire_help_monitor`'s docstring names. Does **not** restore adbd if port
+  5555 is fully dead (USB/Mac still required for cold start).
+- **Effort / risk:** **Low.** One `settings put global adb_wifi_enabled 1`
+  (and maybe `adb_enabled`) via existing `AdbClient` shell at the start of
+  `ensureShizuku` / `ensureHandsets`. Does not solve #188-class "shizuku
+  never starts and 5555 never returns" without a live adbd.
+
+#### Local Handsets ensure (self, non-Fire) — **Defer**
+
+- **Current owner:** `device/termux/py/stayturgid_handsets.py` via
+  `adb -s localhost:5555` when `STAYTURGID_NO_LOCAL_ADB` is unset.
+- **Benefit:** Survives Termux death for local UI-automation daemon on phones
+  that already have loopback shell.
+- **Effort / risk:** **Medium.** UserService could launch `app_process` with
+  the bundled jar, but Handsets demand on non-Fire is lower and not the Fire
+  failure mode #61 targets. Prefer finishing peer auto-handsets first.
+
+#### FIRERPA process keepalive — **Investigate, don't move yet**
+
+- **Current owner:** Termux boot supervisor `start_adb.py`
+  (`startup_firerpa` / `_launch_firerpa_via_shell`); Mac `firerpa_heal.py`
+  when SSH/ADB are down.
+- **Benefit:** FIRERPA is the Mac's out-of-band gRPC channel. If Termux
+  bootloop dies, FIRERPA may die with it. Agent FGS + UserService could
+  relaunch under uid 2000 without Termux.
+- **Effort / risk:** **Medium–high.** Paths, cert, lifecycle argv, and "child
+  dies when rish session closes" constraints are already non-trivial. Two
+  supervisors thrashing would be worse than one. Decide single ownership
+  before coding.
+
+#### Tailscale repair (Termux copy) — **Audit redundancy only**
+
+- **Current owner:** Agent `CatastrophicRepair.repairTailscale` is primary;
+  Termux `stayturgid_repair.ensure_tailscale` now correctly returns
+  `unknown` without privileged shell (hd8 false-down fix).
+- **Benefit:** Not a Mac-independence gap. Termux copy is either useful
+  boot-window backup or dead weight.
+- **Effort / risk:** Field verification — does agent FGS repair fire before
+  Termux's 5‑min loop matters after boot? Do not "port"; optionally thin
+  Termux once agent preemption is proven.
+
+### Detail: don't move
+
+| Candidate                                      | Why leave it where it is                                                                                                                                                          |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Termux `ensure_wireless_debugging`             | Agent already owns the primary path post-#116 (`tryShellWirelessRepair` sets `adb_wifi_enabled`). Termux is backup/consolidation, not a #61-class win.                            |
+| sshd restart / stale `down` file               | sshd is Termux userland (`runsv`). Agent shelling `sv up` still requires Termux (ADR-004).                                                                                        |
+| Shizuku UID-2000 watchdog                      | Requires privileged shell already up — cannot bootstrap Shizuku from nothing. Peer-start is the real bootstrap. Textbook case of correct Termux/Mac gating.                       |
+| SSH key bootstrap (`bootstrap_ssh.py`)         | "Keys are read from the Mac only — never committed to git." Bundling host keys into an APK is a security regression.                                                              |
+| Dead-man's reachability (`access_monitor.py`)  | External reachability check by definition; a device cannot usefully answer "am I reachable from outside?" when the answer is no.                                                  |
+| Mac `adb_reconnect` / fleet soft-health        | Mac control-plane (transport cache, operator notification, remote agent restart).                                                                                                 |
+| Termux userland ensure\_\*                     | Mirror pin, PATH scrub, daily pkg upgrade, control-ET ssh config, os-release — pure Termux filesystem/apt state.                                                                  |
+| Screen-awake / battery / agent-presence        | UX helpers on the Termux boot loop; not catastrophic connectivity under #62's framing.                                                                                            |
+| Legacy peer pull (`stayturgid_peer_bootstrap`) | ADR-006 chose **push** over pull for agent. Keep as Handsets auto fallback until periodic peer handsets ships; then reassess retirement. Do **not** re-implement pull in the APK. |
 
 ## Summary
 
-Of the issue's three named candidate areas:
+Of the issue's three named areas, **after** #61 / #121 / #116:
 
-- **Peer-help verbs beyond Shizuku** — real, actionable. `handsets-start` is
-  the concrete next step; `ping`/`status` are thin enough not to be worth a
-  separate porting effort (they're just diagnostic one-liners already
-  reachable via `adb shell` directly).
-- **SSH/Tailscale/sshd split** — more nuanced than "split, should
-  consolidate." Tailscale repair is _already_ mostly agent-side and the
-  Termux copy needs an audit (not a blind move). sshd's Termux-side pieces
-  are correctly Termux-side and shouldn't move. The Shizuku watchdog is a
-  genuine, well-reasoned exception to the "move it agent-side" instinct —
-  worth keeping as a documented example of when _not_ to apply this
-  pattern.
-- **"Gated on Mac online / Termux+SSH up"** — the two clearest examples
-  found (`bootstrap_ssh.py`, `access_monitor.py`) are both correctly gated;
-  moving either would be a regression (security for the former, structural
-  impossibility for the latter), not a robustness improvement.
+1. **Peer-help verbs beyond Shizuku** — implementation for `handsets-start` is
+   done; the remaining gap is **scheduling** it like Shizuku (periodic push
+   from assigned peers). Pair with peer-side `adb_wifi_enabled` re-assert so
+   Mac `fire_help_monitor` is not required for steady-state Fire health.
+2. **SSH / Tailscale / sshd split** — Tailscale and port-5555 catastrophic
+   paths are already agent-primary. sshd stays Termux. Termux Tailscale /
+   wireless copies are redundancy candidates, not independence wins.
+3. **"Gated on Mac online / Termux+SSH"** — still-correct Mac gates:
+   `bootstrap_ssh.py`, `access_monitor.py`, `adb_reconnect.py`. Still-correct
+   Termux gates: sshd, package/mirror/PATH, Shizuku shell-watchdog. The
+   remaining wrong-gate is automatic Fire Handsets (+ wireless-toggle
+   re-assert) still depending on Mac launchd or Termux SSH pull.
 
-**Net recommendation:** don't treat this as one broad initiative. Spin a
-single, narrowly-scoped follow-up issue for `handsets-start` (the one clear
-win) referencing this doc and `#61`'s `PeerStarter`/`PeerStartCommands` as
-the template. Leave the Tailscale-redundancy question as a "worth a look
-sometime, not urgent" note rather than its own issue, since it needs
-field observation (does the agent's repair actually preempt Termux's boot
-loop in practice?) before any code change makes sense. The three "don't
-move" candidates don't need follow-up issues at all — they're documented
-here as the record of why, so nobody re-proposes them without rereading
-this.
+**Net recommendation:** do **not** treat #62 as a broad "move everything"
+initiative. File (or implement) one narrow follow-up:
+
+1. **Periodic peer handsets-start** (+ optional `adb_wifi` re-assert on the
+   same peer connection) — clear #61-pattern win, lowest risk.
+2. **FIRERPA keepalive ownership design** — investigate only; no code until
+   Termux vs agent ownership is decided.
+3. Leave Tailscale Termux dedup and the "don't move" rows as documentation
+   so they are not re-proposed without re-reading this file.
+
+Related open work that is **not** a #62 move but blocks Fire independence in
+practice: [#188](https://github.com/djbclark/stayturgid/issues/188) (hd8
+`shizuku_server` never starts after reboot — peer-start is the intended
+recovery when self-start fails, which makes the peer path's completeness
+more important, not less).


### PR DESCRIPTION
## Summary

- Refreshes `docs/operations/agent-apk-migration-candidates.md` for the current fleet state after #61 / #121 / #116 shipped.
- The July audit's top "port handsets-start" recommendation is **done as implementation** (`HandsetsStarter`) but still **manual-only**; remaining top move is **periodic peer handsets-start** (+ peer `adb_wifi_enabled` re-assert).
- Documents correctly Mac/Termux-owned items so they are not re-proposed.

Investigation-only deliverable for #62 — no move code.

## Test plan

- [x] `markdownlint` clean on the doc
- [x] `prettier --check` clean on the doc
- [x] `bash tests/run.sh code` PASS

Closes nothing — leave #62 open for operator decisions on follow-ups.