### PR TITLE
fix: bump ADB auth-wait timeout from 60s to 4min, too short to be tappable

### DIFF
--- a/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/adb/AdbClient.kt
+++ b/device/native-agent/app/src/main/kotlin/org/stayturgid/agent/adb/AdbClient.kt
@@ -33,6 +33,19 @@ import org.stayturgid.agent.adb.AdbProtocol.A_WRTE
  * package rename, `BuildUtils.atLeast29` → inline SDK check, the debug `logd` import dropped, and a
  * configurable [readTimeoutMs] so the one-time "Always allow" authorization on a new target doesn't
  * block a background thread forever (upstream relied on the interactive UI to bound the wait).
+ *
+ * [readTimeoutMs]'s original 60s default was too short for this app's actual first-pairing
+ * workflow: the outer peer-start loop deliberately retries every ~3 minutes while a target is
+ * AUTH_PENDING (HostService.PEERSTART_PENDING_INTERVAL_MS, "retry fast so the operator can finish
+ * it quickly"), but a human being pinged to go tap "Always allow" realistically takes longer than
+ * 60s to notice, walk over, and respond. Once this attempt's socket times out, there's no live
+ * connection left for adbd to send its response through even though the dialog is still visibly
+ * rendered — so a "late" tap silently does nothing, and the next retry a few minutes later presents
+ * a brand-new, visually-identical dialog. Confirmed live 2026-08-02: 28 consecutive "Always allow"
+ * taps on hd8 all failed to stick this way. Bumped to 4 minutes — comfortably past realistic human
+ * response time (especially for a Telegram-ping-driven workflow, which adds its own latency before
+ * the human even looks at the device) while still bounded, not "forever". Has no effect on the
+ * already-authorized happy path, which returns near-instantly regardless of this value.
  */
 private const val TAG = "StayTurgidAdbClient"
 
@@ -41,7 +54,7 @@ class AdbClient(
     private val port: Int,
     private val key: AdbKey,
     private val connectTimeoutMs: Int = 5000,
-    private val readTimeoutMs: Int = 60_000,
+    private val readTimeoutMs: Int = 4 * 60 * 1000,
 ) : Closeable {
     private lateinit var socket: Socket
     private lateinit var plainInputStream: DataInputStream


### PR DESCRIPTION
## Problem
Confirmed live: hd8's "Allow USB debugging?" dialog for p7a's key kept re-appearing — 28 consecutive taps of "Always allow", none of them stuck, dialog still showing after ~2 hours of retries.

The peer-start loop deliberately retries every ~3 minutes while a target is `AUTH_PENDING` (`HostService.PEERSTART_PENDING_INTERVAL_MS`, "retry fast so the operator can finish it quickly" — good design). But each individual connection attempt only held its socket open for `readTimeoutMs=60s` waiting on the human's tap. A human pinged via Telegram to go authorize a device realistically takes longer than 60s to notice, walk over, and respond — once that window passes, the socket that originated the auth challenge is already closed, so a "late" tap has no live connection to actually authorize through. The dialog stays visually rendered (looks unchanged to the operator) but is now inert; the next retry a few minutes later presents a fresh, visually-identical dialog, and the cycle repeats indefinitely.

## Fix
Bumped `readTimeoutMs` `60_000` -> `4*60*1000` (4 min) in `AdbClient`. Comfortably past realistic human response time, still bounded (not "forever", preserving the original design intent). No effect on the already-authorized happy path, which returns near-instantly regardless of this value (confirmed via s24's real `ALREADY_UP` cycles this session).

## Test plan
- [x] `:app:test` passes
- [ ] Live re-verification on hd8/p7a once the new build is deployed