### PR TITLE
fix: refresh stale label/note on a registered port's raw dashboard entry

### DIFF
--- a/control/landing/discover.py
+++ b/control/landing/discover.py
@@ -657,12 +657,36 @@ def discover(environ: Mapping[str, str] | None = None) -> dict:
             if port not in path_ports:
                 host_name = public_host if public_host else "localhost"
                 url = f"http://{host_name}:{port}"
+                fresh_label = _format_service_label(svc_name)
                 if url not in known_urls:
                     known_urls[url] = {
                         "url": url,
-                        "label": _format_service_label(svc_name),
+                        "label": fresh_label,
                         "group": "mac",
                     }
+                else:
+                    # A raw-port entry carried over from a prior state.json
+                    # can get stuck with a stale label/note forever once its
+                    # port becomes Caddy-proxied (load_caddy_proxied_ports)
+                    # and _scan_localhost stops revisiting it -- nothing else
+                    # ever refreshes this entry again. Confirmed real
+                    # 2026-08-03: Open WebUI's raw :8085 entry stayed badged
+                    # "not in registry/ports.yml" after it became both
+                    # registered and caddy-skipped in the same deploy.
+                    entry = known_urls[url]
+                    entry["label"] = fresh_label
+                    entry.pop("unregistered", None)
+                    note = entry.get("note")
+                    if isinstance(note, str) and "not in registry/ports.yml" in note:
+                        cleaned = (
+                            note.replace("; not in registry/ports.yml", "")
+                            .replace("not in registry/ports.yml", "")
+                            .strip("; ")
+                        )
+                        if cleaned:
+                            entry["note"] = cleaned
+                        else:
+                            entry.pop("note", None)
 
     dashboard_services = load_dashboard_brew_services(site_dir=site_dir)
     for label, formatted_label in dashboard_services.items():

--- a/tests/python/test_landing_discover.py
+++ b/tests/python/test_landing_discover.py
@@ -143,6 +143,49 @@ def test_gap2_dual_row_ambiguity(mock_env, monkeypatch):
     assert "http://localhost:6736" not in urls
 
 
+def test_stale_registered_entry_label_and_note_are_refreshed(mock_env, mock_known_services, monkeypatch):
+    """A raw-port entry carried over from a prior state.json must not stay
+    stuck with a stale label/note forever once its port becomes registered
+    and Caddy-skipped in the same deploy (_scan_localhost stops revisiting
+    it, so nothing else would ever refresh it) -- confirmed real 2026-08-03:
+    Open WebUI's raw :8085 entry stayed badged "not in registry/ports.yml"
+    after tonight's caddy_path fix made discover.py skip re-scanning it."""
+    monkeypatch.setattr(
+        discover,
+        "load_registered_ports",
+        lambda site_dir, return_map=False: {8085: "open-webui"} if return_map else {8085},
+    )
+    monkeypatch.setattr(
+        state,
+        "load_state",
+        lambda: {
+            "services": [
+                {
+                    "url": "http://localhost:8085",
+                    "label": "Open Webui",
+                    "group": "mac",
+                    "note": "HTTP 200; not in registry/ports.yml",
+                    "unregistered": True,
+                    "reachable": True,
+                    "last_seen": "2026-01-01T00:00:00Z",
+                }
+            ],
+            "hidden": [],
+        },
+    )
+    monkeypatch.setattr(discover, "_scan_localhost", lambda **kwargs: [])
+    monkeypatch.setattr(discover, "_http_probe", lambda url, **kwargs: 200)
+    monkeypatch.setattr(discover, "_tcp_probe", lambda host, port, **kwargs: True)
+
+    result = discover.discover({})
+
+    by_url = {s["url"]: s for s in result["services"]}
+    entry = by_url["http://localhost:8085"]
+    assert entry["label"] == "Open Webui"
+    assert "unregistered" not in entry
+    assert "not in registry" not in (entry.get("note") or "")
+
+
 def test_probe_launchd(monkeypatch):
     import subprocess
 


### PR DESCRIPTION
## Summary
Found live while verifying tonight's ops-v1.2.3 deploy (loopback-detection + registry-driven Caddy port skip): Open WebUI's raw `:8085` dashboard entry stayed permanently badged "not in registry/ports.yml" even though `registry/ports.yml` genuinely has an `open-webui` entry on that port.

Root cause: `known_urls` starts from the prior `state.json`, and the registered-ports seeding loop in `discover()` only fills in a fresh label when the URL isn't already present — it never reconciles a stale carried-over entry. This went unnoticed for already-Caddy-skipped ports (grafana, litellm, etc.) because `_scan_localhost` never revisited them either way, but their stale notes happened to look harmless ("HTTP 200"). Open WebUI hit the exact moment it transitioned from "scanned every run" to "skipped via caddy_path" in the same deploy, so its outdated now-registered note became actively misleading.

## Fix
When a `known_urls` entry already exists for a currently-registered port, refresh its label and drop any stale `unregistered` flag / "not in registry/ports.yml" note text, instead of only doing this for brand-new entries.

## Test plan
- [x] New regression test reproducing the exact stale-carryover scenario
- [x] Full suite: 695 passed, 1 skipped (pre-existing)
- [x] `ruff check` / `ruff format --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registered service ports now correctly refresh existing catalog entries.
  * Removed stale “unregistered” status and registry-related notes when services become registered.
  * Preserved existing service entries and labels during updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->