### PR TITLE
chore: bump ops-release.json to 1.2.3

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.2.2"
+  "version": "1.2.3"
 }


### PR DESCRIPTION
Coordinated ops release 1.2.3, picking up #219 (fresh-checkout guard), #220 (landing loopback detection + registry-driven caddy skip), #221 (hardcoded-list-duplicates-a-source cleanup), #216/#217 (ADB auth timeout), #218 (fire-help inventory fix).