### PR TITLE
test: live-verify coderabbit auto_review config fix (throwaway, will not merge)

### DIFF
--- a/TEST_GUARD_SCRATCH.md
+++ b/TEST_GUARD_SCRATCH.md
@@ -1,3 +1,5 @@
 # test-guard-merged-scratch: throwaway, safe to delete
 
 live-testing coderabbit auto_review config fix, commit 1
+
+live-testing coderabbit auto_review config fix, fixup commit 2

--- a/TEST_GUARD_SCRATCH.md
+++ b/TEST_GUARD_SCRATCH.md
@@ -1,1 +1,3 @@
 # test-guard-merged-scratch: throwaway, safe to delete
+
+live-testing coderabbit auto_review config fix, commit 1


### PR DESCRIPTION
Throwaway PR to live-test the auto_review.enabled:true + auto_incremental_review:false fix from #239. Will not merge. Testing: (1) does auto-review trigger on open, (2) does a fixup push NOT get auto re-reviewed, (3) does plain @coderabbitai review work for the fixup re-review.