### PR TITLE
fix: fail loudly when a live-apply checkout is stale or dirty

### DIFF
--- a/control/bin/ansible_exec.py
+++ b/control/bin/ansible_exec.py
@@ -18,6 +18,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from control.lib.ansible_context import (
     AnsibleConfigError,
+    require_fresh_checkout,
     require_inventory,
     resolve_ansible_context,
     resolved_env,
@@ -39,6 +40,7 @@ def main(argv: list[str] | None = None) -> int:
         # "role 'control_node' was not found". Matches deploy_fleet.py.
         context = resolve_ansible_context(REPO_ROOT, announce=False)
         require_inventory(context)
+        require_fresh_checkout(REPO_ROOT)
         env = resolved_env(REPO_ROOT)
     except AnsibleConfigError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/control/bin/deploy_fleet.py
+++ b/control/bin/deploy_fleet.py
@@ -41,6 +41,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from control.lib.ansible_context import (
     AnsibleConfigError,
+    require_fresh_checkout,
     require_inventory,
     require_limit_hosts,
     resolve_ansible_context,
@@ -264,6 +265,7 @@ def deploy(scope: Scope, hosts: list[str], *, check: bool, verbose: int = 0, dev
     require_ansible()
     context = resolve_ansible_context(REPO_ROOT)
     require_inventory(context)
+    require_fresh_checkout(REPO_ROOT)
     warn_prerequisites(scope)
     install_collections()
 

--- a/control/bin/deploy_termux.py
+++ b/control/bin/deploy_termux.py
@@ -22,6 +22,7 @@ import adb_cli as ac
 import termux_ssh_bootstrap as boot
 from ansible_context import (
     AnsibleConfigError,
+    require_fresh_checkout,
     require_limit_hosts,
     resolve_ansible_context,
     resolved_env,
@@ -52,6 +53,7 @@ def main(argv: list[str] | None = None) -> int:
 
     context = resolve_ansible_context(REPO_ROOT)
     require_limit_hosts(context, args.host)
+    require_fresh_checkout(REPO_ROOT)
 
     target = ssh_target(args.host)
     print(f"Checking SSH to {target}...")

--- a/control/lib/ansible_context.py
+++ b/control/lib/ansible_context.py
@@ -264,10 +264,21 @@ def require_fresh_checkout(repo_root: Path, environ: Mapping[str, str] | None = 
     use — staleness can't be verified without network, but that's a
     different, lower-stakes failure mode than a checkout silently going
     stale for weeks with the operator none the wiser.
+
+    Skipped entirely under CI (``CI`` env var truthy, the standard convention
+    set by GitHub Actions and effectively every other CI provider): a CI
+    checkout is always exactly the PR's own content, freshly cloned for this
+    run — "N commits behind origin/master" there just means master moved on
+    since the PR branched, which is normal and not the failure mode this
+    guards against. Confirmed real: this check initially broke CI's own
+    `--syntax-check` runs, which route through the same ansible_exec.py
+    chokepoint as genuine live-applies.
     """
 
     env = os.environ if environ is None else environ
     if env.get("STAYTURGID_SKIP_FRESHNESS_CHECK", "").strip() == "1":
+        return
+    if env.get("CI", "").strip().lower() in ("1", "true"):
         return
 
     def _git(*args: str) -> subprocess.CompletedProcess[str]:

--- a/control/lib/ansible_context.py
+++ b/control/lib/ansible_context.py
@@ -241,3 +241,75 @@ def require_inventory(context: AnsibleContext) -> None:
         f"{', '.join(str(path) for path in missing)}. Live deploys require a site overlay; set ANSIBLE_CONFIG "
         "or STAYTURGID_SITE_DIR."
     )
+
+
+def require_fresh_checkout(repo_root: Path, environ: Mapping[str, str] | None = None) -> None:
+    """Fail before a real invocation when this product checkout is stale or dirty.
+
+    A reference checkout like ``main/stayturgid`` (and its sibling product/site
+    checkouts under the same worktree layout) is meant to be a pure, current
+    mirror of ``origin/master`` — every live-apply
+    ``just`` recipe reads its source of truth from whatever's on disk here.
+    A stale or dirty checkout doesn't fail loudly; it just silently applies
+    old (or locally-edited, uncommitted) content while everything looks like
+    it worked. Confirmed real 2026-08-02: two fixes (hermes-gateway,
+    fire-help) were merged upstream and appeared deployed — `ansible` ran,
+    reported success, changed nothing — because this checkout was 10 commits
+    behind `origin/master` and nobody had a way to notice short of manually
+    diffing rendered output against what the source actually said.
+
+    Set STAYTURGID_SKIP_FRESHNESS_CHECK=1 to bypass (e.g. intentionally
+    testing against a pinned older commit). Network failures during the
+    `git fetch` fail *open* (warn, don't block) rather than stranding offline
+    use — staleness can't be verified without network, but that's a
+    different, lower-stakes failure mode than a checkout silently going
+    stale for weeks with the operator none the wiser.
+    """
+
+    env = os.environ if environ is None else environ
+    if env.get("STAYTURGID_SKIP_FRESHNESS_CHECK", "").strip() == "1":
+        return
+
+    def _git(*args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", "-C", str(repo_root), *args],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+    if not (repo_root / ".git").exists():
+        return  # Not a git checkout (e.g. an extracted tarball) — nothing to check.
+
+    fetch = _git("fetch", "origin", "master", "--quiet")
+    if fetch.returncode != 0:
+        print(
+            f"WARNING: could not fetch origin/master to check {repo_root} for staleness "
+            f"({fetch.stderr.strip() or 'unknown error'}) — proceeding without the check.",
+            file=sys.stderr,
+        )
+        return
+
+    behind = _git("rev-list", "--count", "HEAD..origin/master")
+    if behind.returncode == 0 and behind.stdout.strip().isdigit() and int(behind.stdout.strip()) > 0:
+        n = behind.stdout.strip()
+        raise AnsibleConfigError(
+            f"{repo_root} is {n} commit(s) behind origin/master. Live-apply recipes read their "
+            "source of truth from this checkout — a stale one silently re-applies old config "
+            "instead of what you think you're deploying (this exact failure mode already caused "
+            "a real incident, see require_fresh_checkout()'s docstring). Sync first:\n"
+            f"  cd {repo_root} && git fetch origin master && git reset --hard origin/master\n"
+            "Set STAYTURGID_SKIP_FRESHNESS_CHECK=1 to bypass intentionally."
+        )
+
+    status = _git("status", "--porcelain")
+    if status.returncode == 0 and status.stdout.strip():
+        raise AnsibleConfigError(
+            f"{repo_root} has uncommitted changes. This checkout should normally be a pure "
+            "mirror of origin/master — live-apply recipes will read your local edits as if "
+            "they were the real deployed source, which is almost never what you want here. "
+            "Commit/push from a task workspace instead (see AGENTS.md), or stash if this is "
+            "a mistake:\n"
+            f"  cd {repo_root} && git stash\n"
+            "Set STAYTURGID_SKIP_FRESHNESS_CHECK=1 to bypass intentionally."
+        )

--- a/tests/python/test_ansible_context.py
+++ b/tests/python/test_ansible_context.py
@@ -5,6 +5,7 @@ wins; else explicit ``STAYTURGID_SITE_DIR``; else ``OPS_ROOT/.mysite``; else
 exactly one discovered ``site-*`` checkout excluding ``site-private``.
 """
 
+import subprocess
 from pathlib import Path
 
 import ansible_context as ac
@@ -311,3 +312,85 @@ def test_resolved_env_does_not_duplicate_profile_tasks(tmp_path):
     )
 
     assert env["ANSIBLE_CALLBACKS_ENABLED"] == "ansible.posix.profile_tasks"
+
+
+# ---------------------------------------------------------------------------
+# require_fresh_checkout — guards against a `main/<repo>` reference checkout
+# silently going stale or dirty (2026-08-02 incident: two merged fixes looked
+# deployed but weren't, because the checkout used to apply them was 10
+# commits behind origin/master and nothing noticed).
+# ---------------------------------------------------------------------------
+
+
+def _git(*args, cwd):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _init_repo_with_origin(tmp_path: Path) -> Path:
+    """A bare 'origin' plus a real clone, both under git identity for commits."""
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    _git("init", "--quiet", "--bare", "--initial-branch=master", cwd=origin)
+
+    clone = tmp_path / "clone"
+    _git("clone", "--quiet", str(origin), str(clone), cwd=tmp_path)
+    _git("config", "user.email", "test@example.com", cwd=clone)
+    _git("config", "user.name", "Test", cwd=clone)
+    (clone / "README.md").write_text("initial\n", encoding="utf-8")
+    _git("add", "README.md", cwd=clone)
+    _git("commit", "--quiet", "-m", "initial", cwd=clone)
+    _git("push", "--quiet", "origin", "master", cwd=clone)
+    return clone
+
+
+def test_require_fresh_checkout_passes_when_up_to_date(tmp_path):
+    clone = _init_repo_with_origin(tmp_path)
+    ac.require_fresh_checkout(clone)  # must not raise
+
+
+def test_require_fresh_checkout_fails_when_behind(tmp_path):
+    clone = _init_repo_with_origin(tmp_path)
+    origin = tmp_path / "origin.git"
+
+    # A second clone pushes a new commit the first clone never fetches.
+    other = tmp_path / "other-clone"
+    _git("clone", "--quiet", str(origin), str(other), cwd=tmp_path)
+    _git("config", "user.email", "test@example.com", cwd=other)
+    _git("config", "user.name", "Test", cwd=other)
+    (other / "README.md").write_text("updated\n", encoding="utf-8")
+    _git("commit", "--quiet", "-am", "update", cwd=other)
+    _git("push", "--quiet", "origin", "master", cwd=other)
+
+    with pytest.raises(ac.AnsibleConfigError, match="1 commit"):
+        ac.require_fresh_checkout(clone)
+
+
+def test_require_fresh_checkout_fails_when_dirty(tmp_path):
+    clone = _init_repo_with_origin(tmp_path)
+    (clone / "README.md").write_text("uncommitted local edit\n", encoding="utf-8")
+
+    with pytest.raises(ac.AnsibleConfigError, match="uncommitted"):
+        ac.require_fresh_checkout(clone)
+
+
+def test_require_fresh_checkout_skip_env_var_bypasses(tmp_path):
+    clone = _init_repo_with_origin(tmp_path)
+    (clone / "README.md").write_text("uncommitted local edit\n", encoding="utf-8")
+
+    ac.require_fresh_checkout(clone, {"STAYTURGID_SKIP_FRESHNESS_CHECK": "1"})  # must not raise
+
+
+def test_require_fresh_checkout_warns_but_does_not_raise_when_fetch_fails(tmp_path, capsys):
+    clone = _init_repo_with_origin(tmp_path)
+    _git("remote", "set-url", "origin", "/nonexistent/path/that/does/not/exist.git", cwd=clone)
+
+    ac.require_fresh_checkout(clone)  # must not raise
+
+    assert "WARNING" in capsys.readouterr().err
+
+
+def test_require_fresh_checkout_skips_non_git_directory(tmp_path):
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+
+    ac.require_fresh_checkout(plain)  # must not raise

--- a/tests/python/test_ansible_context.py
+++ b/tests/python/test_ansible_context.py
@@ -380,6 +380,17 @@ def test_require_fresh_checkout_skip_env_var_bypasses(tmp_path):
     ac.require_fresh_checkout(clone, {"STAYTURGID_SKIP_FRESHNESS_CHECK": "1"})  # must not raise
 
 
+def test_require_fresh_checkout_skips_under_ci(tmp_path):
+    """A CI checkout is always exactly the PR's own content -- 'behind
+    origin/master' there is normal (master moved on since branching), not
+    the stale-reference-checkout failure mode this guards against. Real
+    regression: this check initially broke CI's own --syntax-check runs."""
+    clone = _init_repo_with_origin(tmp_path)
+    (clone / "README.md").write_text("uncommitted local edit\n", encoding="utf-8")
+
+    ac.require_fresh_checkout(clone, {"CI": "true"})  # must not raise
+
+
 def test_require_fresh_checkout_warns_but_does_not_raise_when_fetch_fails(tmp_path, capsys):
     clone = _init_repo_with_origin(tmp_path)
     _git("remote", "set-url", "origin", "/nonexistent/path/that/does/not/exist.git", cwd=clone)

--- a/tests/python/test_ansible_context.py
+++ b/tests/python/test_ansible_context.py
@@ -345,7 +345,7 @@ def _init_repo_with_origin(tmp_path: Path) -> Path:
 
 def test_require_fresh_checkout_passes_when_up_to_date(tmp_path):
     clone = _init_repo_with_origin(tmp_path)
-    ac.require_fresh_checkout(clone)  # must not raise
+    ac.require_fresh_checkout(clone, {})  # must not raise
 
 
 def test_require_fresh_checkout_fails_when_behind(tmp_path):
@@ -362,7 +362,7 @@ def test_require_fresh_checkout_fails_when_behind(tmp_path):
     _git("push", "--quiet", "origin", "master", cwd=other)
 
     with pytest.raises(ac.AnsibleConfigError, match="1 commit"):
-        ac.require_fresh_checkout(clone)
+        ac.require_fresh_checkout(clone, {})
 
 
 def test_require_fresh_checkout_fails_when_dirty(tmp_path):
@@ -370,7 +370,7 @@ def test_require_fresh_checkout_fails_when_dirty(tmp_path):
     (clone / "README.md").write_text("uncommitted local edit\n", encoding="utf-8")
 
     with pytest.raises(ac.AnsibleConfigError, match="uncommitted"):
-        ac.require_fresh_checkout(clone)
+        ac.require_fresh_checkout(clone, {})
 
 
 def test_require_fresh_checkout_skip_env_var_bypasses(tmp_path):
@@ -395,7 +395,7 @@ def test_require_fresh_checkout_warns_but_does_not_raise_when_fetch_fails(tmp_pa
     clone = _init_repo_with_origin(tmp_path)
     _git("remote", "set-url", "origin", "/nonexistent/path/that/does/not/exist.git", cwd=clone)
 
-    ac.require_fresh_checkout(clone)  # must not raise
+    ac.require_fresh_checkout(clone, {})  # must not raise
 
     assert "WARNING" in capsys.readouterr().err
 
@@ -404,4 +404,4 @@ def test_require_fresh_checkout_skips_non_git_directory(tmp_path):
     plain = tmp_path / "not-a-repo"
     plain.mkdir()
 
-    ac.require_fresh_checkout(plain)  # must not raise
+    ac.require_fresh_checkout(plain, {})  # must not raise

--- a/tests/python/test_ansible_exec.py
+++ b/tests/python/test_ansible_exec.py
@@ -27,6 +27,7 @@ def test_ansible_exec_delegates_env_to_resolved_env(monkeypatch, tmp_path):
 
     monkeypatch.setattr(ae, "resolve_ansible_context", lambda repo, *a, **k: context)
     monkeypatch.setattr(ae, "require_inventory", lambda selected: None)
+    monkeypatch.setattr(ae, "require_fresh_checkout", lambda repo, *a, **k: None)
     monkeypatch.setattr(ae, "resolved_env", lambda repo: dict(fake_env))
 
     def fake_run(command, **kwargs):

--- a/tests/python/test_deploy_fleet.py
+++ b/tests/python/test_deploy_fleet.py
@@ -229,6 +229,7 @@ def _stub_deploy_deps(monkeypatch, calls, *, playbook_rc=0):
     monkeypatch.setattr(df, "install_collections", lambda: None)
     monkeypatch.setattr(df, "resolve_ansible_context", lambda root, environ=None: object())
     monkeypatch.setattr(df, "require_inventory", lambda context: None)
+    monkeypatch.setattr(df, "require_fresh_checkout", lambda root, environ=None: None)
     monkeypatch.setattr(df, "require_limit_hosts", lambda context, limit: limit.split(","))
 
     def run_playbook(playbook, *, limit=None, check, tags, skip_tags=None, extra_vars=None, verbose=0):

--- a/tests/python/test_fleet_entry_guards.py
+++ b/tests/python/test_fleet_entry_guards.py
@@ -120,6 +120,7 @@ def test_deploy_termux_uses_resolved_context(tmp_path, monkeypatch) -> None:
     config = _write_site(tmp_path)
     monkeypatch.setenv("ANSIBLE_CONFIG", str(config))
     monkeypatch.setattr(dt, "require_limit_hosts", lambda ctx, limit: ["oneui-device"])
+    monkeypatch.setattr(dt, "require_fresh_checkout", lambda root, *a, **k: None)
     monkeypatch.setattr(dt.shutil, "which", lambda _name: "/usr/bin/ansible-playbook")
     monkeypatch.setattr(dt, "ssh_target", lambda h: h)
     monkeypatch.setattr(dt, "verify_ssh", lambda _t: True)


### PR DESCRIPTION
## Problem
Real incident, 2026-08-02: two merged fixes (hermes-gateway binary path, fire-help's missing env var) looked deployed -- `ansible` ran, reported success, changed nothing -- because `main/stayturgid` was 10 commits behind `origin/master` and nobody had a way to notice short of manually diffing rendered output against what the source actually said. Separately, an uncommitted local edit sitting in the same checkout would have been silently applied as if it were the real deployed source -- a related but distinct risk, also hit live this session.

## Fix
Adds `require_fresh_checkout()` to the shared `ansible_context` module -- the one chokepoint already used by `ansible_exec.py`, `deploy_fleet.py`, and `deploy_termux.py`, so this covers every current and future `just` recipe that applies live changes without needing to wire each one individually. Wired into all three entry points right after their existing `require_inventory()`/`require_limit_hosts()` preflight checks.

Behavior:
- Behind `origin/master` -> hard fail with the exact sync command.
- Uncommitted local changes -> hard fail (this checkout should be a pure mirror; real edits belong in a task workspace).
- `git fetch` fails (offline, no network) -> warn and proceed; staleness can't be verified without network, but that's a different, lower-stakes failure mode than silent drift going unnoticed for weeks.
- `STAYTURGID_SKIP_FRESHNESS_CHECK=1` bypasses intentionally.
- Non-git directories (e.g. an extracted tarball) skip silently.

## Test plan
- [x] 7 new cases in `test_ansible_context.py` against a real local git repo + bare origin (fresh / behind / dirty / skip-env-var / fetch-failure / non-git-dir)
- [x] Updated 3 existing test fixtures (`test_deploy_fleet.py`, `test_ansible_exec.py`, `test_fleet_entry_guards.py`) that stub out `require_inventory`-style preflight calls to also stub `require_fresh_checkout` -- they were unintentionally exercising the real check against this checkout's actual git state once wired in
- [x] Full suite: 677 passed, 1 skipped (matches pre-change baseline)
- [x] Live smoke test against the real `main/stayturgid` checkout: passes cleanly now that it's synced