### PR TITLE
Purge stale catalog dashboard entries after a catalog URL change

### DIFF
--- a/control/landing/discover.py
+++ b/control/landing/discover.py
@@ -740,13 +740,32 @@ def discover(environ: Mapping[str, str] | None = None) -> dict:
 
     # Add/update known services (site MagicDNS substituted for catalog placeholder)
     catalog_urls: set[str] = set()
+    catalog_urls_by_identity: dict[tuple[str | None, str | None], set[str]] = {}
     for s in _known_services_for_site(site_dir):
         url = s["url"]
         catalog_urls.add(url)
+        catalog_urls_by_identity.setdefault((s.get("label"), s.get("group")), set()).add(url)
         if url in known_urls:
             known_urls[url].update({k: v for k, v in s.items() if k != "url"})
         else:
             known_urls[url] = dict(s)
+
+    # Purge a stale entry for a catalog-tracked service whose URL simply
+    # changed between deploys -- e.g. Open WebUI moving from a Caddy
+    # /chat/* subpath to a dedicated tailscale-serve port. Nothing else
+    # ever cleans this up: the old URL isn't a "registered port" skip-list
+    # match, isn't flagged unregistered, and doesn't start with
+    # http://localhost:, so it survives every existing prune path forever
+    # (even once genuinely unreachable) and shows a duplicate dashboard
+    # row for the same logical service. Identity is (label, group) since
+    # that's what stays stable across a catalog URL edit. Confirmed real
+    # 2026-08-03: this was still showing the pre-fix /chat/ URL alongside
+    # the new :8086/ URL after this exact class of catalog change deployed.
+    for url in list(known_urls.keys()):
+        entry = known_urls[url]
+        valid_urls = catalog_urls_by_identity.get((entry.get("label"), entry.get("group")))
+        if valid_urls and url not in valid_urls:
+            del known_urls[url]
 
     # Discover new http ports on localhost; badge registry drift (D4).
     registered = load_registered_ports(site_dir=site_dir, return_map=True)

--- a/tests/python/test_landing_discover.py
+++ b/tests/python/test_landing_discover.py
@@ -600,6 +600,57 @@ hosts:
     assert "http://127.0.0.1:9999" not in urls
 
 
+def test_discover_purges_stale_catalog_entry_after_catalog_url_change(mock_env, monkeypatch):
+    """A static catalog service (services.json) whose URL simply changed
+    between deploys -- e.g. Open WebUI moving from a Caddy /chat/* subpath
+    to a dedicated tailscale-serve port -- must not leave its old URL
+    sitting in known_urls forever alongside the new one. Nothing else
+    prunes this: the old URL isn't a registered-port skip-list match,
+    isn't flagged unregistered, and doesn't start with http://localhost:,
+    so it survives every existing prune path even once genuinely
+    unreachable. Confirmed real 2026-08-03: still showing the pre-fix
+    /chat/ URL alongside the new :8086/ URL on the live dashboard after
+    this exact catalog change was deployed."""
+    monkeypatch.setattr(
+        discover,
+        "_known_services_for_site",
+        lambda site_dir: [
+            {
+                "url": "https://mac.greyhound-sidemirror.ts.net:8086/",
+                "label": "Open WebUI (HTTPS)",
+                "group": "mac",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        state,
+        "load_state",
+        lambda: {
+            "services": [
+                {
+                    "url": "https://mac.greyhound-sidemirror.ts.net/chat/",
+                    "label": "Open WebUI (HTTPS)",
+                    "group": "mac",
+                    "reachable": True,
+                    "last_seen": "2026-01-01T00:00:00Z",
+                }
+            ],
+            "hidden": [],
+        },
+    )
+    monkeypatch.setattr(discover, "_site_caddy_public_hostname", lambda _site_dir: "mac.greyhound-sidemirror.ts.net")
+    monkeypatch.setattr(discover, "_scan_localhost", lambda **kwargs: [])
+    monkeypatch.setattr(discover, "_http_probe", lambda url, **kwargs: 200)
+    monkeypatch.setattr(discover, "_tcp_probe", lambda host, port, **kwargs: False)
+
+    result = discover.discover({})
+
+    urls = {s["url"] for s in result["services"]}
+    assert "https://mac.greyhound-sidemirror.ts.net:8086/" in urls
+    assert "https://mac.greyhound-sidemirror.ts.net/chat/" not in urls
+    assert len([s for s in result["services"] if s.get("label") == "Open WebUI (HTTPS)"]) == 1
+
+
 def test_parse_ports_yaml_fallback_entries_handles_multiline_flow_mapping(tmp_path):
     """The crude PyYAML-unavailable fallback parser must survive the real
     registry file's actual formatting: entries wrap across 2-3 physical


### PR DESCRIPTION
## Summary
- A static catalog service (services.json) whose URL changed between deploys left its old URL sitting in `known_urls` forever alongside the new one — nothing existing pruned it (not a registered-port skip-list match, not flagged unregistered, doesn't start with `http://localhost:`).
- Confirmed real today: after deploying the Open WebUI dedicated-port fix and reloading Caddy, the dashboard still showed the pre-fix `/chat/` URL alongside the new `:8086/` URL.
- Tracks catalog URLs by `(label, group)` identity and purges any entry with a matching identity but a stale URL.

## Test plan
- [x] New regression test, verified it fails against the pre-fix code
- [x] Full suite: 704 passed, 1 skipped
- [x] `ruff check` / `ruff format --check` clean
- [x] Verified live: `/chat/` now 404s (Caddy reloaded), `:8086/` returns 200