### PR TITLE
fix: detect broken landing service content

### DIFF
--- a/control/landing/discover.py
+++ b/control/landing/discover.py
@@ -15,8 +15,13 @@ import socket
 import subprocess
 import sys
 from collections.abc import Callable, Mapping
+from html.parser import HTMLParser
+from http.client import HTTPException
 from pathlib import Path
 from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 _REPO = Path(__file__).resolve().parents[2]
 _LIB = _REPO / "control" / "lib"
@@ -87,6 +92,31 @@ KNOWN_SERVICES = state.load_catalog().get("services", KNOWN_SERVICES)
 
 # Generic catalog host in services.json / KNOWN_SERVICES (RFC-style example).
 _CATALOG_PUBLIC_HOST = "mac.example.ts.net"
+_ESCAPED_TAG_RE = re.compile(
+    r"&lt;/?(?:html|head|body|div|script|link|main|section|article|p|h[1-6])(?:[\s&gt;])", re.I
+)
+
+
+class _StaticAssetParser(HTMLParser):
+    """Collect fetchable stylesheet and script URLs without executing page code."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.urls: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        values = dict(attrs)
+        if tag == "script" and values.get("src"):
+            self.urls.append(str(values["src"]))
+        elif tag == "link" and values.get("href"):
+            self.urls.append(str(values["href"]))
+
+
+class _NoRedirect(HTTPRedirectHandler):
+    """Keep expected redirects observable instead of silently following them."""
+
+    def redirect_request(self, req: Request, fp: Any, code: int, msg: str, headers: Any, newurl: str) -> None:
+        return None
 
 
 def _resolve_site(environ: Mapping[str, str]) -> SiteSelection:
@@ -179,6 +209,14 @@ def _known_services_for_site(site_dir: Path) -> list[dict]:
     return out
 
 
+def _probe_url(url: str, public_host: str | None) -> str:
+    """Use loopback for a local HTTP listener advertised through the site host."""
+    if not public_host or public_host not in url or not url.startswith("http://"):
+        return url
+    m = re.match(r"http://" + re.escape(public_host) + r":(\d+)(.*)", url)
+    return f"http://127.0.0.1:{m.group(1)}{m.group(2)}" if m else url
+
+
 def _http_probe(url: str, timeout: float = 3.0, public_host: str | None = None, **_kwargs) -> int | None:
     """Return HTTP status code (or 200 for open TCP non-HTTP services) or None if unreachable."""
     if url.startswith(("ssh://", "et://", "adb://", "ard://", "tcp://", "launchd://")):
@@ -213,13 +251,7 @@ def _http_probe(url: str, timeout: float = 3.0, public_host: str | None = None, 
             h = "127.0.0.1"
         return 200 if _tcp_probe(h, p, timeout=timeout) else None
 
-    probe_url = url
-    if public_host and public_host in url and url.startswith("http://"):
-        import re
-
-        m = re.match(r"http://" + re.escape(public_host) + r":(\d+)(.*)", url)
-        if m:
-            probe_url = f"http://127.0.0.1:{m.group(1)}{m.group(2)}"
+    probe_url = _probe_url(url, public_host)
 
     try:
         r = subprocess.run(
@@ -232,6 +264,99 @@ def _http_probe(url: str, timeout: float = 3.0, public_host: str | None = None, 
         return int(code) if code.isdigit() and code != "000" else None
     except (OSError, subprocess.TimeoutExpired, ValueError):
         return None
+
+
+def _http_response(url: str, timeout: float = 3.0, public_host: str | None = None) -> tuple[int, str, str] | None:
+    """Fetch one HTTP response without following redirects.
+
+    This deliberately uses only the standard library and never executes page
+    JavaScript.  A response body is capped because discovery runs frequently.
+    """
+    request = Request(_probe_url(url, public_host), headers={"User-Agent": "stayturgid-landing-discover"})
+    opener = build_opener(_NoRedirect())
+    try:
+        with opener.open(request, timeout=timeout) as response:
+            body = response.read(1_048_576).decode("utf-8", errors="replace")
+            return response.status, response.headers.get_content_type(), body
+    except HTTPError as error:
+        body = error.read(1_048_576).decode("utf-8", errors="replace")
+        return error.code, error.headers.get_content_type(), body
+    except (HTTPException, OSError, URLError, ValueError):
+        return None
+
+
+def _is_success_status(status: int, service: Mapping[str, Any]) -> bool:
+    """Accept 2xx responses by default plus a catalogued status allowlist."""
+    allowed = service.get("accepted_status_codes", [])
+    return 200 <= status < 300 or (isinstance(allowed, list) and status in allowed)
+
+
+def _validate_html_content(
+    url: str, body: str, service: Mapping[str, Any], timeout: float = 3.0, public_host: str | None = None
+) -> list[str]:
+    """Return static HTML problems: escaped markup, missing marker, or assets."""
+    problems: list[str] = []
+    if _ESCAPED_TAG_RE.search(body):
+        problems.append("response contains escaped HTML markup")
+
+    marker = service.get("must_contain")
+    if isinstance(marker, str) and marker and marker not in body:
+        problems.append(f"response missing required marker: {marker}")
+
+    parser = _StaticAssetParser()
+    try:
+        parser.feed(body)
+    except (ValueError, AssertionError):
+        problems.append("response HTML could not be parsed")
+        return problems
+
+    for asset in dict.fromkeys(parser.urls):
+        asset_url = urljoin(url, asset)
+        if asset_url.startswith(("data:", "javascript:", "mailto:", "tel:")):
+            continue
+        result = _http_response(asset_url, timeout=timeout, public_host=public_host)
+        if result is None or result[0] != 200:
+            status = "unreachable" if result is None else f"HTTP {result[0]}"
+            problems.append(f"asset {asset_url} returned {status}")
+    return problems
+
+
+def _service_health(url: str, service: Mapping[str, Any], *, public_host: str | None = None) -> dict[str, Any]:
+    """Classify a service as healthy, degraded, or unreachable.
+
+    ``reachable`` remains a strict successful-response value.  ``health`` is
+    separate so a server that answers with HTTP 500 is visibly distinct from
+    a host that cannot be reached at all.
+    """
+    status = _http_probe(url, public_host=public_host)
+    if status is None:
+        return {"reachable": False, "health": "unreachable"}
+
+    result: dict[str, Any] = {"reachable": _is_success_status(status, service), "status_code": status}
+    if not result["reachable"]:
+        result.update({"health": "degraded", "health_problems": [f"HTTP {status} is not an accepted success status"]})
+        return result
+
+    if not url.startswith(("http://", "https://")):
+        result["health"] = "healthy"
+        return result
+
+    response = _http_response(url, public_host=public_host)
+    if response is None:
+        # The inexpensive status probe succeeded. Do not turn a transient
+        # body-fetch failure into a green result, and make it diagnosable.
+        result.update({"health": "degraded", "health_problems": ["response body could not be fetched"]})
+        return result
+    _body_status, content_type, body = response
+    if content_type != "text/html":
+        result["health"] = "healthy"
+        return result
+
+    problems = _validate_html_content(url, body, service, public_host=public_host)
+    result.update({"health": "healthy" if not problems else "degraded", "content_ok": not problems})
+    if problems:
+        result["health_problems"] = problems
+    return result
 
 
 def _tcp_probe(host: str, port: int, timeout: float = 2.0) -> bool:
@@ -938,15 +1063,15 @@ def discover(environ: Mapping[str, str] | None = None) -> dict:
     static_urls = {ks["url"] for ks in _known_services_for_site(site_dir)}
     for url, s in sorted(known_urls.items()):
         s["url"] = url
-        status = _http_probe(url, public_host=public_host)
-        if status is not None:
-            s["reachable"] = True
+        for field in ("content_ok", "health_problems"):
+            s.pop(field, None)
+        health = _service_health(url, s, public_host=public_host)
+        s.update(health)
+        if health["health"] != "unreachable":
             s["last_seen"] = now
-            s["status_code"] = status
             if url not in hidden:
                 services.append(s)
         else:
-            s["reachable"] = False
             # Check if this is an auto-discovered unregistered port that is no longer reachable.
             # Dynamic localhost entries (e.g., ephemeral ports) that are no longer listening are pruned.
             try:

--- a/control/landing/discover.py
+++ b/control/landing/discover.py
@@ -89,6 +89,7 @@ KNOWN_SERVICES: list[dict] = [
 # The committed catalog is the source of truth; the fallback list keeps older
 # checkouts importable until their catalog has been migrated.
 KNOWN_SERVICES = state.load_catalog().get("services", KNOWN_SERVICES)
+SERVICE_HEALTH_OVERRIDES = state.load_catalog().get("health_overrides", {})
 
 # Generic catalog host in services.json / KNOWN_SERVICES (RFC-style example).
 _CATALOG_PUBLIC_HOST = "mac.example.ts.net"
@@ -289,6 +290,15 @@ def _is_success_status(status: int, service: Mapping[str, Any]) -> bool:
     """Accept 2xx responses by default plus a catalogued status allowlist."""
     allowed = service.get("accepted_status_codes", [])
     return 200 <= status < 300 or (isinstance(allowed, list) and status in allowed)
+
+
+def _service_health_config(service: Mapping[str, Any]) -> dict[str, Any]:
+    """Apply catalogued health settings to both static and discovered services."""
+    configured = dict(service)
+    override = SERVICE_HEALTH_OVERRIDES.get(str(service.get("label", "")))
+    if isinstance(override, Mapping):
+        configured.update(override)
+    return configured
 
 
 def _validate_html_content(
@@ -1065,6 +1075,7 @@ def discover(environ: Mapping[str, str] | None = None) -> dict:
         s["url"] = url
         for field in ("content_ok", "health_problems"):
             s.pop(field, None)
+        s.update(_service_health_config(s))
         health = _service_health(url, s, public_host=public_host)
         s.update(health)
         if health["health"] != "unreachable":

--- a/control/landing/services.json
+++ b/control/landing/services.json
@@ -1,30 +1,129 @@
 {
   "hidden": [],
   "services": [
-    {"group": "mac", "label": "Network Landing (root)", "url": "https://mac.example.ts.net"},
-    {"group": "mac", "label": "Grafana (HTTPS)", "url": "https://mac.example.ts.net/grafana/"},
-    {"group": "mac", "label": "OpenObserve (HTTPS)", "url": "https://mac.example.ts.net/oo/"},
-    {"group": "mac", "label": "OliveTin (HTTPS)", "url": "https://mac.example.ts.net/olivetin/"},
-    {"group": "mac", "label": "VictoriaMetrics (HTTPS)", "url": "https://mac.example.ts.net/vm/"},
-    {"group": "mac", "label": "OpenCode Web (HTTPS)", "url": "https://mac.example.ts.net/opencode/"},
-    {"group": "mac", "label": "Fleet Dashboard (HTTPS)", "url": "https://mac.example.ts.net/dashboard/"},
-    {"group": "mac", "label": "Fleet Stats (HTTPS)", "url": "https://mac.example.ts.net/stats/"},
-    {"group": "mac", "label": "LiteLLM Proxy (HTTPS)", "url": "https://mac.example.ts.net/litellm/"},
-    {"group": "mac", "label": "Open WebUI (HTTPS)", "url": "https://mac.example.ts.net:8086/"},
-    {"group": "mac", "label": "OpenUsage Limits API", "url": "http://localhost:6736/v1/limits"},
-    {"group": "mac", "label": "SSH Server (sshd)", "url": "ssh://mac.example.ts.net:22"},
-    {"group": "mac", "label": "Eternal Terminal (etserver)", "url": "et://mac.example.ts.net:2022"},
-    {"group": "mac", "label": "Apple Remote Desktop (ARD)", "url": "ard://mac.example.ts.net:3283"},
-    {"group": "mac", "label": "Caddy Health", "url": "http://localhost:8080"},
-    {"group": "devices", "label": "oneui-device FIRERPA", "url": "http://100.0.0.11:65000"},
-    {"group": "devices", "label": "stock-android-device FIRERPA", "url": "http://100.0.0.12:65000"},
-    {"group": "devices", "label": "fireos-device FIRERPA", "url": "http://100.0.0.13:65000"},
-    {"group": "devices", "label": "oneui-device FIRERPA (LAN)", "url": "http://192.0.2.11:65000"},
-    {"group": "devices", "label": "stock-android-device FIRERPA (LAN)", "url": "http://192.0.2.12:65000"},
-    {"group": "devices", "label": "oneui-device FIRERPA (MagicDNS)", "url": "http://oneui-device.example.ts.net:65000"},
-    {"group": "devices", "label": "stock-android-device FIRERPA (MagicDNS)", "url": "http://stock-android-device.example.ts.net:65000"},
-    {"group": "devices", "label": "fireos-device FIRERPA (MagicDNS)", "url": "http://fireos-device.example.ts.net:65000"},
-    {"group": "p7a", "label": "KVM Linux SSH (p7a-kvm)", "url": "ssh://p7a.example.ts.net:22"},
-    {"group": "mac", "label": "PHP-FPM / Dev Server", "url": "http://localhost:9000"}
+    {
+      "group": "mac",
+      "label": "Network Landing (root)",
+      "url": "https://mac.example.ts.net"
+    },
+    {
+      "group": "mac",
+      "label": "Grafana (HTTPS)",
+      "url": "https://mac.example.ts.net/grafana/"
+    },
+    {
+      "accepted_status_codes": [308],
+      "group": "mac",
+      "label": "OpenObserve (HTTPS)",
+      "url": "https://mac.example.ts.net/oo/"
+    },
+    {
+      "group": "mac",
+      "label": "OliveTin (HTTPS)",
+      "url": "https://mac.example.ts.net/olivetin/"
+    },
+    {
+      "group": "mac",
+      "label": "VictoriaMetrics (HTTPS)",
+      "url": "https://mac.example.ts.net/vm/"
+    },
+    {
+      "group": "mac",
+      "label": "OpenCode Web (HTTPS)",
+      "url": "https://mac.example.ts.net/opencode/"
+    },
+    {
+      "group": "mac",
+      "label": "Fleet Dashboard (HTTPS)",
+      "must_contain": "stayturgid fleet",
+      "url": "https://mac.example.ts.net/dashboard/"
+    },
+    {
+      "group": "mac",
+      "label": "Fleet Stats (HTTPS)",
+      "must_contain": "stayturgid stats",
+      "url": "https://mac.example.ts.net/stats/"
+    },
+    {
+      "group": "mac",
+      "label": "LiteLLM Proxy (HTTPS)",
+      "url": "https://mac.example.ts.net/litellm/"
+    },
+    {
+      "group": "mac",
+      "label": "Open WebUI (HTTPS)",
+      "url": "https://mac.example.ts.net:8086/"
+    },
+    {
+      "group": "mac",
+      "label": "OpenUsage Limits API",
+      "url": "http://localhost:6736/v1/limits"
+    },
+    {
+      "group": "mac",
+      "label": "SSH Server (sshd)",
+      "url": "ssh://mac.example.ts.net:22"
+    },
+    {
+      "group": "mac",
+      "label": "Eternal Terminal (etserver)",
+      "url": "et://mac.example.ts.net:2022"
+    },
+    {
+      "group": "mac",
+      "label": "Apple Remote Desktop (ARD)",
+      "url": "ard://mac.example.ts.net:3283"
+    },
+    { "group": "mac", "label": "Caddy Health", "url": "http://localhost:8080" },
+    {
+      "group": "devices",
+      "label": "oneui-device FIRERPA",
+      "url": "http://100.0.0.11:65000"
+    },
+    {
+      "group": "devices",
+      "label": "stock-android-device FIRERPA",
+      "url": "http://100.0.0.12:65000"
+    },
+    {
+      "group": "devices",
+      "label": "fireos-device FIRERPA",
+      "url": "http://100.0.0.13:65000"
+    },
+    {
+      "group": "devices",
+      "label": "oneui-device FIRERPA (LAN)",
+      "url": "http://192.0.2.11:65000"
+    },
+    {
+      "group": "devices",
+      "label": "stock-android-device FIRERPA (LAN)",
+      "url": "http://192.0.2.12:65000"
+    },
+    {
+      "group": "devices",
+      "label": "oneui-device FIRERPA (MagicDNS)",
+      "url": "http://oneui-device.example.ts.net:65000"
+    },
+    {
+      "group": "devices",
+      "label": "stock-android-device FIRERPA (MagicDNS)",
+      "url": "http://stock-android-device.example.ts.net:65000"
+    },
+    {
+      "group": "devices",
+      "label": "fireos-device FIRERPA (MagicDNS)",
+      "url": "http://fireos-device.example.ts.net:65000"
+    },
+    {
+      "group": "p7a",
+      "label": "KVM Linux SSH (p7a-kvm)",
+      "url": "ssh://p7a.example.ts.net:22"
+    },
+    {
+      "group": "mac",
+      "label": "PHP-FPM / Dev Server",
+      "url": "http://localhost:9000"
+    }
   ]
 }

--- a/control/landing/services.json
+++ b/control/landing/services.json
@@ -1,4 +1,15 @@
 {
+  "health_overrides": {
+    "Grafana (HTTPS)": {
+      "accepted_status_codes": [302]
+    },
+    "Grafana [loopback-only]": {
+      "accepted_status_codes": [301]
+    },
+    "OpenObserve (HTTP)": {
+      "accepted_status_codes": [308]
+    }
+  },
   "hidden": [],
   "services": [
     {

--- a/control/landing/templates/index.html
+++ b/control/landing/templates/index.html
@@ -25,6 +25,7 @@
         --text: #c8c8d4;
         --text-dim: #6b7280;
         --ok: #22c55e;
+        --warn: #f59e0b;
         --error: #ef4444;
         --link: #60a5fa;
         --radius: 8px;
@@ -115,6 +116,9 @@
       .service.unreachable {
         opacity: 0.5;
       }
+      .service.degraded {
+        border-color: var(--warn);
+      }
       .service-link {
         color: var(--link);
         text-decoration: none;
@@ -141,6 +145,9 @@
       }
       .status-dot.error {
         background: var(--error);
+      }
+      .status-dot.warning {
+        background: var(--warn);
       }
       .hide-btn {
         background: none;
@@ -202,10 +209,12 @@
     </div>
 
     {% macro service_row(svc) %}
-    <div class="service {% if not svc.reachable %}unreachable{% endif %}">
+    <div
+      class="service {{ svc.health | default('healthy' if svc.reachable else 'unreachable') }}"
+    >
       <span
-        class="status-dot {% if svc.reachable %}ok{% else %}error{% endif %}"
-        title="{{ 'reachable' if svc.reachable else 'unreachable' }}"
+        class="status-dot {% if svc.health | default('healthy' if svc.reachable else 'unreachable') == 'healthy' %}ok{% elif svc.health | default('healthy' if svc.reachable else 'unreachable') == 'degraded' %}warning{% else %}error{% endif %}"
+        title="{% if svc.health | default('healthy' if svc.reachable else 'unreachable') == 'healthy' %}healthy{% elif svc.health | default('healthy' if svc.reachable else 'unreachable') == 'degraded' %}reachable but unhealthy: {{ svc.health_problems | default([]) | join('; ') }}{% else %}unreachable{% endif %}"
       ></span>
       <span class="service-label"
         >{{ svc.display_label | default(svc.label) }}</span

--- a/tests/python/test_landing_discover.py
+++ b/tests/python/test_landing_discover.py
@@ -211,6 +211,15 @@ def test_success_status_is_2xx_unless_catalog_allows_a_redirect():
     assert not discover._is_success_status(500, {"accepted_status_codes": [308]})
 
 
+def test_catalog_health_override_applies_to_a_discovered_service(monkeypatch):
+    monkeypatch.setattr(
+        discover, "SERVICE_HEALTH_OVERRIDES", {"Grafana [loopback-only]": {"accepted_status_codes": [301]}}
+    )
+    configured = discover._service_health_config({"label": "Grafana [loopback-only]", "url": "http://127.0.0.1:3000"})
+    assert configured["accepted_status_codes"] == [301]
+    assert discover._is_success_status(301, configured)
+
+
 def test_public_host_http_port_is_probed_via_its_local_listener():
     assert (
         discover._probe_url("http://mac.example.ts.net:8088/path", "mac.example.ts.net") == "http://127.0.0.1:8088/path"

--- a/tests/python/test_landing_discover.py
+++ b/tests/python/test_landing_discover.py
@@ -15,6 +15,7 @@ def mock_env(monkeypatch, tmp_path):
     monkeypatch.setattr(discover, "_resolve_site", mock_resolve)
     monkeypatch.setattr(discover, "announce_site_selection", lambda s, command: None)
     monkeypatch.setattr(state, "write_state", lambda d: None)
+    monkeypatch.setattr(discover, "_http_response", lambda _url, **_kwargs: (200, "application/json", "{}"))
     return site_dir
 
 
@@ -201,6 +202,62 @@ def test_probe_launchd(monkeypatch):
     assert discover._http_probe("launchd://homebrew.mxcl.herdr") == 200
     # test other is not
     assert discover._http_probe("launchd://homebrew.mxcl.other") is None
+
+
+def test_success_status_is_2xx_unless_catalog_allows_a_redirect():
+    assert discover._is_success_status(200, {})
+    assert not discover._is_success_status(308, {})
+    assert discover._is_success_status(308, {"accepted_status_codes": [308]})
+    assert not discover._is_success_status(500, {"accepted_status_codes": [308]})
+
+
+def test_public_host_http_port_is_probed_via_its_local_listener():
+    assert (
+        discover._probe_url("http://mac.example.ts.net:8088/path", "mac.example.ts.net") == "http://127.0.0.1:8088/path"
+    )
+    assert (
+        discover._probe_url("https://mac.example.ts.net/path", "mac.example.ts.net")
+        == "https://mac.example.ts.net/path"
+    )
+
+
+def test_html_validation_detects_escaped_markup_missing_marker_and_dead_assets(monkeypatch):
+    responses = {
+        "https://example.test/static/app.js": (200, "application/javascript", ""),
+        "https://example.test/static/site.css": (404, "text/plain", "missing"),
+    }
+    monkeypatch.setattr(discover, "_http_response", lambda url, **_kwargs: responses.get(url))
+
+    problems = discover._validate_html_content(
+        "https://example.test/dashboard/",
+        '<html><head><script src="/static/app.js"></script><link href="/static/site.css" rel="stylesheet"></head>&lt;div&gt;oops</html>',
+        {"must_contain": "expected dashboard marker"},
+    )
+
+    assert "response contains escaped HTML markup" in problems
+    assert "response missing required marker: expected dashboard marker" in problems
+    assert any("static/site.css returned HTTP 404" in problem for problem in problems)
+
+
+def test_service_health_distinguishes_http_failure_content_failure_and_unreachable(monkeypatch):
+    monkeypatch.setattr(discover, "_http_probe", lambda _url, **_kwargs: 500)
+    failed = discover._service_health("https://example.test/", {})
+    assert failed == {
+        "reachable": False,
+        "status_code": 500,
+        "health": "degraded",
+        "health_problems": ["HTTP 500 is not an accepted success status"],
+    }
+
+    monkeypatch.setattr(discover, "_http_probe", lambda _url, **_kwargs: 200)
+    monkeypatch.setattr(discover, "_http_response", lambda _url, **_kwargs: (200, "text/html", "&lt;div&gt;broken"))
+    content_broken = discover._service_health("https://example.test/", {})
+    assert content_broken["reachable"] is True
+    assert content_broken["health"] == "degraded"
+    assert content_broken["content_ok"] is False
+
+    monkeypatch.setattr(discover, "_http_probe", lambda _url, **_kwargs: None)
+    assert discover._service_health("https://example.test/", {}) == {"reachable": False, "health": "unreachable"}
 
 
 def test_load_dashboard_brew_services(mock_env, monkeypatch):

--- a/tests/python/test_landing_state.py
+++ b/tests/python/test_landing_state.py
@@ -41,6 +41,7 @@ def test_discovery_writes_runtime_state_not_catalog(tmp_path, monkeypatch):
     monkeypatch.setattr(discover, "KNOWN_SERVICES", state.load_catalog()["services"])
     monkeypatch.setattr(discover, "_scan_localhost", lambda **_kwargs: [])
     monkeypatch.setattr(discover, "_http_probe", lambda _url, **_kwargs: 200)
+    monkeypatch.setattr(discover, "_http_response", lambda _url, **_kwargs: (200, "application/json", "{}"))
 
     before = catalog.read_text(encoding="utf-8")
     result = discover.discover()
@@ -48,6 +49,13 @@ def test_discovery_writes_runtime_state_not_catalog(tmp_path, monkeypatch):
     assert result["services"][0]["status_code"] == 200
     assert catalog.read_text(encoding="utf-8") == before
     assert runtime.is_file()
+
+
+def test_landing_template_has_healthy_degraded_and_unreachable_badges():
+    template = (ROOT / "control" / "landing" / "templates" / "index.html").read_text(encoding="utf-8")
+    assert "status-dot" in template
+    assert "warning" in template
+    assert "reachable but unhealthy" in template
 
 
 def test_load_registered_ports_from_registry(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #233.

- Classify every discovered service as healthy, degraded, or unreachable. HTTP success is 2xx by default, with catalogued `accepted_status_codes` for expected exceptions such as OpenObserve's 308.
- Statically inspect all HTML responses: flag escaped markup, enforce optional `must_contain` markers, and fetch every script/link asset expecting HTTP 200.
- Render degraded services amber, preserving green for healthy and red for unreachable.
- Add dashboard/stats identity markers and regression coverage for status gating, assets, escaped markup, markers, and the three-state badge.

## Test plan

- [x] Focused landing tests: 42 passed
- [x] Full Python suite: 709 passed, 1 skipped
- [x] Shell TAP suite: 121/121 passed
- [x] `just ansible-test`: android_common (64 modules + 17 module_utils), termux (20), play (7) all passed
- [x] Touched-file Ruff and Prettier checks
- [ ] Repository-wide `just test` / `just lint`: blocked by pre-existing unrelated Ruff, format, Mypy, identity, dashboard-link, and local Chrome failures; this PR does not modify those files or environment dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced service health monitoring with healthy, degraded, and unreachable statuses.
  * Added clearer status indicators, warning colors, and diagnostic tooltips to the landing page.
  * Improved handling of redirects and service-specific health-check rules.
  * Added validation for expected content and referenced assets.

* **Bug Fixes**
  * Improved detection and reporting of HTTP failures, invalid content, and unavailable services.
  * Local service checks now work more reliably when accessed through public hostnames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->