### PR TITLE
Migration note: session handoffs move to site-private memory/handoffs/

### DIFF
--- a/docs/operations/sessions/README.md
+++ b/docs/operations/sessions/README.md
@@ -1,0 +1,5 @@
+# Frozen archive
+
+Frozen archive as of 2026-08-03. New handoffs live in site-private
+`memory/handoffs/` — see site-private
+`docs/session-handoff-compaction-spec.md`.


### PR DESCRIPTION
## Summary
Companion to djbclark/site-private#29 (the session-handoff v0.1 spec/build). `docs/operations/sessions/handoff-*.md` in this repo is superseded — new session handoffs go to `site-private`'s `memory/handoffs/` from here forward.

Adds `docs/operations/sessions/README.md` (the directory previously had none): a one-line note that this is now a frozen archive, pointing at the new convention.

Per the migration spec (site-private `docs/session-handoff-compaction-spec.md` §9): "No retroactive conversion — the old docs' value doesn't justify the churn, and the new system's chain lineage starts clean." Existing files in this directory are untouched.

## Test plan
- [x] `README.md` added, no other files changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a frozen-archive notice dated August 3, 2026.
  * Directed new handoffs to the designated private handoff directory and compaction specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->