### PR TITLE
chore: bump ops-release.json to 1.2.1

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.2.0"
+  "version": "1.2.1"
 }


### PR DESCRIPTION
Coordinated ops-v1.2.1 release bump for the merged #199 remediation.