### PR TITLE
Fix dashboard double-escaped cards, root-absolute links, and /stats 500

### DIFF
--- a/control/bin/dashboard.py
+++ b/control/bin/dashboard.py
@@ -533,9 +533,14 @@ def _render_template(name: str, **ctx) -> str:
 def index():
     devices = build_device_data()
     now = time.strftime("%Y-%m-%d %H:%M:%S")
-    cards = "\n".join(
-        _render_template("_device_card.html", device=d, oc_web_url=OC_WEB_URL, network_url=NETWORK_URL, now=now)
-        for d in devices
+    # Each card is already-rendered HTML; wrap in Markup before interpolating
+    # into dashboard.html's {{ cards }} or Jinja re-escapes it (matches the
+    # _svc_badge() convention used elsewhere in this file).
+    cards = Markup(
+        "\n".join(
+            _render_template("_device_card.html", device=d, oc_web_url=OC_WEB_URL, network_url=NETWORK_URL, now=now)
+            for d in devices
+        )
     )
     return _render_template("dashboard.html", cards=cards, oc_web_url=OC_WEB_URL, network_url=NETWORK_URL, now=now)
 
@@ -795,7 +800,7 @@ def errors_page():
     )
 
 
-@app.route("/stats")
+@app.route("/stats", strict_slashes=False)
 def stats_page():
     range_str = request.args.get("range", "1w")
     delta = _parse_timeframe(range_str)

--- a/control/site_contract/sync_templates/fragments/caddy/stayturgid.caddy.j2
+++ b/control/site_contract/sync_templates/fragments/caddy/stayturgid.caddy.j2
@@ -11,12 +11,34 @@
 # (Caddy sorts unmatched handle last as catch-all).
 #
 # Path policy:
-# - handle_path (strip prefix): apps that assume they own / (dashboard, opencode,
-#   stats, olivetin, victoriametrics).
+# - handle_path (strip prefix): apps that assume they own / (dashboard,
+#   opencode, olivetin, victoriametrics) plus LiteLLM, whose own FastAPI
+#   routes (e.g. the Swagger asset mount) are always registered at bare
+#   paths — the proxy must keep stripping the prefix; LiteLLM is instead
+#   told its external prefix via SERVER_ROOT_PATH (site-djbclark
+#   roles/litellm) purely so it *generates* correct absolute links
+#   (Swagger JS/CSS URLs, OpenAPI "servers", /ui redirects). Verified by
+#   reading litellm/proxy/proxy_server.py directly — root_path passed to
+#   FastAPI() only affects link generation, not routing.
 # - handle (preserve path): apps configured with a base/sub path (Grafana
-#   serve_from_sub_path + root_url=/grafana/; OpenObserve ZO_BASE_URI=/oo).
+#   serve_from_sub_path + root_url=/grafana/; OpenObserve ZO_BASE_URI=/oo)
+#   or apps whose backend route needs to see the literal path segment
+#   (stayturgid /stats — the dashboard backend's own /stats route, as
+#   opposed to /dashboard/* which lands on its bare "/" route).
 #   Stripping would 301-loop Grafana (root_url → strip → root_url) and send
 #   OO's /web/ redirect off the /oo/ prefix.
+#
+# OliveTin (still handle_path, unresolved): the pinned OliveTin 3000.17.1
+# webUI ships a static, pre-built index.html with a hardcoded
+# `<base href="/" />` and root-absolute /assets/*.js references baked in at
+# build time (verified in ~/.local/share/olivetin/webui/index.html — no
+# server-side templating). OliveTin's own docs (reverse-proxies/caddy.html)
+# document `externalRestAddress` for the API base under a subpath, but that
+# does not touch the static asset URLs, and there is no config key (checked
+# the binary's full koanf tag list) to rewrite the baked-in base href.
+# Neither handle nor handle_path fixes this without a replace_response-style
+# HTML rewrite, which was explicitly ruled out — escalating as a finding
+# rather than working around it (see djbclark/site-djbclark#84).
 
 # Fleet dashboard (legacy Flask; retained until full D7)
 handle_path /dashboard/* {
@@ -43,8 +65,15 @@ handle_path /litellm/* {
 }
 {% endif %}
 
-# Fleet stats (same backend as dashboard)
-handle_path /stats/* {
+# Fleet stats (same backend as dashboard; unlike /dashboard/* this must
+# preserve the "stats" segment — the backend's own /stats route needs it,
+# handle_path stripped it down to "/" and landed on the dashboard's route
+# instead (djbclark/stayturgid#234 / djbclark/site-djbclark#84). Named matcher
+# (not `handle /stats /stats/*`, which Caddy rejects — handle takes a single
+# path argument) covers both the bare path and anything under it (backend
+# route is strict_slashes=False).
+@stats path /stats /stats/*
+handle @stats {
 	reverse_proxy 127.0.0.1:{{ ports['fleet-dashboard'] }}
 }
 

--- a/control/templates/dashboard.html
+++ b/control/templates/dashboard.html
@@ -22,7 +22,7 @@
           >stats</a
         >
         <a
-          href="/errors"
+          href="errors"
           style="color: var(--link); text-decoration: none; font-size: 11px"
           >errors</a
         >
@@ -43,7 +43,7 @@
     <main>
       <div
         id="device-grid"
-        hx-get="/api/devices"
+        hx-get="api/devices"
         hx-trigger="every 60s, load"
         hx-swap="innerHTML"
         hx-indicator="#spinner"

--- a/control/templates/errors.html
+++ b/control/templates/errors.html
@@ -12,7 +12,7 @@
       <span class="header-sub">{{ now }} — {{ count }} line(s)</span>
       <span style="display: flex; gap: 8px">
         <a
-          href="/"
+          href="."
           style="color: var(--link); text-decoration: none; font-size: 11px"
           >dashboard</a
         >

--- a/control/templates/stats.html
+++ b/control/templates/stats.html
@@ -37,6 +37,7 @@
         >
           <select name="range" class="range-select">
             {% for val, label in select_options %}
+            <!-- prettier-ignore -->
             <option value="{{ val }}" {%- if val == range_str %} selected{% endif -%}>
               {{ label }}
             </option>

--- a/control/templates/stats.html
+++ b/control/templates/stats.html
@@ -37,17 +37,7 @@
         >
           <select name="range" class="range-select">
             {% for val, label in select_options %}
-            <option
-              value="{{ val }}"
-              {%-
-              if
-              val=""
-              ="range_str"
-              %}
-              selected{%
-              endif
-              -%}
-            >
+            <option value="{{ val }}" {%- if val == range_str %} selected{% endif -%}>
               {{ label }}
             </option>
             {% endfor %}


### PR DESCRIPTION
## Summary

Three bugs in `control/bin/dashboard.py` and its templates (#234):

1. **Double-escaped device cards.** `index()` built card HTML as a plain
   `str` and interpolated it into `dashboard.html`'s `{{ cards }}`, so Jinja
   auto-escaped already-rendered markup a second time. Wrapped in `Markup()`,
   matching the existing `_svc_badge()` convention in this file.
2. **Root-absolute links break under the `/dashboard/*` subpath.** Fixed
   `hx-get="/api/devices"` → `api/devices`, `dashboard.html`'s
   `href="/errors"` → `errors`, and (same bug class, found in the audit)
   `errors.html`'s own back-link `href="/"` → `.`. `href="/stats"` is left
   absolute, per the issue — it's a real top-level Caddy route.
3. **`/stats` 500.** Root cause: `stats.html`'s `<option selected>` block was
   mangled Jinja (`{%- if val="" ="range_str" %}` — not valid syntax),
   throwing `TemplateSyntaxError` on every render. Rewritten as
   `{%- if val == range_str %} selected{% endif -%}`. Also added
   `strict_slashes=False` to the `/stats` route since the site registry and
   the Caddy fragment reference `/stats/` with a trailing slash.

Coordinated with `djbclark/site-djbclark#84`: `stayturgid.caddy.j2`'s
`/stats/*` block switches from `handle_path` (which stripped the whole
"stats" segment) to a named `handle @stats` matcher preserving the path,
plus documentation comments from the LiteLLM/OliveTin subpath investigation
done for that companion issue. **Land together** — the `/stats` fix only
works end-to-end with both PRs merged.

Companion PR: djbclark/site-djbclark#(see feature/fleet-dashboard-stats-fix branch)

Closes #234

## Test plan

- [x] `ruff check`/`ruff format --check` on touched files: clean
- [x] `bash just/tools/html_validate.sh`: all templates pass
- [x] `.venv-test/bin/pytest` (full suite): pass
- [x] `bash tests/run.sh unit`: pass (121/121)
- [x] `just site-contract-check`: OK
- [x] Manually verified via Flask test client: `/stats` now returns 200
      (was 500), `Markup()` wrap confirmed to prevent double-escaping
      (isolated repro), `/stats/` (trailing slash) now 200 via
      `strict_slashes=False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)