### PR TITLE
Fix opencode-web LaunchAgent pointing at a stale binary path

### DIFF
--- a/ansible/roles/control_node/defaults/main.yml
+++ b/ansible/roles/control_node/defaults/main.yml
@@ -97,7 +97,13 @@ stayturgid_hermes_telegram_bot_token: ""
 # ── OpenCode web (control-node web UI reachable from fleet devices) ─────────
 stayturgid_opencode_web_enabled: true
 stayturgid_opencode_web_port: 4096
-stayturgid_opencode_path: "{{ lookup('env', 'HOME') }}/.local/bin/opencode"
+# opencode's own installer/self-update relocated its binary from
+# ~/.local/bin/opencode to ~/.opencode/bin/opencode at some point -- this
+# default silently pointed at the old, now-missing path, so the
+# com.stayturgid.opencode-web LaunchAgent exec'd nothing (EX_CONFIG,
+# perpetual restart loop, port 4096 never listening). Confirmed real
+# 2026-08-03.
+stayturgid_opencode_path: "{{ lookup('env', 'HOME') }}/.opencode/bin/opencode"
 stayturgid_opencode_web_label: com.stayturgid.opencode-web
 
 # ── Fleet dashboard (Flask + HTMX web UI, port 4097) ──────────────────────


### PR DESCRIPTION
## Summary
- `opencode`'s own installer/self-update relocated its binary from `~/.local/bin/opencode` to `~/.opencode/bin/opencode`. `stayturgid_opencode_path` still pointed at the old location, so `com.stayturgid.opencode-web` exec'd nothing (`EX_CONFIG`), perpetually restart-looping with port 4096 never listening.
- Confirmed real today — surfaced as the one failed health check during an unrelated `site-serverapps` run.

## Test plan
- [x] YAML validates, `ansible-lint` clean
- [x] Full suite: 704 passed, 1 skipped
- [x] Confirmed the real binary now lives at `~/.opencode/bin/opencode`