### PR TITLE
fix: bind-aware URLs for registered ports + tailscale_serve_port skip list

### DIFF
--- a/control/landing/discover.py
+++ b/control/landing/discover.py
@@ -13,7 +13,7 @@ import os
 import socket
 import subprocess
 import sys
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -428,6 +428,53 @@ def load_registered_ports(
 LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost"}
 
 
+def _ports_matching(doc: object, predicate: Callable[[dict], bool]) -> set[int]:
+    """Return ports from a parsed registry doc whose entry satisfies *predicate*.
+
+    Scans both ``hosts.*.ports`` and ``product_defaults.*`` -- the same two
+    sources load_registered_ports itself ingests -- so a skip-list function
+    can't silently diverge from what counts as "registered" just because a
+    matching field happened to live under product_defaults instead of a
+    concrete host entry.
+    """
+    ports: set[int] = set()
+
+    def _ingest(entries: object) -> None:
+        if not isinstance(entries, list):
+            return
+        for entry in entries:
+            if isinstance(entry, dict) and isinstance(entry.get("port"), int) and predicate(entry):
+                ports.add(entry["port"])
+
+    hosts = doc.get("hosts") if isinstance(doc, dict) else None
+    if isinstance(hosts, dict):
+        for host_data in hosts.values():
+            if isinstance(host_data, dict):
+                _ingest(host_data.get("ports"))
+    product_defaults = doc.get("product_defaults") if isinstance(doc, dict) else None
+    if isinstance(product_defaults, dict):
+        for group_entries in product_defaults.values():
+            _ingest(group_entries)
+
+    return ports
+
+
+def _load_registry_doc(registry_path: Path | None, site_dir: Path | None) -> object | None:
+    """Resolve and parse the registry file, or None if unavailable/unparseable."""
+    path = registry_path
+    if path is None:
+        if site_dir is None:
+            selection = _resolve_site(os.environ)
+            site_dir = selection.path
+        path = _resolve_registry_ports_path(site_dir)
+    if path is None or not path.is_file() or yaml is None:
+        return None
+    try:
+        return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        return None
+
+
 def load_loopback_only_registered_ports(
     registry_path: Path | None = None,
     *,
@@ -447,39 +494,10 @@ def load_loopback_only_registered_ports(
     loop uses this to pick 127.0.0.1 instead of the public host and apply the
     same [loopback-only] badge _scan_localhost already applies.
     """
-    path = registry_path
-    if path is None:
-        if site_dir is None:
-            selection = _resolve_site(os.environ)
-            site_dir = selection.path
-        path = _resolve_registry_ports_path(site_dir)
-    if path is None or not path.is_file() or yaml is None:
+    doc = _load_registry_doc(registry_path, site_dir)
+    if doc is None:
         return set()
-    try:
-        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    except (OSError, yaml.YAMLError):
-        return set()
-
-    ports: set[int] = set()
-
-    def _ingest(entries: object) -> None:
-        if not isinstance(entries, list):
-            return
-        for entry in entries:
-            if (
-                isinstance(entry, dict)
-                and isinstance(entry.get("port"), int)
-                and str(entry.get("bind") or "").strip() in LOOPBACK_HOSTS
-            ):
-                ports.add(entry["port"])
-
-    hosts = doc.get("hosts") if isinstance(doc, dict) else None
-    if isinstance(hosts, dict):
-        for host_data in hosts.values():
-            if isinstance(host_data, dict):
-                _ingest(host_data.get("ports"))
-
-    return ports
+    return _ports_matching(doc, lambda entry: str(entry.get("bind") or "").strip() in LOOPBACK_HOSTS)
 
 
 def load_caddy_proxied_ports(
@@ -496,35 +514,10 @@ def load_caddy_proxied_ports(
     additive registry field (see registry/ports.yml's header comment in
     site-djbclark) -- a registry with no such field simply yields no skips.
     """
-    path = registry_path
-    if path is None:
-        if site_dir is None:
-            selection = _resolve_site(os.environ)
-            site_dir = selection.path
-        path = _resolve_registry_ports_path(site_dir)
-    if path is None or not path.is_file() or yaml is None:
+    doc = _load_registry_doc(registry_path, site_dir)
+    if doc is None:
         return set()
-    try:
-        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    except (OSError, yaml.YAMLError):
-        return set()
-
-    ports: set[int] = set()
-
-    def _ingest(entries: object) -> None:
-        if not isinstance(entries, list):
-            return
-        for entry in entries:
-            if isinstance(entry, dict) and isinstance(entry.get("port"), int) and entry.get("caddy_path"):
-                ports.add(entry["port"])
-
-    hosts = doc.get("hosts") if isinstance(doc, dict) else None
-    if isinstance(hosts, dict):
-        for host_data in hosts.values():
-            if isinstance(host_data, dict):
-                _ingest(host_data.get("ports"))
-
-    return ports
+    return _ports_matching(doc, lambda entry: bool(entry.get("caddy_path")))
 
 
 def load_tailscale_serve_ports(
@@ -542,35 +535,10 @@ def load_tailscale_serve_ports(
     function rather than folded into load_caddy_proxied_ports so neither
     one's name/behavior changes for existing callers.
     """
-    path = registry_path
-    if path is None:
-        if site_dir is None:
-            selection = _resolve_site(os.environ)
-            site_dir = selection.path
-        path = _resolve_registry_ports_path(site_dir)
-    if path is None or not path.is_file() or yaml is None:
+    doc = _load_registry_doc(registry_path, site_dir)
+    if doc is None:
         return set()
-    try:
-        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    except (OSError, yaml.YAMLError):
-        return set()
-
-    ports: set[int] = set()
-
-    def _ingest(entries: object) -> None:
-        if not isinstance(entries, list):
-            return
-        for entry in entries:
-            if isinstance(entry, dict) and isinstance(entry.get("port"), int) and entry.get("tailscale_serve_port"):
-                ports.add(entry["port"])
-
-    hosts = doc.get("hosts") if isinstance(doc, dict) else None
-    if isinstance(hosts, dict):
-        for host_data in hosts.values():
-            if isinstance(host_data, dict):
-                _ingest(host_data.get("ports"))
-
-    return ports
+    return _ports_matching(doc, lambda entry: bool(entry.get("tailscale_serve_port")))
 
 
 # Caddy's own front-door listeners -- not a proxied backend (no caddy_path
@@ -716,8 +684,10 @@ def discover(environ: Mapping[str, str] | None = None) -> dict:
                 del known_urls[url_key]
 
     # Add/update known services (site MagicDNS substituted for catalog placeholder)
+    catalog_urls: set[str] = set()
     for s in _known_services_for_site(site_dir):
         url = s["url"]
+        catalog_urls.add(url)
         if url in known_urls:
             known_urls[url].update({k: v for k, v in s.items() if k != "url"})
         else:
@@ -776,6 +746,28 @@ def discover(environ: Mapping[str, str] | None = None) -> dict:
                 fresh_label = _format_service_label(svc_name)
                 if loopback_only:
                     fresh_label += " [loopback-only]"
+                    # A raw (no-path) entry for this exact port can persist
+                    # under a different, now-wrong host key forever
+                    # otherwise -- e.g. the public-hostname URL a prior run
+                    # created before this port was known to be
+                    # loopback-only. Clean those up so the dashboard doesn't
+                    # show a stale broken-link row alongside the correct
+                    # one. Never touches a different, legitimately distinct
+                    # path-routed entry for the same port (those have a
+                    # path component, so the bare f"http://{host}:{port}"
+                    # key never matches them), nor a catalog-declared static
+                    # entry that happens to share this port number -- only a
+                    # prior run's own leftover raw-port entry is fair game.
+                    # Confirmed real 2026-08-03: an unguarded version of this
+                    # cleanup deleted a legitimate static catalog entry whose
+                    # port collided with an unrelated newly-loopback-only
+                    # registered port.
+                    for other_host in ("127.0.0.1", "localhost", public_host):
+                        if not other_host:
+                            continue
+                        stale_url = f"http://{other_host}:{port}"
+                        if stale_url != url and stale_url not in catalog_urls:
+                            known_urls.pop(stale_url, None)
                 if url not in known_urls:
                     entry: dict[str, Any] = {
                         "url": url,

--- a/control/landing/discover.py
+++ b/control/landing/discover.py
@@ -421,6 +421,67 @@ def load_registered_ports(
     return ports_map if return_map else ports_set
 
 
+# lsof binds and registry `bind` values that mean "loopback only, never
+# reachable via the public Tailscale hostname" -- shared by _scan_localhost's
+# lsof-based detection and load_loopback_only_registered_ports' registry-based
+# detection below, so the two can't drift apart on what counts as loopback.
+LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost"}
+
+
+def load_loopback_only_registered_ports(
+    registry_path: Path | None = None,
+    *,
+    site_dir: Path | None = None,
+) -> set[int]:
+    """Return registered ports whose registry entry declares a loopback ``bind``.
+
+    discover()'s "registered ports" seeding loop (below) creates a raw-port
+    dashboard entry for every registered port using the public Tailscale
+    hostname unconditionally -- it has no bind-awareness at all, unlike
+    _scan_localhost's lsof-based detection. That's fine for a port that's
+    genuinely reachable off-box, but wrong (and misleading -- a live,
+    clickable dead link) for one that's registered with ``bind: "127.0.0.1"``
+    and only reachable via Caddy/tailscale-serve/etc. Confirmed real
+    2026-08-03: Open WebUI's raw registered-port entry advertised the public
+    hostname on a loopback-only port. Consumer: discover()'s registered-ports
+    loop uses this to pick 127.0.0.1 instead of the public host and apply the
+    same [loopback-only] badge _scan_localhost already applies.
+    """
+    path = registry_path
+    if path is None:
+        if site_dir is None:
+            selection = _resolve_site(os.environ)
+            site_dir = selection.path
+        path = _resolve_registry_ports_path(site_dir)
+    if path is None or not path.is_file() or yaml is None:
+        return set()
+    try:
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        return set()
+
+    ports: set[int] = set()
+
+    def _ingest(entries: object) -> None:
+        if not isinstance(entries, list):
+            return
+        for entry in entries:
+            if (
+                isinstance(entry, dict)
+                and isinstance(entry.get("port"), int)
+                and str(entry.get("bind") or "").strip() in LOOPBACK_HOSTS
+            ):
+                ports.add(entry["port"])
+
+    hosts = doc.get("hosts") if isinstance(doc, dict) else None
+    if isinstance(hosts, dict):
+        for host_data in hosts.values():
+            if isinstance(host_data, dict):
+                _ingest(host_data.get("ports"))
+
+    return ports
+
+
 def load_caddy_proxied_ports(
     registry_path: Path | None = None,
     *,
@@ -455,6 +516,52 @@ def load_caddy_proxied_ports(
             return
         for entry in entries:
             if isinstance(entry, dict) and isinstance(entry.get("port"), int) and entry.get("caddy_path"):
+                ports.add(entry["port"])
+
+    hosts = doc.get("hosts") if isinstance(doc, dict) else None
+    if isinstance(hosts, dict):
+        for host_data in hosts.values():
+            if isinstance(host_data, dict):
+                _ingest(host_data.get("ports"))
+
+    return ports
+
+
+def load_tailscale_serve_ports(
+    registry_path: Path | None = None,
+    *,
+    site_dir: Path | None = None,
+) -> set[int]:
+    """Return ports whose registry entry declares a ``tailscale_serve_port``.
+
+    Same skip-list purpose as ``load_caddy_proxied_ports`` (avoid a
+    redundant raw-port scan duplicate once a backend's real external route
+    is already shown), but for a backend exposed via ``tailscale serve
+    --https=<port>`` directly instead of a Caddy subpath -- e.g. open-webui,
+    which has no reverse-proxy-subpath support at all. Kept as a separate
+    function rather than folded into load_caddy_proxied_ports so neither
+    one's name/behavior changes for existing callers.
+    """
+    path = registry_path
+    if path is None:
+        if site_dir is None:
+            selection = _resolve_site(os.environ)
+            site_dir = selection.path
+        path = _resolve_registry_ports_path(site_dir)
+    if path is None or not path.is_file() or yaml is None:
+        return set()
+    try:
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        return set()
+
+    ports: set[int] = set()
+
+    def _ingest(entries: object) -> None:
+        if not isinstance(entries, list):
+            return
+        for entry in entries:
+            if isinstance(entry, dict) and isinstance(entry.get("port"), int) and entry.get("tailscale_serve_port"):
                 ports.add(entry["port"])
 
     hosts = doc.get("hosts") if isinstance(doc, dict) else None
@@ -514,7 +621,6 @@ def _scan_localhost(
     # while every external client got connection refused, and the dashboard
     # had no way to tell the difference because it only ever probed loopback
     # in the first place, then advertised the public hostname anyway.
-    LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost"}
     host_name = public_host if public_host else "localhost"
     scanned: set[int] = set()
     for line in r.stdout.splitlines():
@@ -653,17 +759,33 @@ def discover(environ: Mapping[str, str] | None = None) -> dict:
             pass
 
     if registered:
+        loopback_only_registered = load_loopback_only_registered_ports(site_dir=site_dir)
         for port, svc_name in registered.items():
             if port not in path_ports:
-                host_name = public_host if public_host else "localhost"
+                loopback_only = port in loopback_only_registered
+                # A registered port with bind:127.0.0.1 can never be reached
+                # via the public Tailscale hostname, no matter what this
+                # loop advertises -- match _scan_localhost's own bind-aware
+                # URL choice and [loopback-only] badge instead of always
+                # using the public host. Confirmed real 2026-08-03: this
+                # loop advertised Open WebUI's registered raw port via the
+                # public hostname even though it was loopback-only, a live
+                # dead link on the dashboard.
+                host_name = "127.0.0.1" if loopback_only else (public_host if public_host else "localhost")
                 url = f"http://{host_name}:{port}"
                 fresh_label = _format_service_label(svc_name)
+                if loopback_only:
+                    fresh_label += " [loopback-only]"
                 if url not in known_urls:
-                    known_urls[url] = {
+                    entry: dict[str, Any] = {
                         "url": url,
                         "label": fresh_label,
                         "group": "mac",
                     }
+                    if loopback_only:
+                        entry["loopback_only"] = True
+                        entry["note"] = "loopback-only -- not reachable via Tailscale/LAN"
+                    known_urls[url] = entry
                 else:
                     # A raw-port entry carried over from a prior state.json
                     # can get stuck with a stale label/note forever once its
@@ -699,10 +821,12 @@ def discover(environ: Mapping[str, str] | None = None) -> dict:
             }
 
     caddy_proxied_ports = load_caddy_proxied_ports(site_dir=site_dir)
+    tailscale_serve_ports = load_tailscale_serve_ports(site_dir=site_dir)
+    externally_routed_ports = path_ports | caddy_proxied_ports | tailscale_serve_ports | CADDY_FRONT_DOOR_PORTS
     for s in _scan_localhost(
         registered_ports=registered if registered else None,
         public_host=public_host,
-        skip_ports=path_ports | caddy_proxied_ports | CADDY_FRONT_DOOR_PORTS,
+        skip_ports=externally_routed_ports,
     ):
         url = s["url"]
         if url not in known_urls:

--- a/control/landing/discover.py
+++ b/control/landing/discover.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import datetime
 import os
+import re
 import socket
 import subprocess
 import sys
@@ -348,27 +349,68 @@ def _format_service_label(name: str) -> str:
     return name.replace("-", " ").replace("_", " ").title()
 
 
-def _parse_ports_yaml_fallback(path: Path) -> dict[int, str]:
-    res: dict[int, str] = {}
+def _parse_ports_yaml_fallback_entries(path: Path) -> dict[int, dict[str, object]]:
+    """Crude parser used only when PyYAML is unavailable.
+
+    Real registry entries are flow-mapping style (`- {port: N, bind: "X",
+    ...}`) but routinely wrap across 2-3 physical lines (a long note, a
+    list-valued caddy_path) -- so this accumulates each entry's full
+    `{...}` block (by brace depth) before matching fields, rather than
+    assuming one entry = one line, which would silently miss bind/
+    caddy_path/tailscale_serve_port whenever they landed on a continuation
+    line rather than the same line as `port:`.
+    """
+    res: dict[int, dict[str, object]] = {}
     try:
-        lines = path.read_text(encoding="utf-8").splitlines()
+        text = path.read_text(encoding="utf-8")
     except OSError:
         return res
-    import re
 
     port_re = re.compile(r"port:\s*(\d+)")
     svc_re = re.compile(r"service:\s*([a-zA-Z0-9_-]+)")
-    for line in lines:
-        line = line.strip()
-        if line.startswith("#") or "port:" not in line:
+    bind_re = re.compile(r'bind:\s*"([^"]*)"')
+    caddy_path_re = re.compile(r"caddy_path:\s*(\[[^\]]*\]|\"[^\"]*\")")
+    tsp_re = re.compile(r"tailscale_serve_port:\s*(\d+)")
+
+    block: list[str] = []
+    depth = 0
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if depth == 0:
+            if line.startswith("#") or "{" not in line:
+                continue
+            block = []
+        block.append(line)
+        depth += line.count("{") - line.count("}")
+        if depth > 0:
             continue
-        pm = port_re.search(line)
-        sm = svc_re.search(line)
-        if pm:
-            p = int(pm.group(1))
-            svc = sm.group(1) if sm else f"Port {p}"
-            res[p] = svc
+        blob = " ".join(block)
+        block = []
+        pm = port_re.search(blob)
+        if not pm:
+            continue
+        p = int(pm.group(1))
+        sm = svc_re.search(blob)
+        bm = bind_re.search(blob)
+        cm = caddy_path_re.search(blob)
+        tm = tsp_re.search(blob)
+        entry: dict[str, object] = {"service": sm.group(1) if sm else f"Port {p}"}
+        if bm:
+            entry["bind"] = bm.group(1)
+        if cm:
+            # Only truthiness is ever checked on this field -- the raw
+            # matched text (a quoted string or a bracketed list literal) is
+            # fine as-is, no need to actually parse the list.
+            entry["caddy_path"] = cm.group(1)
+        if tm:
+            entry["tailscale_serve_port"] = tm.group(1)
+        res[p] = entry
     return res
+
+
+def _parse_ports_yaml_fallback(path: Path) -> dict[int, str]:
+    entries = _parse_ports_yaml_fallback_entries(path)
+    return {p: str(e.get("service", f"Port {p}")) for p, e in entries.items()}
 
 
 def load_registered_ports(
@@ -460,15 +502,28 @@ def _ports_matching(doc: object, predicate: Callable[[dict], bool]) -> set[int]:
 
 
 def _load_registry_doc(registry_path: Path | None, site_dir: Path | None) -> object | None:
-    """Resolve and parse the registry file, or None if unavailable/unparseable."""
+    """Resolve and parse the registry file, or None if unavailable/unparseable.
+
+    When PyYAML is unavailable, falls back to the same crude line-based
+    parser load_registered_ports uses, wrapped into the same hosts/ports doc
+    shape _ports_matching already knows how to scan -- so the bind/
+    caddy_path/tailscale_serve_port skip-list functions don't silently
+    regress to "nothing registered" just because yaml is missing. That
+    would resurrect the exact bug this module fixes: a loopback-only port
+    re-advertised via the public hostname, or a Caddy/tailscale-serve
+    backend's raw port re-appearing as an unregistered dead link.
+    """
     path = registry_path
     if path is None:
         if site_dir is None:
             selection = _resolve_site(os.environ)
             site_dir = selection.path
         path = _resolve_registry_ports_path(site_dir)
-    if path is None or not path.is_file() or yaml is None:
+    if path is None or not path.is_file():
         return None
+    if yaml is None:
+        entries = _parse_ports_yaml_fallback_entries(path)
+        return {"hosts": {"_fallback": {"ports": [{"port": p, **e} for p, e in entries.items()]}}}
     try:
         return yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     except (OSError, yaml.YAMLError):
@@ -768,6 +823,19 @@ def discover(environ: Mapping[str, str] | None = None) -> dict:
                         stale_url = f"http://{other_host}:{port}"
                         if stale_url != url and stale_url not in catalog_urls:
                             known_urls.pop(stale_url, None)
+                else:
+                    # Symmetric cleanup for the reverse transition: a port
+                    # that used to be loopback-only (bind widened to 0.0.0.0
+                    # or the registry entry removed) can leave behind a
+                    # stale 127.0.0.1 raw-port entry from a prior run,
+                    # duplicating the service on the dashboard under a wrong,
+                    # now-mislabeled [loopback-only] row alongside the new
+                    # public-host entry. 127.0.0.1 still answers after the
+                    # bind widens, so this isn't a dead link like the
+                    # forward direction -- just a stale duplicate.
+                    stale_url = f"http://127.0.0.1:{port}"
+                    if stale_url != url and stale_url not in catalog_urls:
+                        known_urls.pop(stale_url, None)
                 if url not in known_urls:
                     entry: dict[str, Any] = {
                         "url": url,

--- a/control/landing/services.json
+++ b/control/landing/services.json
@@ -10,7 +10,7 @@
     {"group": "mac", "label": "Fleet Dashboard (HTTPS)", "url": "https://mac.example.ts.net/dashboard/"},
     {"group": "mac", "label": "Fleet Stats (HTTPS)", "url": "https://mac.example.ts.net/stats/"},
     {"group": "mac", "label": "LiteLLM Proxy (HTTPS)", "url": "https://mac.example.ts.net/litellm/"},
-    {"group": "mac", "label": "Open WebUI (HTTPS)", "url": "https://mac.example.ts.net/chat/"},
+    {"group": "mac", "label": "Open WebUI (HTTPS)", "url": "https://mac.example.ts.net:8086/"},
     {"group": "mac", "label": "OpenUsage Limits API", "url": "http://localhost:6736/v1/limits"},
     {"group": "mac", "label": "SSH Server (sshd)", "url": "ssh://mac.example.ts.net:22"},
     {"group": "mac", "label": "Eternal Terminal (etserver)", "url": "et://mac.example.ts.net:2022"},

--- a/tests/python/test_landing_discover.py
+++ b/tests/python/test_landing_discover.py
@@ -409,12 +409,43 @@ hosts:
     assert ports == {8085}
 
 
+def test_discover_skips_tailscale_serve_backend_via_registry(mock_env, mock_known_services, monkeypatch):
+    """End-to-end: a tailscale_serve_port entry suppresses the raw-port scan
+    duplicate exactly like caddy_path does (test_discover_skips_caddy_proxied_backend_via_registry
+    above) -- confirmed real 2026-08-03, Open WebUI moved to this exposure
+    mechanism entirely since it has no reverse-proxy-subpath support."""
+    site_dir = mock_env
+    registry_dir = site_dir / "registry"
+    registry_dir.mkdir()
+    (registry_dir / "ports.yml").write_text(
+        """
+hosts:
+  mac:
+    ports:
+      - {port: 8085, bind: "127.0.0.1", owner: site, service: open-webui, status: active, tailscale_serve_port: 8086}
+"""
+    )
+
+    monkeypatch.setattr(
+        discover, "load_registered_ports", lambda site_dir, return_map=False: {} if return_map else set()
+    )
+    monkeypatch.setattr(state, "load_state", lambda: {"services": [], "hidden": []})
+
+    lsof_out = "python3.1 1 djbclark 1u IPv4 0x1 0t0 TCP 127.0.0.1:8085 (LISTEN)\n"
+    monkeypatch.setattr(discover.subprocess, "run", _fake_run_factory(lsof_out))
+
+    result = discover.discover({})
+
+    assert result["services"] == []
+
+
 def test_load_loopback_only_registered_ports(tmp_path):
     """Registry entries with bind:127.0.0.1 (or ::1/localhost) are the
     ports discover()'s registered-ports seeding loop must not advertise via
     the public Tailscale hostname -- confirmed real 2026-08-03: it did so
     unconditionally before this fix, producing a live dead link on the
-    dashboard for Open WebUI's raw registered port."""
+    dashboard for Open WebUI's raw registered port. Covers all three
+    loopback bind spellings the field accepts, not just 127.0.0.1."""
     registry = tmp_path / "ports.yml"
     registry.write_text(
         """
@@ -422,6 +453,8 @@ hosts:
   mac:
     ports:
       - {port: 8085, bind: "127.0.0.1", owner: site, service: open-webui, status: active}
+      - {port: 8086, bind: "::1", owner: site, service: ipv6-loopback-app, status: active}
+      - {port: 8087, bind: "localhost", owner: site, service: localhost-app, status: active}
       - {port: 443, bind: "*", owner: site, service: caddy-https, status: active}
       - {port: 4318, bind: "0.0.0.0", owner: site, service: vector-otlp-http, status: active}
 """
@@ -429,7 +462,7 @@ hosts:
 
     ports = discover.load_loopback_only_registered_ports(registry_path=registry)
 
-    assert ports == {8085}
+    assert ports == {8085, 8086, 8087}
 
 
 def test_discover_registered_loopback_port_advertises_127001_not_public_host(
@@ -463,6 +496,59 @@ hosts:
     entry = by_url["http://127.0.0.1:9999"]
     assert entry.get("loopback_only") is True
     assert "[loopback-only]" in entry["label"]
+
+
+def test_discover_removes_stale_public_host_entry_when_port_becomes_loopback_only(
+    mock_env, mock_known_services, monkeypatch
+):
+    """A prior run's raw-port entry under the OLD (public-hostname) URL for
+    a port that has since become registered with bind:127.0.0.1 must be
+    removed, not left sitting alongside the new correct 127.0.0.1 entry --
+    otherwise the dashboard shows two rows (one a stale dead link) for the
+    same port. Found by CodeRabbit review on the fix for this same class of
+    bug (2026-08-03)."""
+    site_dir = mock_env
+    registry_dir = site_dir / "registry"
+    registry_dir.mkdir()
+    (registry_dir / "ports.yml").write_text(
+        """
+hosts:
+  mac:
+    ports:
+      - {port: 9999, bind: "127.0.0.1", owner: site, service: loopback-only-app, status: active}
+"""
+    )
+    # A real (non-placeholder) public hostname -- discover() has a separate,
+    # unrelated purge step for un-rewritten mac.example.ts.net/.example.ts.net
+    # catalog placeholders that would otherwise delete a placeholder-hostname
+    # stale entry for the wrong reason and mask whether this test is
+    # actually exercising the new cleanup code.
+    monkeypatch.setattr(
+        state,
+        "load_state",
+        lambda: {
+            "services": [
+                {
+                    "url": "http://mac.greyhound-sidemirror.ts.net:9999",
+                    "label": "Loopback Only App",
+                    "group": "mac",
+                    "reachable": True,
+                    "last_seen": "2026-01-01T00:00:00Z",
+                }
+            ],
+            "hidden": [],
+        },
+    )
+    monkeypatch.setattr(discover, "_site_caddy_public_hostname", lambda _site_dir: "mac.greyhound-sidemirror.ts.net")
+    monkeypatch.setattr(discover, "_scan_localhost", lambda **kwargs: [])
+    monkeypatch.setattr(discover, "_http_probe", lambda url, **kwargs: None)
+    monkeypatch.setattr(discover, "_tcp_probe", lambda host, port, **kwargs: False)
+
+    result = discover.discover({})
+
+    urls = {s["url"] for s in result["services"]}
+    assert "http://127.0.0.1:9999" in urls
+    assert "http://mac.greyhound-sidemirror.ts.net:9999" not in urls
 
 
 def test_scan_localhost_advertises_public_url_for_wildcard_bind(monkeypatch):

--- a/tests/python/test_landing_discover.py
+++ b/tests/python/test_landing_discover.py
@@ -387,6 +387,84 @@ hosts:
     assert result["services"] == []
 
 
+def test_load_tailscale_serve_ports(tmp_path):
+    """tailscale_serve_port is the analogous field to caddy_path for a
+    backend exposed via `tailscale serve --https=<port>` directly instead
+    of a Caddy subpath -- confirmed real 2026-08-03: Open WebUI has no
+    reverse-proxy-subpath support at all, so it moved from caddy_path to
+    this field entirely."""
+    registry = tmp_path / "ports.yml"
+    registry.write_text(
+        """
+hosts:
+  mac:
+    ports:
+      - {port: 8085, bind: "127.0.0.1", owner: site, service: open-webui, status: active, tailscale_serve_port: 8086}
+      - {port: 6736, bind: "127.0.0.1", owner: site, service: openusage-limits, status: active}
+"""
+    )
+
+    ports = discover.load_tailscale_serve_ports(registry_path=registry)
+
+    assert ports == {8085}
+
+
+def test_load_loopback_only_registered_ports(tmp_path):
+    """Registry entries with bind:127.0.0.1 (or ::1/localhost) are the
+    ports discover()'s registered-ports seeding loop must not advertise via
+    the public Tailscale hostname -- confirmed real 2026-08-03: it did so
+    unconditionally before this fix, producing a live dead link on the
+    dashboard for Open WebUI's raw registered port."""
+    registry = tmp_path / "ports.yml"
+    registry.write_text(
+        """
+hosts:
+  mac:
+    ports:
+      - {port: 8085, bind: "127.0.0.1", owner: site, service: open-webui, status: active}
+      - {port: 443, bind: "*", owner: site, service: caddy-https, status: active}
+      - {port: 4318, bind: "0.0.0.0", owner: site, service: vector-otlp-http, status: active}
+"""
+    )
+
+    ports = discover.load_loopback_only_registered_ports(registry_path=registry)
+
+    assert ports == {8085}
+
+
+def test_discover_registered_loopback_port_advertises_127001_not_public_host(
+    mock_env, mock_known_services, monkeypatch
+):
+    """End-to-end reproduction of the real 2026-08-03 bug: a registered port
+    with bind:127.0.0.1 that ISN'T Caddy/tailscale-serve-skipped must get a
+    127.0.0.1 URL and the [loopback-only] badge from the registered-ports
+    seeding loop, not the public Tailscale hostname."""
+    site_dir = mock_env
+    registry_dir = site_dir / "registry"
+    registry_dir.mkdir()
+    (registry_dir / "ports.yml").write_text(
+        """
+hosts:
+  mac:
+    ports:
+      - {port: 9999, bind: "127.0.0.1", owner: site, service: loopback-only-app, status: active}
+"""
+    )
+    monkeypatch.setattr(state, "load_state", lambda: {"services": [], "hidden": []})
+    monkeypatch.setattr(discover, "_scan_localhost", lambda **kwargs: [])
+    monkeypatch.setattr(discover, "_http_probe", lambda url, **kwargs: None)
+    monkeypatch.setattr(discover, "_tcp_probe", lambda host, port, **kwargs: False)
+
+    result = discover.discover({})
+
+    by_url = {s["url"]: s for s in result["services"]}
+    assert "http://127.0.0.1:9999" in by_url
+    assert "http://localhost:9999" not in by_url
+    entry = by_url["http://127.0.0.1:9999"]
+    assert entry.get("loopback_only") is True
+    assert "[loopback-only]" in entry["label"]
+
+
 def test_scan_localhost_advertises_public_url_for_wildcard_bind(monkeypatch):
     lsof_out = "python3.1 1234 djbclark 12u IPv4 0xbeef 0t0 TCP *:9091 (LISTEN)\n"
     monkeypatch.setattr(discover.subprocess, "run", _fake_run_factory(lsof_out))

--- a/tests/python/test_landing_discover.py
+++ b/tests/python/test_landing_discover.py
@@ -551,6 +551,120 @@ hosts:
     assert "http://mac.greyhound-sidemirror.ts.net:9999" not in urls
 
 
+def test_discover_removes_stale_loopback_entry_when_port_becomes_non_loopback(
+    mock_env, mock_known_services, monkeypatch
+):
+    """Mirror image of test_discover_removes_stale_public_host_entry_when_port_becomes_loopback_only:
+    a port that USED to be loopback-only (bind widened, or the registry
+    entry changed) must not leave its old 127.0.0.1 raw-port entry sitting
+    alongside the new public-host entry -- that's a stale duplicate row on
+    the dashboard, not a dead link, but still wrong. Found by CodeRabbit
+    review on the forward-direction fix (2026-08-03)."""
+    site_dir = mock_env
+    registry_dir = site_dir / "registry"
+    registry_dir.mkdir()
+    (registry_dir / "ports.yml").write_text(
+        """
+hosts:
+  mac:
+    ports:
+      - {port: 9999, bind: "0.0.0.0", owner: site, service: now-public-app, status: active}
+"""
+    )
+    monkeypatch.setattr(
+        state,
+        "load_state",
+        lambda: {
+            "services": [
+                {
+                    "url": "http://127.0.0.1:9999",
+                    "label": "Now Public App [loopback-only]",
+                    "group": "mac",
+                    "loopback_only": True,
+                    "reachable": True,
+                    "last_seen": "2026-01-01T00:00:00Z",
+                }
+            ],
+            "hidden": [],
+        },
+    )
+    monkeypatch.setattr(discover, "_site_caddy_public_hostname", lambda _site_dir: "mac.greyhound-sidemirror.ts.net")
+    monkeypatch.setattr(discover, "_scan_localhost", lambda **kwargs: [])
+    monkeypatch.setattr(discover, "_http_probe", lambda url, **kwargs: None)
+    monkeypatch.setattr(discover, "_tcp_probe", lambda host, port, **kwargs: False)
+
+    result = discover.discover({})
+
+    urls = {s["url"] for s in result["services"]}
+    assert "http://mac.greyhound-sidemirror.ts.net:9999" in urls
+    assert "http://127.0.0.1:9999" not in urls
+
+
+def test_parse_ports_yaml_fallback_entries_handles_multiline_flow_mapping(tmp_path):
+    """The crude PyYAML-unavailable fallback parser must survive the real
+    registry file's actual formatting: entries wrap across 2-3 physical
+    lines (a long note, a list-valued caddy_path) rather than always
+    landing on the same line as `port:`. A naive same-line regex silently
+    dropped bind/caddy_path/tailscale_serve_port whenever they landed on a
+    continuation line -- found by CodeRabbit review (2026-08-03), matches
+    the real ~/site-djbclark/registry/ports.yml wrapping style verbatim."""
+    registry = tmp_path / "ports.yml"
+    registry.write_text(
+        """
+hosts:
+  mac:
+    ports:
+      - {port: 4097,  bind: "127.0.0.1", owner: stayturgid, service: fleet-dashboard,     status: active,
+         caddy_path: ["/dashboard/*", "/stats/*"],
+         note: "long explanation that wraps onto its own line"}
+      - {port: 8085,  bind: "127.0.0.1", owner: site, service: open-webui, status: active,
+         tailscale_serve_port: 8086}
+      - {port: 443,   bind: "*",         owner: site, service: caddy-https,         status: active}
+"""
+    )
+
+    entries = discover._parse_ports_yaml_fallback_entries(registry)
+
+    assert entries[4097]["service"] == "fleet-dashboard"
+    assert entries[4097]["bind"] == "127.0.0.1"
+    assert entries[4097].get("caddy_path")
+    assert entries[8085]["service"] == "open-webui"
+    assert entries[8085].get("tailscale_serve_port") == "8086"
+    assert entries[443]["bind"] == "*"
+    assert "caddy_path" not in entries[443]
+    assert "tailscale_serve_port" not in entries[443]
+
+
+def test_registry_loaders_fall_back_correctly_without_pyyaml(tmp_path, monkeypatch):
+    """If PyYAML is unavailable, load_loopback_only_registered_ports/
+    load_caddy_proxied_ports/load_tailscale_serve_ports must not silently
+    return an empty set (that would resurrect the exact bug this module
+    fixes: a loopback-only or Caddy/tailscale-serve-skipped port
+    re-advertised as an unregistered raw dead link). Found by CodeRabbit
+    review (2026-08-03): load_registered_ports already had a real fallback
+    parser, but the three newer skip-list loaders didn't share it."""
+    registry = tmp_path / "ports.yml"
+    registry.write_text(
+        """
+hosts:
+  mac:
+    ports:
+      - {port: 4097,  bind: "127.0.0.1", owner: stayturgid, service: fleet-dashboard,     status: active,
+         caddy_path: ["/dashboard/*", "/stats/*"],
+         note: "long explanation that wraps onto its own line"}
+      - {port: 8085,  bind: "127.0.0.1", owner: site, service: open-webui, status: active,
+         tailscale_serve_port: 8086}
+      - {port: 9999,  bind: "127.0.0.1", owner: site, service: plain-loopback, status: active}
+"""
+    )
+
+    monkeypatch.setattr(discover, "yaml", None)
+
+    assert discover.load_caddy_proxied_ports(registry_path=registry) == {4097}
+    assert discover.load_tailscale_serve_ports(registry_path=registry) == {8085}
+    assert discover.load_loopback_only_registered_ports(registry_path=registry) == {4097, 8085, 9999}
+
+
 def test_scan_localhost_advertises_public_url_for_wildcard_bind(monkeypatch):
     lsof_out = "python3.1 1234 djbclark 12u IPv4 0xbeef 0t0 TCP *:9091 (LISTEN)\n"
     monkeypatch.setattr(discover.subprocess, "run", _fake_run_factory(lsof_out))


### PR DESCRIPTION
## Summary
Companion to djbclark/site-djbclark#71 (Open WebUI moves to a dedicated `tailscale serve` port). Two real bugs found live while investigating the reported `/chat/` regression:

1. `discover()`'s "registered ports" seeding loop advertised every registered port via the public Tailscale hostname unconditionally, with zero bind-awareness — unlike `_scan_localhost`'s lsof-based detection, which already got this right. A registered port with `bind: 127.0.0.1` got a live, clickable dead link on the dashboard instead of the `[loopback-only]` badge and `127.0.0.1` URL. Fixed via `load_loopback_only_registered_ports()` (same additive-field pattern as `load_caddy_proxied_ports`).
2. Added `load_tailscale_serve_ports()` — the analogous skip-list function to `load_caddy_proxied_ports()` but for the registry's new `tailscale_serve_port` field.

Also updates `services.json`: Open WebUI's catalog entry now points at its dedicated tailscale-serve URL instead of the broken `/chat/` path.

## Test plan
- [x] 3 new tests (registry parsing x2, end-to-end bind-aware advertisement)
- [x] Full suite: 698 passed, 1 skipped (pre-existing) — re-ran twice after an unrelated flaky `test_ui_guard.py` failure (passes in isolation) to confirm clean
- [x] `ruff check` / `ruff format --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved discovery for loopback-only services with localhost URLs and clear loopback labels.
  - Tailscale Serve services are now detected accurately without duplicate local entries.
  - Service details and metadata now reflect current network availability more accurately.

- **Bug Fixes**
  - Prevented invalid public URLs for services available only on the local machine.
  - Removed stale listings when services change between local-only and externally available.
  - Updated the Open WebUI connection to use port 8086.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->