### PR TITLE
chore: bump ops-release.json to 1.2.5

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.2.4"
+  "version": "1.2.5"
 }


### PR DESCRIPTION
Coordinated ops-v1.2.5 release.