### PR TITLE
chore: bump ops-release.json to 1.2.4

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.2.3"
+  "version": "1.2.4"
 }


### PR DESCRIPTION
Coordinated ops release 1.2.4, picking up #223 (stale registered-port label/note reconciliation fix, found while verifying 1.2.3's live deploy).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application release version from 1.2.3 to 1.2.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->