### PR TITLE
ci: gate CodeRabbit reviews on a label instead of every push

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+reviews:
+  auto_review:
+    enabled: false
+    labels:
+      - "review-ready"


### PR DESCRIPTION
Default auto_review re-reviews a PR on every push — burning the shared rate-limit budget on small incremental fix-and-repush diffs instead of complete reviews. Switches to explicit `review-ready` label triggering. Going forward: add the `review-ready` label when a PR is actually ready for a look, not on every push.