### PR TITLE
docs: scheduling-tier policy — GitHub Actions default, never raw cron

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,10 @@ See `${OPS_ROOT:-~/ops}/site-djbclark/docs/OPS-RELEASES.md`.
 
 See [docs/adding-a-launchd-service.md](docs/adding-a-launchd-service.md) — two
 paths: `control_node` role for fleet-wide agents, `site_agents` role for
-per-site agents.
+per-site agents. **Before scheduling anything periodic**, read that doc's
+"Before adding any scheduled/periodic job" section first — the Mac control
+node is a laptop, often off, so GitHub Actions `schedule:` is the default
+unless the job genuinely needs local machine access; never raw `cron`.
 
 ## Conventions
 

--- a/docs/adding-a-launchd-service.md
+++ b/docs/adding-a-launchd-service.md
@@ -5,6 +5,33 @@ Covers the two deployment paths: the **control_node** Ansible role (global
 agents under `com.stayturgid.*`) and the **site_agents** Ansible role
 (per-site agents under `com.<site_ns>.*`).
 
+## Before adding any scheduled/periodic job: pick the right tier
+
+The Mac control node is a laptop and is often off or asleep. Never assume
+it's always on when choosing where a scheduled job runs. Decide in this
+order:
+
+1. **GitHub Actions `schedule:` (cron syntax), if the job doesn't need this
+   machine.** Runs on GitHub's own infrastructure regardless of whether this
+   Mac is on — the correct default for anything that only needs `gh`/GitHub
+   API access, or reads/writes to a repo (e.g. the periodic
+   `.github/workflows/*.yml` `schedule:` jobs already in this repo and in
+   site-djbclark).
+2. **launchd (this doc) or Jobber, only when the job genuinely needs this
+   machine** — local ADB/Tailscale/network access to fleet devices, local
+   filesystem/git-worktree state, or anything else that can't run on a
+   GitHub-hosted runner. Both launchd (`StartCalendarInterval`) and Jobber
+   tolerate the Mac being asleep/off at the scheduled time and catch up on
+   next wake — unlike raw Unix cron, which silently misses a run entirely if
+   the machine isn't up at that exact moment.
+3. **Never use raw Unix `cron`/`crontab` for anything in this project.** It
+   has no wake-catchup semantics at all, so a job scheduled while this Mac is
+   off just doesn't run, silently, with no signal that it was skipped.
+
+If you're unsure whether a job needs local machine access, default to GitHub
+Actions and only move it to launchd/Jobber if you hit a concrete reason it
+can't run there.
+
 ## Which path to use
 
 | If the service is...                                  | Use                                    |


### PR DESCRIPTION
Operator flagged this as an intended standing rule that was never actually written down: the Mac control node is a laptop, often off, so scheduled/periodic jobs must not assume it's always on.

Adds a "Before adding any scheduled/periodic job" section to `docs/adding-a-launchd-service.md` documenting the decision order:

1. GitHub Actions `schedule:` (runs on GitHub's infra, correct default when the job doesn't need this machine).
2. launchd or Jobber, only when the job genuinely needs local machine/device access — both tolerate the Mac being asleep/off and catch up on next wake.
3. Never raw Unix `cron`/`crontab` — no wake-catchup semantics, a job silently doesn't run if the machine's off at the scheduled time.

Also adds a short pointer to this from `AGENTS.md`'s launchd section.

Audited before writing this: no raw cron usage anywhere in this repo, site-djbclark, or this Mac's live crontab (empty) — every currently-scheduled thing (this repo's new Termux:X11 monthly check, site-djbclark's `track-issue-activity`/`sync-tracked-issues`) is already correctly on GitHub Actions, and every local launchd/Jobber job genuinely needs local device/network access. No existing violation to fix — this is codifying the rule going forward.