### PR TITLE
fix: stop unattended recovery from foregrounding apps

### DIFF
--- a/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/install_apk.yml
+++ b/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/install_apk.yml
@@ -92,6 +92,7 @@
         installer: "{{ 'org.stayturgid.agent' if _apk.id != 'org.stayturgid.agent' else omit }}"
       when: not _version_current | default(false)
       delegate_to: localhost
+      register: _apk_install
 
 - name: Trigger required application service headlessly — {{ _apk.id }}
   ansible.builtin.command:
@@ -146,7 +147,12 @@
       - monkey -p {{ _apk.id }} -c android.intent.category.LAUNCHER 1 2>/dev/null
   changed_when: false
   failed_when: false
-  when: _apk.monkey | default(false)
+  # A launcher intent visibly foregrounds the app. It is only needed directly
+  # after an install to clear Android's stopped-package state; never do it on
+  # a routine desired-state convergence (#199).
+  when:
+    - _apk.monkey | default(false)
+    - _apk_install.changed | default(false)
 
 - name: Grant Shizuku permission — {{ _apk.id }}
   delegate_to: localhost

--- a/control/tools/native-agent/README.md
+++ b/control/tools/native-agent/README.md
@@ -3,7 +3,7 @@
 | Script             | Purpose                                       |
 | ------------------ | --------------------------------------------- |
 | `grant_shizuku.py` | pm grant + patch `shizuku.json`               |
-| `start_agent.py`   | force-stop + MainActivity → HostService       |
+| `start_agent.py`   | headless PeerStartReceiver → HostService      |
 | `rollout.py`       | install APK + grant + Shizuku restart + start |
 
 ```bash

--- a/control/tools/native-agent/rollout.py
+++ b/control/tools/native-agent/rollout.py
@@ -4,7 +4,7 @@
 Steps per host (when adb-reachable):
   1. adb install -r debug APK
   2. grant_shizuku.py (pm grant + conditional Shizuku server restart)
-  3. start_agent.py (MainActivity → HostService)
+  3. start_agent.py (headless PeerStartReceiver → HostService)
 
 AutoJs6 was already removed fleet-wide before this script's introduction
 (OPTIONS K1); this only handles the native-agent APK itself.

--- a/control/tools/native-agent/start_agent.py
+++ b/control/tools/native-agent/start_agent.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Start stayturgid native-agent HostService on a device.
+"""Headlessly nudge stayturgid native-agent HostService on a device.
 
-FGS cannot be started from adb shell on API 34+; launch MainActivity which
-auto-starts HostService in app context.
+The exported PeerStartReceiver starts the foreground service from app context.
+Never use MainActivity for unattended recovery: it interrupts the operator's
+foreground task (#199).
 
 Usage: ./start_agent.py <host-or-serial> [adb_serial]
 """
@@ -19,7 +20,8 @@ import adb_cli as adb  # noqa: E402
 
 PKG_DEBUG = "org.stayturgid.agent.debug"
 PKG_RELEASE = "org.stayturgid.agent"
-ACTIVITY = "org.stayturgid.agent.MainActivity"
+PEER_START_RECEIVER = "org.stayturgid.agent.PeerStartReceiver"
+PEER_START_ACTION = "org.stayturgid.agent.action.PEER_START_NOW"
 
 
 def _resolve_pkg(serial: str) -> str | None:
@@ -40,20 +42,15 @@ def main(argv: list[str] | None = None) -> int:
     if not pkg:
         sys.stderr.write(f"ERROR: neither {PKG_DEBUG} nor {PKG_RELEASE} installed on {serial}\n")
         return 1
-    component = f"{pkg}/{ACTIVITY}"
-    print(f"Starting native-agent on {serial} ({component})...")
-    # Force-stop first so FGS + UserService restart cleanly after freezes.
-    adb.adb(serial, "shell", f"am force-stop {pkg}")
-    # Stop any stale UserService processes (which run as UID 2000 under Shizuku and survive force-stop)
-    for p in (PKG_DEBUG, PKG_RELEASE):
-        stale = adb.adb(serial, "shell", f"pidof {p}:userservice").stdout or ""
-        pids = [pid for pid in stale.strip().split() if pid.isdigit()]
-        if pids:
-            adb.adb(serial, "shell", f"kill {' '.join(pids)}")
-    time.sleep(1)
-    r = adb.adb(serial, "shell", f"am start -n {component}")
+    component = f"{pkg}/{PEER_START_RECEIVER}"
+    print(f"Headlessly starting native-agent on {serial} ({component})...")
+    r = adb.adb(
+        serial,
+        "shell",
+        f"am broadcast --include-stopped-packages -a {PEER_START_ACTION} -n {component}",
+    )
     if r.returncode != 0:
-        sys.stderr.write((r.stderr or r.stdout or "am start failed").strip() + "\n")
+        sys.stderr.write((r.stderr or r.stdout or "peer-start broadcast failed").strip() + "\n")
         return 1
     time.sleep(4)
     pid = adb.adb(serial, "shell", f"pidof {pkg}").stdout or ""

--- a/device/termux/cfengine/policy/stayturgid.cf
+++ b/device/termux/cfengine/policy/stayturgid.cf
@@ -176,11 +176,11 @@ bundle agent check_stayturgid_agent(p, s) {
     # and escalate if it crosses $(reboot_after).
     !agent_alive::
       "$(p)/bin/am"
-        args => "broadcast -a org.stayturgid.agent.action.PEER_START_NOW -n org.stayturgid.agent/org.stayturgid.agent.PeerStartReceiver",
+        args => "broadcast --include-stopped-packages -a org.stayturgid.agent.action.PEER_START_NOW -n org.stayturgid.agent/org.stayturgid.agent.PeerStartReceiver",
         contain => silent_bg;
 
       "$(p)/bin/adb"
-        args => "-s localhost:5555 shell am broadcast -a org.stayturgid.agent.action.PEER_START_NOW -n org.stayturgid.agent/org.stayturgid.agent.PeerStartReceiver",
+        args => "-s localhost:5555 shell am broadcast --include-stopped-packages -a org.stayturgid.agent.action.PEER_START_NOW -n org.stayturgid.agent/org.stayturgid.agent.PeerStartReceiver",
         contain => silent_bg;
 
       "$(p)/bin/bash"

--- a/device/termux/cfengine/policy/stayturgid.cf
+++ b/device/termux/cfengine/policy/stayturgid.cf
@@ -116,14 +116,11 @@ bundle agent check_bootloop(s) {
 # Mac-hailed cf-runagent run (Tier 3a) can catch it sooner since it runs this
 # bundle on demand.
 #
-# Restart: Termux's own `am start` of the exported launcher (MainActivity,
-# whose onCreate() starts HostService) is tried first — no loopback needed —
-# but it is best-effort only: Android 10+ background-activity-launch
-# restrictions frequently block a background Termux process from starting an
-# activity, worse after Termux has been idle/backgrounded a while and worse
-# still on Fire OS, and it fails *silently* (exit 0, nothing launches). The
-# old adb-loopback `am start` is kept as a fallback — it may still succeed
-# even though it is no longer the liveness signal.
+# Restart: trigger the agent's exported peer-start receiver with a broadcast,
+# never its launcher activity. `am start` makes MainActivity foreground itself
+# over whatever the operator is using (observed live on p7a, #199). The
+# receiver starts HostService headlessly and works both from Termux directly
+# and through an already-authorized loopback ADB shell.
 #
 # Reboot escalation is alert-only, on purpose: this bundle never executes a
 # reboot itself. After REBOOT_AFTER=3 consecutive checks (~15 min at the
@@ -174,16 +171,16 @@ bundle agent check_stayturgid_agent(p, s) {
         args => "-c 'mkdir -p $(s)/state; rm -f $(fail_state) $(reboot_marker)'",
         contain => silent_bg;
 
-    # Not alive: try Termux's own am first (no loopback dependency; see file
-    # header for its best-effort caveat), then the adb-loopback fallback,
-    # then record the outcome and escalate if it crosses $(reboot_after).
+    # Not alive: try Termux's own headless broadcast first (no loopback
+    # dependency), then the adb-loopback fallback, then record the outcome
+    # and escalate if it crosses $(reboot_after).
     !agent_alive::
       "$(p)/bin/am"
-        args => "start -n org.stayturgid.agent/.MainActivity",
+        args => "broadcast -a org.stayturgid.agent.action.PEER_START_NOW -n org.stayturgid.agent/org.stayturgid.agent.PeerStartReceiver",
         contain => silent_bg;
 
       "$(p)/bin/adb"
-        args => "-s localhost:5555 shell am start -n org.stayturgid.agent/.MainActivity",
+        args => "-s localhost:5555 shell am broadcast -a org.stayturgid.agent.action.PEER_START_NOW -n org.stayturgid.agent/org.stayturgid.agent.PeerStartReceiver",
         contain => silent_bg;
 
       "$(p)/bin/bash"

--- a/device/termux/py/stayturgid_repair.py
+++ b/device/termux/py/stayturgid_repair.py
@@ -81,7 +81,6 @@ A11Y_SVC = "org.autojs.autojs6/org.autojs.autojs.core.accessibility.Accessibilit
 TAILSCALE_PACKAGE = "com.tailscale.ipn"
 TAILSCALE_CONTROL_HOST = "controlplane.tailscale.com"
 TAILSCALE_RECEIVER = "com.tailscale.ipn/com.tailscale.ipn.IPNReceiver"
-TAILSCALE_ACTIVITY = "com.tailscale.ipn/com.tailscale.ipn.MainActivity"
 
 
 def ts():
@@ -429,17 +428,9 @@ def ensure_tailscale(have_sh=False):
     """Restore always-on policy and request runtime reconnect when possible.
 
     Tailscale's exported CONNECT_VPN receiver is the supported headless path.
-    Some Fire OS / WorkManager combinations reject its expedited worker; the
-    activity fallback may then require an unlocked operator action. Never
+    If it cannot restore the tunnel, report the failure for an operator rather
+    than launching MainActivity over the current foreground app (#199). Never
     report repair unless both policy and runtime verify healthy.
-
-    The activity fallback launches Tailscale's MainActivity into the
-    foreground, interrupting whatever the user is doing on-screen — only
-    worth that disruption for a sustained outage, not a single transient
-    ping/DNS blip. It only fires when the previous repair cycle *also* saw
-    the runtime down (~one extra cycle's delay, ~15 min), tracked via
-    state.json rather than in-process state since each cycle is a fresh
-    process invocation.
 
     Every check and repair action below requires a privileged (uid 2000)
     shell — the settings get/put calls throw SecurityException without one,
@@ -449,9 +440,8 @@ def ensure_tailscale(have_sh=False):
     localhost:5555), every one of those calls is guaranteed to fail — not
     because Tailscale is down, but because this process cannot see it.
     Returns "unknown" and does nothing in that case, rather than reporting a
-    false "FAILED" and forcing Tailscale's MainActivity into the foreground
-    against a tunnel that may be perfectly healthy (confirmed live on hd8,
-    2026-07-31: see ``_tailscale_runtime_up``).
+    false "FAILED" against a tunnel that may be perfectly healthy (confirmed
+    live on hd8, 2026-07-31: see ``_tailscale_runtime_up``).
     """
     if read_device_profile().get("tailscaleEnabled") is False:
         return "skip"
@@ -489,15 +479,11 @@ def ensure_tailscale(have_sh=False):
     )
     restored = _wait_for_tailscale(have_sh=have_sh)
     if not restored:
-        if _previous_repair_field("tailscale") == "down":
-            _device_command(["am", "start", "-n", TAILSCALE_ACTIVITY], have_sh)
-            restored = _wait_for_tailscale(attempts=2, have_sh=have_sh)
-        else:
-            log(
-                "Tailscale still down after CONNECT_VPN broadcast; deferring "
-                "foreground activity fallback to next cycle",
-                NOTICE,
-            )
+        log(
+            "Tailscale still down after CONNECT_VPN broadcast; leaving the "
+            "foreground app untouched",
+            NOTICE,
+        )
 
     if restored and policy_ok:
         log("Tailscale runtime/policy restored", NOTICE)
@@ -1135,34 +1121,13 @@ def main():
         shizuku_rc, _ = run(["pgrep", "-f", "[s]hizuku_server"])
         if shizuku_rc == 0:
             shizuku = "up"
-            # Shizuku daemon is running but port 5555 is closed — likely TCP
-            # mode wasn't enabled (fleet profile not applied). Re-applying
-            # the fleet profile is a plain `am start` on an unprotected
-            # activity, unlike HEADLESS_START — this part still works from
-            # Termux without any privilege.
-            log("shizuku_server running but port 5555 closed — re-applying fleet profile", WARNING)
-            shizuku_fp = "/data/local/tmp/shizuku-fleet.json"
-            if not os.path.isfile(shizuku_fp):
-                shizuku_fp = "/sdcard/Download/shizuku-fleet.json"
-            if os.path.isfile(shizuku_fp):
-                run(
-                    [
-                        "am",
-                        "start",
-                        "--user",
-                        "0",
-                        "-a",
-                        "moe.shizuku.privileged.api.APPLY_FLEET_PROFILE",
-                        "-e",
-                        "profile_path",
-                        shizuku_fp,
-                        "-e",
-                        "silent",
-                        "true",
-                        "-n",
-                        "moe.shizuku.privileged.api/moe.shizuku.manager.fleet.FleetProfileActivity",
-                    ]
-                )
+            # Shizuku is up, so its installed rish client can restore TCP
+            # adbd headlessly. Never launch FleetProfileActivity here: that
+            # foregrounds Shizuku over the operator's current app (#199).
+            rish = os.path.join(STG, "bin", "rish")
+            if os.access(rish, os.X_OK):
+                log("shizuku_server running but port 5555 closed — restoring via rish", WARNING)
+                run([rish, "-c", "setprop service.adb.tcp.port 5555; setprop ctl.restart adbd"])
                 time.sleep(1)
             # Re-check if the profile re-apply alone was enough.
             if privileged_shell():
@@ -1249,40 +1214,14 @@ def main():
     # --- 7c. Daily pkg upgrade (once/24h, 3-5am; retries if phone was off) ---
     pkg_upgrade = ensure_pkg_upgrade_daily()
 
-    # --- 8. Re-apply fleet profiles (AutoJs6 + Shizuku) in case app data was cleared.
-    # Gate each independently: AutoJs6 only re-applies when its process is dead
-    # (likely after data clear); Shizuku only when HEADLESS_STATUS/pgrep says down.
-    # Avoids waking healthy apps and suppresses toasts every cycle.
+    # --- 8. Re-apply the Shizuku profile in case app data was cleared.
+    # AutoJs6 is retired; Shizuku uses its headless receiver when needed so
+    # unattended repair never opens an app over the operator's foreground task.
     shizuku_profile = "skip"
     auto_profile = "skip"
     device_profile = "present"
     if expect_shell and have_sh:
-        if not autojs6_present:
-            auto_profile = "retired"
-        else:
-            # AutoJs6: only re-apply if the process is dead (cleared data or crash).
-            auto_running = False
-            rc_auto, _ = sh_adb("pgrep -f org.autojs.autojs6 2>/dev/null")
-            if rc_auto == 0:
-                auto_running = True
-            _, afp_out = sh_adb("[ -f /sdcard/Download/autojs6-fleet.json ] && echo ok || echo missing")
-            if "ok" in afp_out:
-                if not auto_running:
-                    profile = "/sdcard/Download/autojs6-fleet.json"
-                    sh_adb(
-                        "if [ -f %s ]; then am start --user 0 "
-                        "-a org.autojs.autojs6.action.APPLY_FLEET_PROFILE "
-                        "-e profile_path %s -e silent true "
-                        "-n org.autojs.autojs6/org.autojs.autojs.core.pref.fleet.FleetProfileActivity; fi"
-                        % (profile, profile)
-                    )
-                    time.sleep(0.5)
-                    auto_profile = "applied"
-                else:
-                    auto_profile = "up"
-            else:
-                auto_profile = "MISSING"
-                log("autojs6-fleet.json is MISSING from /sdcard/Download/ — re-deploy required")
+        auto_profile = "retired"
         # Shizuku: only re-apply when Shizuku is down.
         _, sf_out = sh_adb("[ -f /data/local/tmp/shizuku-fleet.json ] && echo ok || echo missing")
         profile = "/data/local/tmp/shizuku-fleet.json"
@@ -1295,13 +1234,14 @@ def main():
         if "ok" in sf_out:
             shizuku_profile = "present"
             if shizuku != "up":
+                # A shell-UID ADB session can use Shizuku's exported headless
+                # receiver. FleetProfileActivity is UI-only and must not be
+                # launched from unattended repair (#199).
                 sh_adb(
-                    "if [ -f %s ]; then am start "
-                    "-a moe.shizuku.privileged.api.APPLY_FLEET_PROFILE "
-                    "-e profile_path %s -e silent true "
-                    "-n moe.shizuku.privileged.api/moe.shizuku.manager.fleet.FleetProfileActivity; fi"
-                    % (profile, profile)
+                    "am broadcast -a moe.shizuku.privileged.api.HEADLESS_START "
+                    "-n moe.shizuku.privileged.api/moe.shizuku.manager.receiver.HeadlessStartStopReceiver"
                 )
+                sh_adb("settings put global adb_wifi_enabled 1")
                 time.sleep(0.5)
                 shizuku_profile = "applied"
                 sh_adb("dumpsys deviceidle whitelist +moe.shizuku.privileged.api")

--- a/device/termux/py/stayturgid_repair.py
+++ b/device/termux/py/stayturgid_repair.py
@@ -1129,6 +1129,8 @@ def main():
                 log("shizuku_server running but port 5555 closed — restoring via rish", WARNING)
                 run([rish, "-c", "setprop service.adb.tcp.port 5555; setprop ctl.restart adbd"])
                 time.sleep(1)
+            else:
+                log("shizuku_server running but port 5555 closed and rish is unavailable — cannot restore", WARNING)
             # Re-check if the profile re-apply alone was enough.
             if privileged_shell():
                 have_sh = True

--- a/tests/python/test_bootstrap_apk_lock.py
+++ b/tests/python/test_bootstrap_apk_lock.py
@@ -62,6 +62,14 @@ def test_normal_deploy_ensures_before_it_verifies():
     assert site.index("Import bootstrap APK ensure") < site.index("Import bootstrap APK verify")
 
 
+def test_monkey_launch_is_limited_to_a_real_install():
+    install_tasks = (
+        ROOT / "ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/install_apk.yml"
+    ).read_text(encoding="utf-8")
+    assert "register: _apk_install" in install_tasks
+    assert "- _apk_install.changed | default(false)" in install_tasks
+
+
 def test_locked_version_check_has_no_mutable_latest_lookup():
     tasks = ROOT / "ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks"
     combined = "\n".join(path.read_text(encoding="utf-8") for path in tasks.glob("*.yml"))

--- a/tests/python/test_bootstrap_apk_lock.py
+++ b/tests/python/test_bootstrap_apk_lock.py
@@ -63,11 +63,17 @@ def test_normal_deploy_ensures_before_it_verifies():
 
 
 def test_monkey_launch_is_limited_to_a_real_install():
-    install_tasks = (
-        ROOT / "ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/install_apk.yml"
-    ).read_text(encoding="utf-8")
-    assert "register: _apk_install" in install_tasks
-    assert "- _apk_install.changed | default(false)" in install_tasks
+    tasks = yaml.safe_load(
+        (
+            ROOT / "ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/install_apk.yml"
+        ).read_text(encoding="utf-8")
+    )
+    reconcile = next(task for task in tasks if task["name"].startswith("Reconcile locked APK"))
+    install = next(task for task in reconcile["block"] if task["name"].startswith("Install over ADB"))
+    monkey = next(task for task in tasks if task["name"].startswith("Launch via monkey"))
+
+    assert install["register"] == "_apk_install"
+    assert "_apk_install.changed | default(false)" in monkey["when"]
 
 
 def test_locked_version_check_has_no_mutable_latest_lookup():

--- a/tests/python/test_native_agent_start.py
+++ b/tests/python/test_native_agent_start.py
@@ -14,7 +14,7 @@ start_agent = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(start_agent)
 
 
-def test_start_agent_kills_stale_user_services(monkeypatch) -> None:
+def test_start_agent_uses_headless_receiver_without_stopping_app(monkeypatch) -> None:
     calls: list[list[str]] = []
 
     def fake_adb(serial, *args):
@@ -22,10 +22,6 @@ def test_start_agent_kills_stale_user_services(monkeypatch) -> None:
         calls.append(cmd)
         if "pm path" in " ".join(args):
             return SimpleNamespace(returncode=0, stdout="package:org.stayturgid.agent.debug\n", stderr="")
-        if "pidof org.stayturgid.agent.debug:userservice" in " ".join(args):
-            return SimpleNamespace(returncode=0, stdout="301 302\n", stderr="")
-        if "pidof org.stayturgid.agent:userservice" in " ".join(args):
-            return SimpleNamespace(returncode=0, stdout="\n", stderr="")
         if "pidof org.stayturgid.agent.debug" in " ".join(args):
             return SimpleNamespace(returncode=0, stdout="101\n", stderr="")
         return SimpleNamespace(returncode=0, stdout="OK\n", stderr="")
@@ -36,6 +32,10 @@ def test_start_agent_kills_stale_user_services(monkeypatch) -> None:
 
     exit_code = start_agent.main(["s24"])
     assert exit_code == 0
-    kill_calls = [call for call in calls if any("kill" in part for part in call)]
-    assert len(kill_calls) == 1
-    assert kill_calls[0] == ["adb", "-s", "s24", "shell", "kill 301 302"]
+    shell_commands = [call[-1] for call in calls if len(call) >= 5 and call[-2] == "shell"]
+    assert (
+        "am broadcast --include-stopped-packages "
+        "-a org.stayturgid.agent.action.PEER_START_NOW "
+        "-n org.stayturgid.agent.debug/org.stayturgid.agent.PeerStartReceiver"
+    ) in shell_commands
+    assert not any("am start" in command or "force-stop" in command or "kill " in command for command in shell_commands)

--- a/tests/python/test_stayturgid_repair.py
+++ b/tests/python/test_stayturgid_repair.py
@@ -111,30 +111,14 @@ def test_tailscale_reconnect_receiver_is_verified(monkeypatch):
     assert not any(command[:2] == ["am", "start"] for command, _have_sh in commands)
 
 
-def test_tailscale_first_failure_defers_activity_fallback(monkeypatch):
-    """A single down reading shouldn't yank the app into the foreground —
-    only a second consecutive cycle (tracked via state.json) escalates."""
+def test_tailscale_failure_never_foregrounds_the_app(monkeypatch):
     commands = _setup_tailscale(monkeypatch)
     monkeypatch.setattr(repair, "_tailscale_policy_up", lambda _have_sh=False: True)
     monkeypatch.setattr(repair, "_tailscale_runtime_up", lambda _have_sh=False: False)
     monkeypatch.setattr(repair, "_wait_for_tailscale", lambda attempts=3, have_sh=False: False)
-    monkeypatch.setattr(repair, "_previous_repair_field", lambda _key: "up")
-
     assert repair.ensure_tailscale(have_sh=True) == "FAILED"
     assert any(command[:2] == ["am", "broadcast"] for command, _have_sh in commands)
     assert not any(command[:2] == ["am", "start"] for command, _have_sh in commands)
-
-
-def test_tailscale_failed_receiver_and_activity_report_failure(monkeypatch):
-    commands = _setup_tailscale(monkeypatch)
-    monkeypatch.setattr(repair, "_tailscale_policy_up", lambda _have_sh=False: True)
-    monkeypatch.setattr(repair, "_tailscale_runtime_up", lambda _have_sh=False: False)
-    monkeypatch.setattr(repair, "_wait_for_tailscale", lambda attempts=3, have_sh=False: False)
-    monkeypatch.setattr(repair, "_previous_repair_field", lambda _key: "down")
-
-    assert repair.ensure_tailscale(have_sh=True) == "FAILED"
-    assert any(command[:2] == ["am", "broadcast"] for command, _have_sh in commands)
-    assert any(command[:2] == ["am", "start"] for command, _have_sh in commands)
 
 
 def test_tailscale_no_shell_reports_unknown_without_side_effects(monkeypatch):


### PR DESCRIPTION
Fixes #199.

Live diagnosis on p7a confirmed every observed automatic launch came from `com.android.shell`; the fourth periodic source was the Mac fleet-health monitor, which called `start_agent.py` on a stale heartbeat and executed `am start …MainActivity`. Its cadence matched the reports exactly.

This also removes the other unattended foreground paths found in the complete recovery-policy audit:

- CFEngine agent recovery now broadcasts to `PeerStartReceiver`;
- Shizuku recovery uses `rish` / `HEADLESS_START`;
- normal bootstrap convergence launches Termux:Boot and Shizuku via monkey only after a real install;
- the Tailscale repeated-failure fallback reports failure rather than opening its activity.

Live verification: direct `PeerStartReceiver` and Shizuku `HEADLESS_START` invocations on p7a started their headless services without creating a foreground task; the actual `start_agent.py` helper likewise left the existing task unchanged.

Validation: `bash tests/run.sh code`; `just kt-check` (spotless, detekt, unit tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent startup and recovery flows now run headlessly without opening or force-stopping the app.
  * Improved Tailscale and Shizuku recovery, including wireless debugging restoration.
  * Launcher actions now run only when an APK installation changes the device.

* **Documentation**
  * Updated agent startup documentation to describe the headless launch process.

* **Tests**
  * Added regression coverage for APK installation and headless recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->