### PR TITLE
feat: fold Handsets-start + adb_wifi_enabled re-assert into periodic peer loop (#62)

### DIFF
--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/HandsetsStarter.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/HandsetsStarter.kt
@@ -50,18 +50,28 @@ object HandsetsStarter {
         key: AdbKey,
         port: Int = HandsetsStartCommands.DEFAULT_PORT,
     ): PeerStarter.Result {
-        val jarBytes =
-            try {
-                context.assets.open(ASSET_NAME).use { it.readBytes() }
-            } catch (t: Throwable) {
-                Log.e(TAG, "hs.jar asset read failed", t)
-                return PeerStarter.Result(
-                    target.toString(),
-                    PeerStarter.Outcome.FAILED,
-                    "asset:${t.message}",
-                )
+        val jarBytes = loadJar(context) ?: return assetFailure(target)
+        return try {
+            AdbClient(target.host, target.port, key).use { client ->
+                client.connect()
+                ensureHandsets(target, client, jarBytes, port)
             }
-        return ensureHandsets(target, key, jarBytes, port)
+        } catch (t: AdbAuthPendingException) {
+            authPending(target, t)
+        } catch (t: java.io.IOException) {
+            failed(target, t)
+        }
+    }
+
+    /** Reuse [PeerStarter]'s already-connected periodic-loop client. */
+    internal fun ensureHandsets(
+        context: Context,
+        target: PeerTarget,
+        client: AdbClient,
+        port: Int = HandsetsStartCommands.DEFAULT_PORT,
+    ): PeerStarter.Result {
+        val jarBytes = loadJar(context) ?: return assetFailure(target)
+        return ensureHandsets(target, client, jarBytes, port)
     }
 
     /** Same as the [Context] overload, but with the jar bytes already loaded (unit-test seam). */
@@ -76,40 +86,77 @@ object HandsetsStarter {
         return try {
             AdbClient(target.host, target.port, key).use { client ->
                 client.connect()
-                pushJarIfNeeded(client, jarBytes)
-                exec(client, HandsetsStartCommands.killCommand(port))
-                Thread.sleep(KILL_SETTLE_MS)
-                val startOut = exec(client, HandsetsStartCommands.startCommand(port))
-                Log.i(
-                    TAG,
-                    "handsets-start output for $name: ${startOut.trim().take(START_OUTPUT_LOG_CHARS)}",
-                )
-                if (pollUntilUp(client, port)) {
-                    PeerStarter.Result(name, PeerStarter.Outcome.STARTED)
-                } else {
-                    val log = exec(client, HandsetsStartCommands.tailLogCommand(port))
-                    PeerStarter.Result(
-                        name,
-                        PeerStarter.Outcome.FAILED,
-                        log.trim().replace('\n', ' ').take(FAILURE_DETAIL_CHARS),
-                    )
-                }
+                ensureHandsets(target, client, jarBytes, port)
             }
         } catch (t: AdbAuthPendingException) {
-            Log.i(TAG, "handsets-start $name pending one-time approval: ${t.message}")
-            PeerStarter.Result(
-                name,
-                PeerStarter.Outcome.AUTH_PENDING,
-                "awaiting Always-allow on target",
-            )
-        } catch (t: Throwable) {
-            Log.w(TAG, "handsets-start $name failed", t)
+            authPending(target, t)
+        } catch (t: java.io.IOException) {
+            failed(target, t)
+        }
+    }
+
+    /**
+     * Reuse an already-authorized peer connection from [PeerStarter]'s periodic loop. The port poll
+     * is deliberately before any jar write or process kill: a healthy daemon is ALREADY_UP, never
+     * restarted on each loop iteration.
+     */
+    internal fun ensureHandsets(
+        target: PeerTarget,
+        client: AdbClient,
+        jarBytes: ByteArray,
+        port: Int = HandsetsStartCommands.DEFAULT_PORT,
+    ): PeerStarter.Result {
+        val name = target.toString()
+        if (HandsetsStartCommands.isUp(exec(client, HandsetsStartCommands.pollCommand(port)))) {
+            return PeerStarter.Result(name, PeerStarter.Outcome.ALREADY_UP)
+        }
+        pushJarIfNeeded(client, jarBytes)
+        exec(client, HandsetsStartCommands.killCommand(port))
+        Thread.sleep(KILL_SETTLE_MS)
+        val startOut = exec(client, HandsetsStartCommands.startCommand(port))
+        Log.i(
+            TAG,
+            "handsets-start output for $name: ${startOut.trim().take(START_OUTPUT_LOG_CHARS)}",
+        )
+        return if (pollUntilUp(client, port)) {
+            PeerStarter.Result(name, PeerStarter.Outcome.STARTED)
+        } else {
+            val log = exec(client, HandsetsStartCommands.tailLogCommand(port))
             PeerStarter.Result(
                 name,
                 PeerStarter.Outcome.FAILED,
-                (t.message ?: t.javaClass.simpleName).take(ERROR_MESSAGE_CHARS),
+                log.trim().replace('\n', ' ').take(FAILURE_DETAIL_CHARS),
             )
         }
+    }
+
+    private fun authPending(target: PeerTarget, t: Throwable): PeerStarter.Result {
+        Log.i(TAG, "handsets-start $target pending one-time approval: ${t.message}")
+        return PeerStarter.Result(
+            target.toString(),
+            PeerStarter.Outcome.AUTH_PENDING,
+            "awaiting Always-allow on target",
+        )
+    }
+
+    private fun loadJar(context: Context): ByteArray? =
+        try {
+            context.assets.open(ASSET_NAME).use { it.readBytes() }
+        } catch (t: java.io.IOException) {
+            Log.e(TAG, "hs.jar asset read failed", t)
+            null
+        }
+
+    private fun assetFailure(target: PeerTarget): PeerStarter.Result =
+        PeerStarter.Result(target.toString(), PeerStarter.Outcome.FAILED, "asset:read failed")
+
+    private fun failed(target: PeerTarget, t: Throwable): PeerStarter.Result {
+        Log.w(TAG, "handsets-start $target failed", t)
+        return PeerStarter.Result(
+            target.toString(),
+            PeerStarter.Outcome.FAILED,
+            (t.message ?: t.javaClass.simpleName).take(ERROR_MESSAGE_CHARS),
+        )
     }
 
     private fun pushJarIfNeeded(client: AdbClient, jarBytes: ByteArray) {

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/HandsetsStarter.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/HandsetsStarter.kt
@@ -50,29 +50,32 @@ object HandsetsStarter {
         key: AdbKey,
         port: Int = HandsetsStartCommands.DEFAULT_PORT,
     ): PeerStarter.Result {
-        val jarBytes = loadJar(context) ?: return assetFailure(target)
         return try {
             AdbClient(target.host, target.port, key).use { client ->
                 client.connect()
-                ensureHandsets(target, client, jarBytes, port)
+                ensureHandsets(context, target, client, port)
             }
         } catch (t: AdbAuthPendingException) {
             authPending(target, t)
         } catch (t: java.io.IOException) {
             failed(target, t)
+        } catch (t: IllegalStateException) {
+            failed(target, t)
         }
     }
 
-    /** Reuse [PeerStarter]'s already-connected periodic-loop client. */
+    /**
+     * Reuse [PeerStarter]'s already-connected periodic-loop client. Delegates straight to the
+     * shared implementation with a lazy jar loader, so the liveness poll runs exactly once and the
+     * asset is only ever read on the confirmed not-up path — a healthy daemon must never pay for a
+     * jar read, and a transient asset-read failure must never mark a healthy daemon FAILED.
+     */
     internal fun ensureHandsets(
         context: Context,
         target: PeerTarget,
         client: AdbClient,
         port: Int = HandsetsStartCommands.DEFAULT_PORT,
-    ): PeerStarter.Result {
-        val jarBytes = loadJar(context) ?: return assetFailure(target)
-        return ensureHandsets(target, client, jarBytes, port)
-    }
+    ): PeerStarter.Result = ensureHandsets(target, client, port) { loadJar(context) }
 
     /** Same as the [Context] overload, but with the jar bytes already loaded (unit-test seam). */
     @Suppress("TooGenericExceptionCaught")
@@ -86,30 +89,33 @@ object HandsetsStarter {
         return try {
             AdbClient(target.host, target.port, key).use { client ->
                 client.connect()
-                ensureHandsets(target, client, jarBytes, port)
+                ensureHandsets(target, client, port) { jarBytes }
             }
         } catch (t: AdbAuthPendingException) {
             authPending(target, t)
         } catch (t: java.io.IOException) {
+            failed(target, t)
+        } catch (t: IllegalStateException) {
             failed(target, t)
         }
     }
 
     /**
      * Reuse an already-authorized peer connection from [PeerStarter]'s periodic loop. The port poll
-     * is deliberately before any jar write or process kill: a healthy daemon is ALREADY_UP, never
-     * restarted on each loop iteration.
+     * is deliberately before [jarBytesProvider] runs: a healthy daemon is ALREADY_UP, never
+     * restarted on each loop iteration, and never pays for a jar read/asset-read failure.
      */
     internal fun ensureHandsets(
         target: PeerTarget,
         client: AdbClient,
-        jarBytes: ByteArray,
         port: Int = HandsetsStartCommands.DEFAULT_PORT,
+        jarBytesProvider: () -> ByteArray?,
     ): PeerStarter.Result {
         val name = target.toString()
         if (HandsetsStartCommands.isUp(exec(client, HandsetsStartCommands.pollCommand(port)))) {
             return PeerStarter.Result(name, PeerStarter.Outcome.ALREADY_UP)
         }
+        val jarBytes = jarBytesProvider() ?: return assetFailure(target)
         pushJarIfNeeded(client, jarBytes)
         exec(client, HandsetsStartCommands.killCommand(port))
         Thread.sleep(KILL_SETTLE_MS)

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/PeerStarter.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/PeerStarter.kt
@@ -80,12 +80,15 @@ object PeerStarter {
             }
         val results =
             config.targets.map { target ->
-                val r = ensureShizuku(target, config.shizukuPkg, key)
-                record(context, r)
-                r
+                ensurePeerServices(context, target, config.shizukuPkg, key)
             }
-        PeerStartState.update(context, results)
-        return results
+        results.forEach { result ->
+            record(context, result.shizuku)
+            record(context, result.handsets)
+        }
+        val shizukuResults = results.map { it.shizuku }
+        PeerStartState.update(context, shizukuResults)
+        return shizukuResults
     }
 
     /**
@@ -107,28 +110,7 @@ object PeerStarter {
                 // "approve on the target" reminder we set on the target device.
                 clearTargetReminder(client)
 
-                if (isShizukuUp(client)) {
-                    return@use Result(name, Outcome.ALREADY_UP)
-                }
-
-                val apkPath =
-                    PeerStartCommands.parseApkPath(
-                        exec(client, PeerStartCommands.pmPath(shizukuPkg))
-                    )
-                if (apkPath == null) {
-                    return@use Result(name, Outcome.NOT_INSTALLED, "pkg=$shizukuPkg")
-                }
-
-                val libDir = PeerStartCommands.libDirFor(apkPath)
-                val out = exec(client, PeerStartCommands.starterCommand(libDir, shizukuPkg))
-                Log.i(TAG, "starter output for $name: ${out.trim().take(400)}")
-
-                Thread.sleep(START_SETTLE_MS)
-                if (isShizukuUp(client)) {
-                    Result(name, Outcome.STARTED)
-                } else {
-                    Result(name, Outcome.FAILED, out.trim().replace('\n', ' ').take(300))
-                }
+                ensureShizuku(target, shizukuPkg, client)
             }
         } catch (t: AdbAuthPendingException) {
             Log.i(TAG, "peer-start $name pending one-time approval")
@@ -138,6 +120,59 @@ object PeerStarter {
             val msg = t.message ?: t.javaClass.simpleName
             val outcome = if (isUnreachable(t)) Outcome.UNREACHABLE else Outcome.FAILED
             Result(name, outcome, msg.take(200))
+        }
+    }
+
+    private data class PeerServicesResult(val shizuku: Result, val handsets: Result)
+
+    /** One external-ADB connection per target and periodic iteration. */
+    private fun ensurePeerServices(
+        context: Context,
+        target: PeerTarget,
+        shizukuPkg: String,
+        key: AdbKey,
+    ): PeerServicesResult {
+        return try {
+            AdbClient(target.host, target.port, key).use { client ->
+                client.connect()
+                // This only preserves the toggle when adbd is already reachable and authorized;
+                // it cannot restore adbd or port 5555 after they are fully dead.
+                exec(client, PeerStartCommands.ADB_WIFI_ENABLED_REASSERT)
+                clearTargetReminder(client)
+                val shizuku = ensureShizuku(target, shizukuPkg, client)
+                val handsets = HandsetsStarter.ensureHandsets(context, target, client)
+                PeerServicesResult(shizuku, handsets)
+            }
+        } catch (t: AdbAuthPendingException) {
+            val pending =
+                Result(target.toString(), Outcome.AUTH_PENDING, "awaiting Always-allow on target")
+            PeerServicesResult(pending, pending)
+        } catch (t: Throwable) {
+            Log.w(TAG, "peer services $target failed", t)
+            val detail = (t.message ?: t.javaClass.simpleName).take(200)
+            val outcome = if (isUnreachable(t)) Outcome.UNREACHABLE else Outcome.FAILED
+            val failed = Result(target.toString(), outcome, detail)
+            PeerServicesResult(failed, failed)
+        }
+    }
+
+    private fun ensureShizuku(target: PeerTarget, shizukuPkg: String, client: AdbClient): Result {
+        val name = target.toString()
+        if (isShizukuUp(client)) return Result(name, Outcome.ALREADY_UP)
+        val apkPath =
+            PeerStartCommands.parseApkPath(exec(client, PeerStartCommands.pmPath(shizukuPkg)))
+                ?: return Result(name, Outcome.NOT_INSTALLED, "pkg=$shizukuPkg")
+        val out =
+            exec(
+                client,
+                PeerStartCommands.starterCommand(PeerStartCommands.libDirFor(apkPath), shizukuPkg),
+            )
+        Log.i(TAG, "starter output for $name: ${out.trim().take(400)}")
+        Thread.sleep(START_SETTLE_MS)
+        return if (isShizukuUp(client)) {
+            Result(name, Outcome.STARTED)
+        } else {
+            Result(name, Outcome.FAILED, out.trim().replace('\n', ' ').take(300))
         }
     }
 
@@ -193,6 +228,9 @@ object PeerStarter {
  * `control/bin/fire_peer_help.py:cmd_shizuku_start`.
  */
 object PeerStartCommands {
+    /** Preserve wireless debugging over an already-authorized peer ADB session. */
+    const val ADB_WIFI_ENABLED_REASSERT = "settings put global adb_wifi_enabled 1"
+
     /**
      * `[s]hizuku_server` (bracket trick) so the pgrep pattern never matches its own process. Emits
      * `up`/`down` so the reader is unambiguous.

--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/PeerStarter.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/PeerStarter.kt
@@ -140,7 +140,17 @@ object PeerStarter {
                 exec(client, PeerStartCommands.ADB_WIFI_ENABLED_REASSERT)
                 clearTargetReminder(client)
                 val shizuku = ensureShizuku(target, shizukuPkg, client)
-                val handsets = HandsetsStarter.ensureHandsets(context, target, client)
+                // Isolated so a Handsets-only failure can't clobber an already-successful shizuku
+                // result with the shared outer catch's single Result (see below).
+                val handsets =
+                    try {
+                        HandsetsStarter.ensureHandsets(context, target, client)
+                    } catch (t: Throwable) {
+                        Log.w(TAG, "handsets ensure $target failed", t)
+                        val detail = (t.message ?: t.javaClass.simpleName).take(200)
+                        val outcome = if (isUnreachable(t)) Outcome.UNREACHABLE else Outcome.FAILED
+                        Result(target.toString(), outcome, detail)
+                    }
                 PeerServicesResult(shizuku, handsets)
             }
         } catch (t: AdbAuthPendingException) {


### PR DESCRIPTION
## Summary
- Implements issue #62's top-priority audit recommendation: periodic peer Handsets-start, with the paired `adb_wifi_enabled` re-assert folded in.
- Both were previously Mac-only (`fire_help_monitor.py`); now agent-side, riding the existing ~20min peer-start loop.
- `PeerStarter.ensurePeerServices()` opens one ADB connection per target per iteration, re-asserts `adb_wifi_enabled=1`, then runs Shizuku-ensure and Handsets-ensure over that same connection (previously Handsets would have opened a second connection).
- `HandsetsStarter` gained a client-reuse entry point so the periodic loop doesn't pay for a second ADB handshake; a healthy daemon short-circuits to `ALREADY_UP` before any jar-push/kill/restart.

## Test plan
- [x] `:app:testDebugUnitTest` — all existing native-agent unit tests pass (no changes needed, none referenced the touched symbols)
- [x] `:app:compileDebugKotlin` — compiles clean
- [ ] Live fleet verification: confirm Handsets stays up and `adb_wifi_enabled` survives a full peer-start cycle without the Mac monitor running, on at least one device (s24 first per device-test-order convention)

Closes #62 (periodic peer handsets-start item; other #62 items tracked separately per the audit doc).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handset startup handling with clearer outcomes for already-running services, authentication, and connection failures.
  * Wireless debugging is now reasserted automatically when starting peer services.
  * Shizuku and handset services now report separate startup results.
  * Added handling for authorization-pending states and asset-loading failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->