### PR TITLE
chore: gitignore .ralph-tui/ (machine-local orchestration config)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ node_modules/
 /pnpm-lock.yaml
 *.apk
 *.jks
+
+# Ralph TUI project config is machine-local (absolute path to the
+# shared ops-djbclark control plane) — not shared repo content.
+.ralph-tui/


### PR DESCRIPTION
Part of the Ralph TUI multi-repo orchestration scaffolding (see ops-djbclark). .ralph-tui/config.toml contains a machine-specific absolute path, not shared repo content.