### PR TITLE
fix: gateway uses git-install venv (Python 3.14 breakage)

### DIFF
--- a/ansible/roles/control_node/defaults/main.yml
+++ b/ansible/roles/control_node/defaults/main.yml
@@ -79,6 +79,11 @@ stayturgid_hermes_home: "{{ lookup('env', 'HOME') }}/.hermes"
 stayturgid_hermes_model: big-pickle
 stayturgid_hermes_provider: opencode-zen
 stayturgid_hermes_gateway_label: com.stayturgid.hermes-gateway
+# Binary path for the gateway. Default: git-install venv wrapper (Python
+# version pinned by upstream's requires-python, not the system/homebrew
+# default). Override to stayturgid_homebrew_prefix + /bin/hermes if you
+# want the brew formula instead.
+stayturgid_hermes_bin: "{{ lookup('env', 'HOME') }}/.local/bin/hermes"
 # Site-specific Telegram allowlist (numeric user ids, comma-separated).
 # Empty = leave existing ~/.hermes/.env values alone (pairing still works).
 stayturgid_hermes_telegram_allowed_users: ""

--- a/ansible/roles/control_node/defaults/main.yml
+++ b/ansible/roles/control_node/defaults/main.yml
@@ -50,8 +50,9 @@ stayturgid_mac_brew_packages_base:
   - scrcpy
   - semgrep
   - gitleaks
-  # Hermes Agent (Telegram gateway + Grok OAuth CLI); see tasks/hermes.yml
-  - hermes-agent
+  # Hermes Agent: installed via canonical git+uv method (see tasks/hermes.yml)
+  # The brew formula is unsupported by upstream and pins Python 3.14 which breaks
+  # DaemonThreadPoolExecutor (upstream requires-python caps at <3.14).
   # GNU rsync (3.x, protocol 32) — macOS ships an ancient 2.6.9/protocol-29
   # build at /usr/bin/rsync. Termux devices run modern rsync too, so both
   # ends of the termux_userland synchronize tasks should speak the same

--- a/ansible/roles/control_node/tasks/hermes.yml
+++ b/ansible/roles/control_node/tasks/hermes.yml
@@ -1,44 +1,41 @@
 ---
-# Hermes Agent (control node): brew install, model/config, Telegram gateway keep-alive.
+# Hermes Agent (control node): git-install + uv venv (canonical method).
+# The brew formula is unsupported by upstream and pins Python 3.14 which
+# breaks DaemonThreadPoolExecutor (upstream requires-python caps at <3.14).
+#
+# Canonical install: curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+# This creates ~/.hermes/hermes-agent with uv venv (Python 3.11), wrapper at ~/.local/bin/hermes.
+#
 # Secrets (TELEGRAM_BOT_TOKEN, API keys) stay on the machine only — never in git.
 # First-time auth: hermes auth add opencode-zen --type api-key
 # First-time bot token: set TELEGRAM_BOT_TOKEN in ~/.hermes/.env (or env when running playbook).
 #
 # All tasks gated by stayturgid_hermes_enabled so include from agents.yml never end_host.
-- name: Install Hermes Agent Homebrew formula
-  community.general.homebrew:
-    name: hermes-agent
-    state: present
-  when: stayturgid_hermes_enabled | default(true) | bool
-  register: _hermes_brew_install
-
-- name: Ensure hermes-agent formula is not pinned
-  ansible.builtin.command:
-    cmd: brew unpin hermes-agent
-  register: _hermes_unpin
-  changed_when: "'Unpinned' in (_hermes_unpin.stdout | default(''))"
+- name: Verify Hermes Agent canonical install exists
+  ansible.builtin.stat:
+    path: "{{ stayturgid_hermes_bin }}"
+  register: _hermes_bin_stat
   when: stayturgid_hermes_enabled | default(true) | bool
 
-- name: Resolve Hermes libexec python (for optional Telegram deps)
-  ansible.builtin.shell: |
-    set -euo pipefail
-    brew --prefix hermes-agent 2>/dev/null | head -1
-  args:
-    executable: /bin/bash
-  register: _hermes_brew_prefix
-  changed_when: false
-  failed_when: false
-  when: stayturgid_hermes_enabled | default(true) | bool
+- name: Fail if Hermes Agent canonical install is missing
+  ansible.builtin.fail:
+    msg: >-
+      Hermes Agent not found at {{ stayturgid_hermes_bin }}.
+      Install via: curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+      The brew formula is unsupported by upstream.
+  when:
+    - stayturgid_hermes_enabled | default(true) | bool
+    - not (_hermes_bin_stat.stat.exists | default(false))
 
 - name: Ensure python-telegram-bot in Hermes venv (Telegram gateway)
   ansible.builtin.command:
     cmd: >-
-      uv pip install --python {{ _hermes_brew_prefix.stdout | trim }}/libexec/bin/python
+      uv pip install --python {{ stayturgid_hermes_home }}/hermes-agent/venv/bin/python
       --quiet 'python-telegram-bot>=21' 'qrcode[pil]'
   when:
     - stayturgid_hermes_enabled | default(true) | bool
     - stayturgid_hermes_gateway_enabled | default(true) | bool
-    - (_hermes_brew_prefix.stdout | default('') | trim | length) > 0
+    - (_hermes_bin_stat.stat.exists | default(false))
   register: _hermes_tg_pip
   changed_when: >-
     'Successfully installed' in (_hermes_tg_pip.stdout | default(''))
@@ -71,11 +68,11 @@
 - name: Set Hermes default model (idempotent)
   ansible.builtin.command:
     cmd: >-
-      {{ stayturgid_homebrew_prefix }}/bin/hermes config set model
+      {{ stayturgid_hermes_bin }} config set model
       {{ stayturgid_hermes_model }}
   environment:
     HERMES_HOME: "{{ stayturgid_hermes_home }}"
-    PATH: "{{ stayturgid_homebrew_prefix }}/bin:/usr/bin:/bin"
+    PATH: "{{ stayturgid_hermes_bin | dirname }}:{{ stayturgid_homebrew_prefix }}/bin:/usr/bin:/bin"
   register: _hermes_model_set
   changed_when: >-
     'Set model' in (_hermes_model_set.stdout | default(''))

--- a/ansible/roles/control_node/templates/hermes-gateway.plist.j2
+++ b/ansible/roles/control_node/templates/hermes-gateway.plist.j2
@@ -6,7 +6,7 @@
     <string>{{ stayturgid_hermes_gateway_label }}</string>
     <key>ProgramArguments</key>
     <array>
-        <string>{{ stayturgid_homebrew_prefix }}/bin/hermes</string>
+        <string>{{ stayturgid_hermes_bin }}</string>
         <string>gateway</string>
         <string>run</string>
         <string>--replace</string>
@@ -16,7 +16,7 @@
         <key>HERMES_HOME</key>
         <string>{{ stayturgid_hermes_home }}</string>
         <key>PATH</key>
-        <string>{{ stayturgid_homebrew_prefix }}/bin:{{ stayturgid_homebrew_prefix }}/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <string>{{ lookup('env', 'HOME') }}/.local/bin:{{ stayturgid_homebrew_prefix }}/bin:{{ stayturgid_homebrew_prefix }}/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
 {% if (stayturgid_hermes_telegram_allowed_users | default('') | string | trim | length) > 0 %}
         <key>TELEGRAM_ALLOWED_USERS</key>
         <string>{{ stayturgid_hermes_telegram_allowed_users | string | trim }}</string>


### PR DESCRIPTION
## Problem

The brew formula pins `python@3.14` but upstream `requires-python` caps at `<3.14` (Rust transitives like pydantic-core lack cp314 wheels). Python 3.14 removed `_initializer`/`_initargs` from `ThreadPoolExecutor` internals, breaking `DaemonThreadPoolExecutor` and ALL concurrent tool calls (web_search, web_extract, read_file).

The git-install venv at `~/.hermes/hermes-agent/venv` (Python 3.11.15, matching `requires-python`) was already set up and working — it just wasn't being used because the gateway plist pointed at `/opt/homebrew/bin/hermes`.

## Changes

- Add `stayturgid_hermes_bin` variable (defaults to `~/.local/bin/hermes`, the git-install venv wrapper)
- Gateway plist template uses `{{ stayturgid_hermes_bin }}` instead of hardcoded `{{ stayturgid_homebrew_prefix }}/bin/hermes`
- Add `~/.local/bin` to gateway PATH so subcommands resolve correctly
- Override `stayturgid_hermes_bin` to stay on brew if desired

## Upstream PR

Hermes core fix for the Python 3.14 breakage: https://github.com/NousResearch/hermes-agent/pull/76212

## Testing

```
~/.local/bin/hermes -z "Reply with exactly: PONG" --ignore-user-config
# Result: PONG ✓ (Python 3.11.15)
```

## Note

After merge, gateway restart needed:
```
launchctl kickstart -k gui/$(id -u)/com.stayturgid.hermes-gateway
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Hermes setup now uses the canonical installer and user-local executable by default.
  * Related dependencies use Hermes’ managed Python environment for improved consistency.
  * Gateway services honor the configured Hermes installation path and include it in the execution path.
* **Bug Fixes**
  * Removed reliance on the Homebrew Hermes package.
  * Resolved configuration issues caused by fixed installation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->