### PR TITLE
chore: bump ops-release.json to 1.2.9

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.2.8"
+  "version": "1.2.9"
 }


### PR DESCRIPTION
Coordinated release version bump, part of the ops-v1.2.9 cut.