### PR TITLE
chore(coderabbit): fully disable auto_review, trial ended

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,5 @@
 reviews:
   auto_review:
-    enabled: true
-    auto_incremental_review: false
+    enabled: false
     labels:
       - "review-ready"


### PR DESCRIPTION
Reverting to auto_review.enabled: false — the CodeRabbit free OSS trial has ended and we should not trigger any reviews for the time being. See djbclark/coderabbit-feeder for the full handoff ticket with context. Deliberately NOT triggering a CodeRabbit review on this PR — merging on CI green only.