### PR TITLE
chore: bump ops-release.json to 1.2.8

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.2.7"
+  "version": "1.2.8"
 }


### PR DESCRIPTION
Version bump for coordinated ops-v1.2.8 release.