### PR TITLE
fix: derive fire-help's target hosts from inventory, not a manual patch

### DIFF
--- a/ansible/roles/control_node/templates/fire-help.plist.j2
+++ b/ansible/roles/control_node/templates/fire-help.plist.j2
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
+{#- Fire OS hosts this Mac should peer-help: any stayturgid inventory member
+    with stayturgid_no_local_adb set (matches fire_help_monitor.py's own
+    docstring intent and the existing filter pattern used elsewhere in this
+    role, e.g. the peer-help pubkey fetch task). -#}
+{%- set fire_help_hosts = [] -%}
+{%- for h in groups['stayturgid'] -%}
+{%- if hostvars[h].stayturgid_no_local_adb | default(false) | bool -%}
+{%- set _ = fire_help_hosts.append(h) -%}
+{%- endif -%}
+{%- endfor -%}
 <dict>
     <key>Label</key>
     <string>com.stayturgid.fire-help</string>
@@ -16,6 +26,8 @@
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
         <key>STAYTURGID_ADB</key>
         <string>/opt/homebrew/bin/adb</string>
+        <key>STAYTURGID_FIRE_HELP_HOSTS</key>
+        <string>{{ fire_help_hosts | join(',') }}</string>
     </dict>
     <key>StartInterval</key>
     <integer>{{ stayturgid_interval_sec | default(900) }}</integer>


### PR DESCRIPTION
## Problem
The fire-help launchd plist's `STAYTURGID_FIRE_HELP_HOSTS` env var was missing from `fire-help.plist.j2` entirely. `fire_help_monitor.py`'s own default filter value (`"fireos-device"`) never matches a real device alias in `devices.conf`, so the job silently no-op'd on every scheduled run for weeks with zero errors -- confirmed live 2026-08-02, its last real log entry was 2 weeks stale despite the launchd job "successfully" running on its 15-minute schedule the whole time.

An earlier session patched this by hand-editing the live plist file directly -- which got silently reverted the next time this template rendered, since the fix lived nowhere in git.

## Fix
Derive the host list from inventory instead of hardcoding it: any `stayturgid` group member with `stayturgid_no_local_adb` set (matches the script's own documented intent -- "for each host with STAYTURGID_NO_LOCAL_ADB semantics" -- and an existing filter pattern already used elsewhere in this same role, the peer-help pubkey fetch task). This correctly scales if another Fire OS device joins the fleet later, and can't silently drift out of sync with the live plist again since it's now the actual source of truth.

## Test plan
- [x] Standalone Jinja2 render test (mocking Ansible's `realpath`/`bool` filters): a 3-host fleet with only `hd8` flagged `stayturgid_no_local_adb` renders `hd8`; an all-false fleet renders empty (matches the script's own documented no-op behavior for that case)
- [ ] Live ansible apply + launchctl reload to confirm the rendered plist matches