### PR TITLE
fix: replace three more hardcoded-list-duplicates-a-source antipatterns

### DIFF
--- a/control/bin/firerpa_heal.py
+++ b/control/bin/firerpa_heal.py
@@ -201,24 +201,30 @@ def main(argv: list[str] | None = None) -> int:
         if not target:
             print(f"Unknown host: {args.host}. Known: {[t.alias for t in fleet]}", file=sys.stderr)
             return 1
-        targets[target.alias] = target.ip
+        targets[target.alias] = target
     elif args.all:
-        targets = {t.alias: t.ip for t in fleet if t.enabled}
+        targets = {t.alias: t for t in fleet if t.enabled}
     else:
         print("Specify --host <alias> or --all", file=sys.stderr)
         return 1
 
     trim_log(os.path.join(LOG_ROOT, "logs", LOG_NAME), max_age_days=30, max_lines=2000)
     rc = 0
-    for alias, ip in targets.items():
+    for alias, target in targets.items():
         try:
-            results = heal_device(ip, args.port)
+            results = heal_device(target.ip, args.port)
             if results.get("firerpa") == "unreachable":
-                if alias == "hd8":
-                    _log(INFO, "%s: FIRERPA not running (expected)" % alias)
+                # firerpa_recovery_mode is inventory-declared (Ansible hostvars,
+                # not a hardcoded alias) -- e.g. "control-node-adb" means Fire
+                # OS prevents Termux from executing shell_data_file content, so
+                # a Mac-ADB-supplied UID 2000 is the expected/permanent state,
+                # not a real outage. See site-djbclark inventory/hosts.yml for
+                # which hosts declare this and why.
+                if target.recovery_mode == "control-node-adb":
+                    _log(INFO, "%s: FIRERPA not running (expected, recovery_mode=%s)" % (alias, target.recovery_mode))
                 rc = 1
         except Exception as e:
-            _log(ERR, "%s (%s): heal error: %s" % (alias, ip, e))
+            _log(ERR, "%s (%s): heal error: %s" % (alias, target.ip, e))
             rc = 1
 
     return rc

--- a/control/landing/state.py
+++ b/control/landing/state.py
@@ -128,9 +128,20 @@ def _known_android_devices() -> frozenset[str]:
 
     repo_root = Path(__file__).resolve().parents[2]
     try:
-        data = inventory_list(repo_root)
+        # Bounded: this runs on a Flask request path (landing.py calls it per
+        # dashboard request, though lru_cache means only the first request
+        # actually pays for it) and must not hang the response indefinitely
+        # if ansible-inventory's dynamic source is slow or wedged.
+        data = inventory_list(repo_root, timeout=30)
         hosts = parse_inventory_hosts(data)
-    except (AnsibleConfigError, subprocess.CalledProcessError, OSError, ValueError):
+    except (
+        AnsibleConfigError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        OSError,
+        ValueError,
+        KeyError,
+    ):
         return _KNOWN_ANDROID_DEVICES_FALLBACK
     return frozenset(hosts) if hosts else _KNOWN_ANDROID_DEVICES_FALLBACK
 

--- a/control/landing/state.py
+++ b/control/landing/state.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import functools
 import json
 import os
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -102,7 +104,35 @@ def service_sort_key(s: dict[str, Any]) -> tuple:
 
 
 EXAMPLE_DEVICE_NAMES: set[str] = {"fireos-device", "oneui-device", "stock-android-device"}
-KNOWN_ANDROID_DEVICES: set[str] = {"hd8", "p7a", "s24"}
+
+# Last-resort fallback only -- used when the live Ansible inventory can't be
+# resolved (tests, no site configured). _known_android_devices() below is the
+# real source of truth; this operator's own fleet aliases are not portable to
+# a different site/operator, which is exactly why they shouldn't be the
+# primary source in shared dashboard code.
+_KNOWN_ANDROID_DEVICES_FALLBACK: frozenset[str] = frozenset({"hd8", "p7a", "s24"})
+
+
+@functools.lru_cache(maxsize=1)
+def _known_android_devices() -> frozenset[str]:
+    """Real fleet device aliases from the active Ansible inventory.
+
+    A service whose ``group`` is set directly to a device alias (rather than
+    the generic ``"devices"``/``"android"`` group) is classified Android by
+    matching against this set -- e.g. a per-device dashboard entry. Cached
+    for the process lifetime: landing.py calls this per dashboard request,
+    and an inventory shell-out per request would be a real cost.
+    """
+    from control.lib.ansible_context import AnsibleConfigError
+    from control.lib.fleet_targets import inventory_list, parse_inventory_hosts
+
+    repo_root = Path(__file__).resolve().parents[2]
+    try:
+        data = inventory_list(repo_root)
+        hosts = parse_inventory_hosts(data)
+    except (AnsibleConfigError, subprocess.CalledProcessError, OSError, ValueError):
+        return _KNOWN_ANDROID_DEVICES_FALLBACK
+    return frozenset(hosts) if hosts else _KNOWN_ANDROID_DEVICES_FALLBACK
 
 
 def filter_example_devices(services: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -128,7 +158,7 @@ def get_os_category(s: dict[str, Any]) -> str:
         return "MacOS"
     elif group in ("linux", "computer", "computers"):
         return "Linux"
-    elif group in ("devices", "android") or group in KNOWN_ANDROID_DEVICES:
+    elif group in ("devices", "android") or group in _known_android_devices():
         return "Android"
     return "Other"
 

--- a/control/lib/fleet_targets.py
+++ b/control/lib/fleet_targets.py
@@ -27,8 +27,14 @@ def parse_inventory_hosts(data: dict, group: str = "stayturgid") -> list[str]:
     return list(hosts.keys())
 
 
-def inventory_list(repo_root: Path, group: str = "stayturgid") -> dict:
-    """Load the selected site's evaluated Ansible inventory."""
+def inventory_list(repo_root: Path, group: str = "stayturgid", *, timeout: float | None = None) -> dict:
+    """Load the selected site's evaluated Ansible inventory.
+
+    *timeout* is unbounded by default, matching every existing caller's
+    established behavior (a slow dynamic inventory source can legitimately
+    take a while). Pass an explicit bound for a caller on a request path
+    that must not hang -- e.g. a web request handler.
+    """
 
     context = resolve_ansible_context(repo_root)
     require_inventory(context)
@@ -39,6 +45,7 @@ def inventory_list(repo_root: Path, group: str = "stayturgid") -> dict:
         check=True,
         env=resolved_env(repo_root),
         cwd=repo_root,
+        timeout=timeout,
     )
     return json.loads(result.stdout)
 

--- a/tests/python/test_firerpa_heal.py
+++ b/tests/python/test_firerpa_heal.py
@@ -1,0 +1,70 @@
+import sys
+import types
+
+# firerpa_heal.py hard-requires the real lamda-client hardware SDK at import
+# time (sys.exit(1) on ImportError) -- not installed in CI/dev. Stub it so
+# main()'s pure alias-resolution logic can be exercised without the package.
+if "lamda" not in sys.modules:
+    _lamda_pkg = types.ModuleType("lamda")
+    _lamda_client = types.ModuleType("lamda.client")
+    _lamda_client.Device = object
+    _lamda_pkg.client = _lamda_client
+    sys.modules["lamda"] = _lamda_pkg
+    sys.modules["lamda.client"] = _lamda_client
+
+from control.bin import firerpa_heal  # noqa: E402
+from control.lib.firerpa_fleet import FirerpaTarget  # noqa: E402
+
+
+def test_main_logs_expected_when_recovery_mode_explains_unreachable(monkeypatch):
+    """A device whose inventory declares firerpa_recovery_mode:
+    control-node-adb is expected to show FIRERPA as unreachable (Fire OS
+    blocks Termux's own shell_data_file execution there; Mac ADB supplies
+    UID 2000 instead) -- confirmed real for hd8 2026-08-02. This must be
+    driven by the inventory-derived field, not a hardcoded alias, so any
+    other host declared the same way gets the same "expected" annotation."""
+    calls: list[tuple[int, str]] = []
+    monkeypatch.setattr(firerpa_heal, "_log", lambda level, msg: calls.append((level, msg)))
+    monkeypatch.setattr(firerpa_heal, "trim_log", lambda *a, **k: None)
+    monkeypatch.setattr(firerpa_heal, "heal_device", lambda ip, port: {"firerpa": "unreachable"})
+    target = FirerpaTarget(alias="hd8", ip="1.2.3.4", enabled=True, recovery_mode="control-node-adb")
+    monkeypatch.setattr("control.lib.firerpa_fleet.get_fleet", lambda: [target])
+
+    rc = firerpa_heal.main(["--all"])
+
+    assert rc == 1
+    assert any("expected" in msg and "hd8" in msg for _level, msg in calls)
+
+
+def test_main_does_not_suppress_for_a_different_alias_with_expected_recovery_mode(monkeypatch):
+    """The suppression must follow recovery_mode, not a hardcoded alias --
+    an alias other than "hd8" with the same declared recovery_mode still
+    gets the "expected" annotation."""
+    calls: list[tuple[int, str]] = []
+    monkeypatch.setattr(firerpa_heal, "_log", lambda level, msg: calls.append((level, msg)))
+    monkeypatch.setattr(firerpa_heal, "trim_log", lambda *a, **k: None)
+    monkeypatch.setattr(firerpa_heal, "heal_device", lambda ip, port: {"firerpa": "unreachable"})
+    target = FirerpaTarget(alias="some-other-device", ip="9.9.9.9", enabled=True, recovery_mode="control-node-adb")
+    monkeypatch.setattr("control.lib.firerpa_fleet.get_fleet", lambda: [target])
+
+    rc = firerpa_heal.main(["--all"])
+
+    assert rc == 1
+    assert any("expected" in msg and "some-other-device" in msg for _level, msg in calls)
+
+
+def test_main_does_not_suppress_for_normal_unreachable(monkeypatch):
+    """A device with no special recovery_mode gets no "expected" annotation
+    when FIRERPA is unreachable -- this is a real outage, not documented
+    inventory-declared behavior."""
+    calls: list[tuple[int, str]] = []
+    monkeypatch.setattr(firerpa_heal, "_log", lambda level, msg: calls.append((level, msg)))
+    monkeypatch.setattr(firerpa_heal, "trim_log", lambda *a, **k: None)
+    monkeypatch.setattr(firerpa_heal, "heal_device", lambda ip, port: {"firerpa": "unreachable"})
+    target = FirerpaTarget(alias="s24", ip="5.6.7.8", enabled=True, recovery_mode="none")
+    monkeypatch.setattr("control.lib.firerpa_fleet.get_fleet", lambda: [target])
+
+    rc = firerpa_heal.main(["--all"])
+
+    assert rc == 1
+    assert calls == []

--- a/tests/python/test_firerpa_heal.py
+++ b/tests/python/test_firerpa_heal.py
@@ -3,8 +3,14 @@ import types
 
 # firerpa_heal.py hard-requires the real lamda-client hardware SDK at import
 # time (sys.exit(1) on ImportError) -- not installed in CI/dev. Stub it so
-# main()'s pure alias-resolution logic can be exercised without the package.
-if "lamda" not in sys.modules:
+# main()'s pure alias-resolution logic can be exercised without the package,
+# then remove the stub again once the import completes: firerpa_heal.py only
+# needs `lamda.client.Device` at its own import time (it caches what it needs
+# into its own module namespace), and leaving a fake `lamda` package sitting
+# in sys.modules for the rest of the pytest process could shadow a real
+# import elsewhere.
+_injected_lamda = "lamda" not in sys.modules
+if _injected_lamda:
     _lamda_pkg = types.ModuleType("lamda")
     _lamda_client = types.ModuleType("lamda.client")
     _lamda_client.Device = object
@@ -12,7 +18,13 @@ if "lamda" not in sys.modules:
     sys.modules["lamda"] = _lamda_pkg
     sys.modules["lamda.client"] = _lamda_client
 
-from control.bin import firerpa_heal  # noqa: E402
+try:
+    from control.bin import firerpa_heal  # noqa: E402
+finally:
+    if _injected_lamda:
+        sys.modules.pop("lamda", None)
+        sys.modules.pop("lamda.client", None)
+
 from control.lib.firerpa_fleet import FirerpaTarget  # noqa: E402
 
 

--- a/tests/python/test_heartbeat_freshness_sync.py
+++ b/tests/python/test_heartbeat_freshness_sync.py
@@ -1,0 +1,58 @@
+"""Guards the heartbeat-freshness threshold that must agree across three
+independent runtimes: Python (Mac-side health check), CFEngine (on-device
+liveness check), and Kotlin (native-agent's own invariant test).
+
+All three currently carry a literal 420 (seconds) with a comment saying
+"MUST match" the others (#86, unify rule) -- there is no single file they
+can all import from, since they run in different languages/processes on
+different machines. This test is the enforcement the comments alone can't
+provide: it fails CI the moment any one of the three literals is changed
+without the others.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+FLEET_HEALTH_PY = REPO_ROOT / "control" / "lib" / "fleet_health.py"
+STAYTURGID_CF = REPO_ROOT / "device" / "termux" / "cfengine" / "policy" / "stayturgid.cf"
+HEARTBEAT_WRITER_TEST_KT = (
+    REPO_ROOT
+    / "device"
+    / "native-agent"
+    / "app"
+    / "src"
+    / "test"
+    / "kotlin"
+    / "org"
+    / "stayturgid"
+    / "agent"
+    / "HeartbeatWriterTest.kt"
+)
+
+
+def _extract(path: Path, pattern: str) -> int:
+    text = path.read_text(encoding="utf-8")
+    match = re.search(pattern, text)
+    assert match, f"{path}: pattern not found: {pattern!r}"
+    return int(match.group(1))
+
+
+def test_heartbeat_freshness_threshold_matches_across_python_cfengine_kotlin() -> None:
+    python_value = _extract(FLEET_HEALTH_PY, r"AGENT_HEARTBEAT_FRESH_SEC\s*=\s*(\d+)")
+    cfengine_value = _extract(STAYTURGID_CF, r'"freshness_sec"\s*string\s*=>\s*"(\d+)"')
+    kotlin_value = _extract(HEARTBEAT_WRITER_TEST_KT, r"freshnessSec\s*=\s*(\d+)L")
+
+    assert python_value == cfengine_value == kotlin_value, (
+        f"Heartbeat freshness threshold has drifted out of sync (unify rule, #86): "
+        f"fleet_health.py AGENT_HEARTBEAT_FRESH_SEC={python_value}, "
+        f"stayturgid.cf freshness_sec={cfengine_value}, "
+        f"HeartbeatWriterTest.kt freshnessSec={kotlin_value}. "
+        "The on-device (CFEngine) and Mac-side (Python) liveness checks read "
+        "the same heartbeat file with this same threshold and must agree, or "
+        "one side will flag an agent stale/missing while the other doesn't. "
+        "Update all three together."
+    )

--- a/tests/python/test_landing_state.py
+++ b/tests/python/test_landing_state.py
@@ -154,3 +154,61 @@ def test_filter_example_devices_kept_when_no_actual_devices() -> None:
     filtered = state.filter_example_devices(services)
     labels = {s["label"] for s in filtered}
     assert labels == {"oneui-device FIRERPA", "stock-android-device FIRERPA", "fireos-device FIRERPA"}
+
+
+# ---------------------------------------------------------------------------
+# _known_android_devices() -- registry-driven replacement for the previously
+# hardcoded KNOWN_ANDROID_DEVICES = {"hd8", "p7a", "s24"} literal (2026-08-03
+# cleanup: that hardcoded fleet-alias set is this operator's own device
+# names, not portable to a different site/operator using this same shared
+# dashboard code).
+# ---------------------------------------------------------------------------
+
+
+def test_known_android_devices_derives_from_inventory(monkeypatch) -> None:
+    state._known_android_devices.cache_clear()
+    monkeypatch.setattr("control.lib.fleet_targets.inventory_list", lambda repo_root: {"fake": "data"})
+    monkeypatch.setattr(
+        "control.lib.fleet_targets.parse_inventory_hosts", lambda data, group="stayturgid": ["alpha", "beta"]
+    )
+
+    assert state._known_android_devices() == frozenset({"alpha", "beta"})
+    state._known_android_devices.cache_clear()
+
+
+def test_known_android_devices_falls_back_on_inventory_error(monkeypatch) -> None:
+    from control.lib.ansible_context import AnsibleConfigError
+
+    state._known_android_devices.cache_clear()
+
+    def raise_error(repo_root):
+        raise AnsibleConfigError("no site configured")
+
+    monkeypatch.setattr("control.lib.fleet_targets.inventory_list", raise_error)
+
+    assert state._known_android_devices() == state._KNOWN_ANDROID_DEVICES_FALLBACK
+    state._known_android_devices.cache_clear()
+
+
+def test_known_android_devices_falls_back_on_empty_inventory(monkeypatch) -> None:
+    state._known_android_devices.cache_clear()
+    monkeypatch.setattr("control.lib.fleet_targets.inventory_list", lambda repo_root: {"fake": "data"})
+    monkeypatch.setattr("control.lib.fleet_targets.parse_inventory_hosts", lambda data, group="stayturgid": [])
+
+    assert state._known_android_devices() == state._KNOWN_ANDROID_DEVICES_FALLBACK
+    state._known_android_devices.cache_clear()
+
+
+def test_get_os_category_matches_inventory_derived_alias(monkeypatch) -> None:
+    """A service with group set directly to a real inventory device alias
+    (a per-device dashboard entry) is classified Android -- driven by live
+    inventory, not a hardcoded literal."""
+    state._known_android_devices.cache_clear()
+    monkeypatch.setattr("control.lib.fleet_targets.inventory_list", lambda repo_root: {"fake": "data"})
+    monkeypatch.setattr(
+        "control.lib.fleet_targets.parse_inventory_hosts", lambda data, group="stayturgid": ["some-new-device"]
+    )
+
+    assert state.get_os_category({"group": "some-new-device"}) == "Android"
+    assert state.get_os_category({"group": "unrelated-alias"}) == "Other"
+    state._known_android_devices.cache_clear()

--- a/tests/python/test_landing_state.py
+++ b/tests/python/test_landing_state.py
@@ -167,7 +167,7 @@ def test_filter_example_devices_kept_when_no_actual_devices() -> None:
 
 def test_known_android_devices_derives_from_inventory(monkeypatch) -> None:
     state._known_android_devices.cache_clear()
-    monkeypatch.setattr("control.lib.fleet_targets.inventory_list", lambda repo_root: {"fake": "data"})
+    monkeypatch.setattr("control.lib.fleet_targets.inventory_list", lambda repo_root, timeout=None: {"fake": "data"})
     monkeypatch.setattr(
         "control.lib.fleet_targets.parse_inventory_hosts", lambda data, group="stayturgid": ["alpha", "beta"]
     )
@@ -181,7 +181,7 @@ def test_known_android_devices_falls_back_on_inventory_error(monkeypatch) -> Non
 
     state._known_android_devices.cache_clear()
 
-    def raise_error(repo_root):
+    def raise_error(repo_root, timeout=None):
         raise AnsibleConfigError("no site configured")
 
     monkeypatch.setattr("control.lib.fleet_targets.inventory_list", raise_error)
@@ -192,7 +192,7 @@ def test_known_android_devices_falls_back_on_inventory_error(monkeypatch) -> Non
 
 def test_known_android_devices_falls_back_on_empty_inventory(monkeypatch) -> None:
     state._known_android_devices.cache_clear()
-    monkeypatch.setattr("control.lib.fleet_targets.inventory_list", lambda repo_root: {"fake": "data"})
+    monkeypatch.setattr("control.lib.fleet_targets.inventory_list", lambda repo_root, timeout=None: {"fake": "data"})
     monkeypatch.setattr("control.lib.fleet_targets.parse_inventory_hosts", lambda data, group="stayturgid": [])
 
     assert state._known_android_devices() == state._KNOWN_ANDROID_DEVICES_FALLBACK
@@ -204,7 +204,7 @@ def test_get_os_category_matches_inventory_derived_alias(monkeypatch) -> None:
     (a per-device dashboard entry) is classified Android -- driven by live
     inventory, not a hardcoded literal."""
     state._known_android_devices.cache_clear()
-    monkeypatch.setattr("control.lib.fleet_targets.inventory_list", lambda repo_root: {"fake": "data"})
+    monkeypatch.setattr("control.lib.fleet_targets.inventory_list", lambda repo_root, timeout=None: {"fake": "data"})
     monkeypatch.setattr(
         "control.lib.fleet_targets.parse_inventory_hosts", lambda data, group="stayturgid": ["some-new-device"]
     )


### PR DESCRIPTION
## Summary
Follow-up to the Caddy port-registry fix (#220 / site-djbclark#70): a survey for the same anti-pattern elsewhere (a hardcoded list standing in for data that already has a real authoritative source) turned up three more real instances in this repo.

- `control/bin/firerpa_heal.py`: `if alias == "hd8"` suppressed a "FIRERPA unreachable" alert by hardcoding the one device name it currently applies to. The actual reason (`firerpa_recovery_mode: control-node-adb`, declared in site-djbclark's `inventory/hosts.yml`) was already being parsed into `FirerpaTarget.recovery_mode` two lines above and then discarded. Now checks `target.recovery_mode == "control-node-adb"` instead — correct for any host declared this way, not just hd8, and stops silently suppressing/failing-to-suppress if hd8's declared mode ever changes.
- `control/landing/state.py`: `KNOWN_ANDROID_DEVICES = {"hd8", "p7a", "s24"}` was a hardcoded fleet-alias literal used to classify dashboard entries as Android when `group` is set directly to a device alias. Replaced with `_known_android_devices()`, which derives the real alias list from the live Ansible inventory (same approach `fleet_targets.py`/`firerpa_fleet.py` already use), cached for the process lifetime (this is called per dashboard request), falling back to the old literal only if inventory resolution fails.
- Added `tests/python/test_heartbeat_freshness_sync.py`: the `420` (seconds) heartbeat-freshness threshold is duplicated by real necessity across Python (`fleet_health.py`), CFEngine (`stayturgid.cf`), and Kotlin (`HeartbeatWriterTest.kt`) — three different runtimes with no single file to import from. The comments already say "MUST match" (#86); this test enforces it instead of relying on the comment alone.

## Test plan
- [x] Full suite: `uv run pytest` → 686 passed, 1 skipped (pre-existing)
- [x] `uv run ruff check` / `ruff format --check` on all changed files
- [x] Manually verified the new heartbeat-sync test actually fails on an injected mismatch, then reverted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device recovery handling based on recovery mode rather than a specific device alias.
  * Android device detection now recognizes inventory-defined devices and uses fallback detection when inventory is unavailable.
  * Improved recovery error reporting with clearer device and mode information.

* **Tests**
  * Added coverage for recovery behavior, inventory-based device detection, fallback handling, and synchronized heartbeat thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->