### PR TITLE
chore: bump ops-release.json to 1.2.2

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.2.1"
+  "version": "1.2.2"
 }


### PR DESCRIPTION
Coordinated release cut ops-v1.2.2.