### PR TITLE
fix(coderabbit): enable auto_review with incremental review off, not full disable

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,6 @@
 reviews:
   auto_review:
-    enabled: false
+    enabled: true
+    auto_incremental_review: false
     labels:
       - "review-ready"


### PR DESCRIPTION
## Summary
- CodeRabbit's `auto_review.enabled: false` (set 2026-08-01 to stop re-review spam on every fixup push) also disabled the manual `@coderabbitai review` incremental re-review path, forcing the costlier `full review` command and repeatedly hitting the shared rate limit (see site-private `reference_coderabbit_manual_review_trigger.md` / `reference_coderabbit_rate_limit_tracking.md`).
- Fix: `enabled: true` + `auto_incremental_review: false` — auto-reviews once when the `review-ready` label is present (real trigger this time, per CodeRabbit's docs the label-opt-in only reliably fires on the enabled path), skips auto re-review on every push (preserves the original rate-limit goal), and should let plain `@coderabbitai review` work for fixup-commit re-reviews without needing `full review`.

## Test plan
- [ ] Confirm CodeRabbit still doesn't auto-review on every push to an already-reviewed PR (rate-limit goal preserved)
- [ ] Confirm `review-ready` label + `@coderabbitai review` triggers a first review
- [ ] Confirm a fixup push + plain `@coderabbitai review` triggers an incremental re-review without needing `full review`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review settings.
  * Automatic incremental reviews are now disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->