### PR TITLE
agent: bump native-agent to 0.9.5-handsets-adb-peer-loop

### DIFF
--- a/device/native-agent/app/build.gradle.kts
+++ b/device/native-agent/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "org.stayturgid.agent"
         minSdk = 26
         targetSdk = 36
-        versionCode = 22
-        versionName = "0.9.4-guided-setup"
+        versionCode = 23
+        versionName = "0.9.5-handsets-adb-peer-loop"
         val buildTimeUtc =
             System.getenv("SOURCE_DATE_EPOCH")?.toLongOrNull()?.let { Instant.ofEpochSecond(it) }
                 ?: Instant.now().truncatedTo(ChronoUnit.SECONDS)


### PR DESCRIPTION
## Summary
Releases #207 (already merged to master, `2f17861`) as `agent-v0.9.5`: folds Handsets keep-alive + `adb_wifi_enabled` re-assertion into the agent's existing ~20min periodic peer-start loop, removing the previous Mac-only dependency on `fire_help_monitor.py`.

## Build note (unrelated to this change)
`assembleRelease`/`assembleDebug` initially failed via the local `includeBuild` composite against `~/src/Shizuku/api` (stale cached intermediates from unrelated earlier work causing a Gradle type-cast error at `:api:demo`). Worked around with `-Pshizuku.composite=false` (published Maven artifacts) rather than debug the composite link, since that's out of scope for a version bump. Not a regression from this PR.

## Test plan
- [x] `:app:test` — all unit tests pass
- [x] `:app:assembleDebug` / `:app:assembleRelease` — both `BUILD SUCCESSFUL`
- [x] Installed on s24 (device-test-order: s24 first) — launches clean, no crash
- [ ] Live verification of the actual periodic-loop behavior (Handsets/adb_wifi_enabled surviving a full cycle without the Mac monitor) — pending, `logcat` shows no `StayTurgidPeer` activity yet since launch; need to confirm s24 has peer targets configured before a ~20min observation is meaningful

Do not merge until the live verification above is confirmed.