### PR TITLE
Enforce secretspec as canonical path to secrets

### DIFF
--- a/.github/ci-secretspec.toml
+++ b/.github/ci-secretspec.toml
@@ -1,0 +1,8 @@
+[project]
+name = "ci-secretspec"
+revision = "1.0"
+require_reason = false
+
+[profiles.default]
+# Minimal stub for CI environments where the real secretspec.toml symlink is broken
+CI_DUMMY_SECRET = { description = "Dummy secret to satisfy secretspec parser", required = false }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ jobs:
     # upstream generic config for every check and test subprocess.
     env:
       ANSIBLE_CONFIG: ${{ github.workspace }}/ansible/ansible.cfg
+      SECRETSPEC_FILE: ${{ github.workspace }}/.github/ci-secretspec.toml
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -41,6 +42,12 @@ jobs:
         run: npm install -g markdownlint-cli
       - name: Install prettier
         run: npm install -g prettier
+      - name: Install secretspec
+        run: |
+          curl -fsSLO https://github.com/cachix/secretspec/releases/download/v0.18.0/secretspec-x86_64-unknown-linux-gnu.tar.xz
+          tar -xJf secretspec-x86_64-unknown-linux-gnu.tar.xz
+          sudo mv secretspec /usr/local/bin/
+          rm secretspec-x86_64-unknown-linux-gnu.tar.xz
       - name: Install lychee (link checker)
         run: |
           curl -fsSLO https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-x86_64-unknown-linux-gnu.tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,8 @@ jobs:
         run: |
           curl -fsSLO https://github.com/cachix/secretspec/releases/download/v0.18.0/secretspec-x86_64-unknown-linux-gnu.tar.xz
           tar -xJf secretspec-x86_64-unknown-linux-gnu.tar.xz
-          sudo mv secretspec /usr/local/bin/
-          rm secretspec-x86_64-unknown-linux-gnu.tar.xz
+          sudo mv secretspec-x86_64-unknown-linux-gnu/secretspec /usr/local/bin/
+          rm -rf secretspec-x86_64-unknown-linux-gnu.tar.xz secretspec-x86_64-unknown-linux-gnu
       - name: Install lychee (link checker)
         run: |
           curl -fsSLO https://github.com/lycheeverse/lychee/releases/download/lychee-v0.24.2/lychee-x86_64-unknown-linux-gnu.tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       ANSIBLE_CONFIG: ${{ github.workspace }}/ansible/ansible.cfg
       SECRETSPEC_FILE: ${{ github.workspace }}/.github/ci-secretspec.toml
+      SECRETSPEC_PROVIDER: dotenv
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/control/bin/ansible_exec.py
+++ b/control/bin/ansible_exec.py
@@ -46,11 +46,11 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
 
-    command = ["ansible-playbook", "-e", f"stayturgid_repo_root={REPO_ROOT}", *args[1:]]
+    command = ["secretspec", "run", "--", "ansible-playbook", "-e", f"stayturgid_repo_root={REPO_ROOT}", *args[1:]]
     try:
         return subprocess.run(command, cwd=REPO_ROOT, env=env).returncode
     except FileNotFoundError:
-        print("ERROR: ansible-playbook not found (brew install ansible)", file=sys.stderr)
+        print("ERROR: secretspec or ansible-playbook not found", file=sys.stderr)
         return 127
 
 

--- a/control/bin/check_termux_pkg_updates.py
+++ b/control/bin/check_termux_pkg_updates.py
@@ -49,9 +49,7 @@ SSH_TIMEOUT_SEC = int(os.environ.get("STAYTURGID_TERMUX_PKG_CHECK_TIMEOUT", "180
 # apt list --upgradable line, e.g.:
 #   curl/stable 8.12.1 aarch64 [upgradable from: 8.11.0]
 #   libandroid-support/stable 29-1 aarch64 [upgradable from: 28-3]
-_UPGRADABLE_RE = re.compile(
-    r"^([^/\s]+)/\S+\s+(\S+)\s+\S+\s+\[upgradable from:\s*([^\]]+)\]\s*$"
-)
+_UPGRADABLE_RE = re.compile(r"^([^/\s]+)/\S+\s+(\S+)\s+\S+\s+\[upgradable from:\s*([^\]]+)\]\s*$")
 
 
 def parse_apt_upgradable(text: str) -> list[dict[str, str]]:
@@ -225,10 +223,7 @@ def main(argv: list[str] | None = None) -> int:
         if not args.dry_run:
             hermes_notify(message)
     else:
-        print(
-            "No Termux package updates available on %s"
-            % (", ".join(hosts) if hosts else "(none)")
-        )
+        print("No Termux package updates available on %s" % (", ".join(hosts) if hosts else "(none)"))
 
     # Errors contacting hosts are non-fatal for the "updates available" path
     # (same spirit as check_apk_updates treating one bad GitHub repo as skip),

--- a/control/bin/deploy_fleet.py
+++ b/control/bin/deploy_fleet.py
@@ -48,8 +48,8 @@ from control.lib.ansible_context import (
     resolved_env,
 )
 from control.lib.fleet_deploy_lock import FleetLockHeld, fleet_lock
-from control.lib.fleet_targets import FLEET_STATUS_VAR, inventory_list as _inventory_list
-from control.lib.fleet_targets import offline_hosts, parse_inventory_hosts
+from control.lib.fleet_targets import FLEET_STATUS_VAR, offline_hosts, parse_inventory_hosts
+from control.lib.fleet_targets import inventory_list as _inventory_list
 
 SITE_PLAYBOOK = REPO_ROOT / "ansible" / "playbooks" / "site.yml"
 MAC_SITE_PLAYBOOK = REPO_ROOT / "ansible" / "playbooks" / "control_node" / "site.yml"
@@ -60,6 +60,7 @@ REQUIREMENTS = REPO_ROOT / "ansible" / "requirements.yml"
 # letting a hung or endlessly-retrying rollout run indefinitely (see #104).
 # Override with STAYTURGID_DEPLOY_TIMEOUT_SECONDS for unusually large fleets.
 DEPLOY_TIMEOUT_SECONDS = int(os.environ.get("STAYTURGID_DEPLOY_TIMEOUT_SECONDS", "1800"))
+
 
 class Scope(str, Enum):
     FULL = "full"
@@ -144,6 +145,9 @@ def require_ansible() -> None:
     if not shutil.which("ansible-playbook"):
         print("ERROR: ansible-playbook not found (brew install ansible)", file=sys.stderr)
         sys.exit(1)
+    if not shutil.which("secretspec"):
+        print("ERROR: secretspec not found (brew install secretspec)", file=sys.stderr)
+        sys.exit(1)
 
 
 def _requirements_hash() -> str:
@@ -223,6 +227,9 @@ def run_playbook(
     # belong to this checkout. Passing the latter explicitly prevents roles
     # from inferring the product root from an overlay's ansible.cfg path.
     cmd = [
+        "secretspec",
+        "run",
+        "--",
         "ansible-playbook",
         str(playbook),
         "-e",

--- a/control/bin/deploy_termux.py
+++ b/control/bin/deploy_termux.py
@@ -50,6 +50,9 @@ def main(argv: list[str] | None = None) -> int:
     if not shutil.which("ansible-playbook"):
         print("ERROR: ansible-playbook not found (brew install ansible)", file=sys.stderr)
         return 1
+    if not shutil.which("secretspec"):
+        print("ERROR: secretspec not found (brew install secretspec)", file=sys.stderr)
+        return 1
 
     context = resolve_ansible_context(REPO_ROOT)
     require_limit_hosts(context, args.host)
@@ -87,7 +90,7 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     rc = subprocess.run(
-        ["ansible-playbook", str(PLAYBOOK), "--limit", args.host],
+        ["secretspec", "run", "--", "ansible-playbook", str(PLAYBOOK), "--limit", args.host],
         env=resolved_env(REPO_ROOT),
         cwd=REPO_ROOT,
     ).returncode

--- a/control/bin/termux_pkg_nightly.py
+++ b/control/bin/termux_pkg_nightly.py
@@ -87,6 +87,9 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     cmd = [
+        "secretspec",
+        "run",
+        "--",
         "ansible-playbook",
         str(PLAYBOOK),
         "-e",
@@ -147,7 +150,7 @@ def main(argv: list[str] | None = None) -> int:
         log("ERROR: %s" % exc)
         return 3
     except FileNotFoundError:
-        log("ERROR: ansible-playbook not found on PATH=%s" % env.get("PATH"))
+        log("ERROR: secretspec or ansible-playbook not found on PATH=%s" % env.get("PATH"))
         return 2
     except subprocess.TimeoutExpired:
         log("ERROR: ansible-playbook timed out")

--- a/control/bin/verify_drift.py
+++ b/control/bin/verify_drift.py
@@ -49,7 +49,7 @@ def main(argv: list[str] | None = None) -> int:
     env["ANSIBLE_STDOUT_CALLBACK"] = "default"
 
     proc = subprocess.run(
-        ["ansible-playbook", str(PLAYBOOK), "-l", hosts],
+        ["secretspec", "run", "--", "ansible-playbook", str(PLAYBOOK), "-l", hosts],
         env=env,
         timeout=120,
     )

--- a/control/lib/termux_ssh_bootstrap.py
+++ b/control/lib/termux_ssh_bootstrap.py
@@ -164,7 +164,7 @@ def run_bootstrap_playbook(
         stdout=subprocess.DEVNULL,
         cwd=repo_root,
     )
-    cmd = ["ansible-playbook", str(playbook)]
+    cmd = ["secretspec", "run", "--", "ansible-playbook", str(playbook)]
     if hosts:
         cmd.extend(["--limit", ",".join(hosts)])
     return subprocess.run(cmd, env=env, cwd=repo_root).returncode

--- a/control/site_contract/serverapps.py
+++ b/control/site_contract/serverapps.py
@@ -64,35 +64,6 @@ KNOWN_APPS = (
 )
 OUR_CONFIG_PREFIXES = (Path.home() / ".config" / "stayturgid",)
 
-# Own-mode secrets that ansible roles read via lookup('env', ...) (e.g.
-# serverapp_openobserve, serverapp_vector). Not committed, not in secretspec —
-# self-healed here so a fresh shell/agent session doesn't need to remember to
-# `source` it before running site-serverapps.
-OWN_MODE_SECRETS_ENV_FILE = Path.home() / ".config" / "stayturgid" / "observability.env"
-
-
-def _load_own_mode_secrets_env(path: Path = OWN_MODE_SECRETS_ENV_FILE) -> dict[str, str]:
-    """Parse simple KEY=VALUE lines from an own-mode secrets file.
-
-    Never overrides a variable already present in the environment, so an
-    operator who did explicitly export something (e.g. for a one-off
-    override) still wins. Missing file is not an error — own-mode apps that
-    don't need these vars run fine without it.
-    """
-    if not path.is_file():
-        return {}
-    loaded: dict[str, str] = {}
-    for raw_line in path.read_text().splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, _, value = line.partition("=")
-        key = key.strip()
-        value = value.strip().strip('"').strip("'")
-        if key and key not in os.environ:
-            loaded[key] = value
-    return loaded
-
 
 class ServerAppsError(Exception):
     """Precondition, execution, or user-content refusal for site-serverapps."""
@@ -2077,6 +2048,9 @@ def _run_ansible_role(plan: ServerAppsPlan, app: AppPlan, *, dry_run: bool) -> N
         return
 
     cmd = [
+        "secretspec",
+        "run",
+        "--",
         "ansible-playbook",
         "-i",
         "localhost,",
@@ -2096,7 +2070,6 @@ def _run_ansible_role(plan: ServerAppsPlan, app: AppPlan, *, dry_run: bool) -> N
             text=True,
             env={
                 **os.environ,
-                **_load_own_mode_secrets_env(),
                 "ANSIBLE_ROLES_PATH": str(plan.product_root / "ansible" / "roles"),
             },
         )

--- a/control/tools/native-agent/reingest_soft_health.py
+++ b/control/tools/native-agent/reingest_soft_health.py
@@ -36,28 +36,6 @@ BATCH = 50
 MAX_ATTEMPTS = 12
 
 
-def _load_env_files() -> None:
-    for rel in (
-        Path.home() / ".config" / "djbclark" / "observability.env",
-        Path.home() / ".config" / "stayturgid" / "observability.env",
-    ):
-        if not rel.is_file():
-            continue
-        try:
-            for line in rel.read_text(encoding="utf-8", errors="replace").splitlines():
-                line = line.strip()
-                if not line or line.startswith("#") or "=" not in line:
-                    continue
-                if line.startswith("export "):
-                    line = line[len("export ") :]
-                k, _, v = line.partition("=")
-                k, v = k.strip(), v.strip().strip('"').strip("'")
-                if k and k not in os.environ:
-                    os.environ[k] = v
-        except OSError:
-            pass
-
-
 def _post_batch(uri: str, user: str, password: str, rows: list[dict]) -> None:
     body = json.dumps(rows).encode("utf-8")
     req = urllib.request.Request(
@@ -101,7 +79,6 @@ def _post_batch(uri: str, user: str, password: str, rows: list[dict]) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    _load_env_files()
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--uri", default=os.environ.get("SOFT_HEALTH_OO_URI", DEFAULT_URI))
     p.add_argument("--since", default=None, help="ISO ts inclusive, e.g. 2026-07-20T00:00:00Z")

--- a/control/tools/native-agent/reingest_soft_health.py
+++ b/control/tools/native-agent/reingest_soft_health.py
@@ -10,10 +10,9 @@ Never deletes or truncates the JSONL. Skips corrupt lines. Batches POSTs with
 retries on 5xx / connection errors (not on permanent 4xx except 429).
 
 Usage:
-  ./reingest_soft_health.py
-  ./reingest_soft_health.py --since 2026-07-20T00:00:00Z
-  ./reingest_soft_health.py --dry-run
-  OPENOBSERVE_ROOT_EMAIL=… OPENOBSERVE_ROOT_PASSWORD=… ./reingest_soft_health.py
+  secretspec run -- ./reingest_soft_health.py
+  secretspec run -- ./reingest_soft_health.py --since 2026-07-20T00:00:00Z
+  secretspec run -- ./reingest_soft_health.py --dry-run
 """
 
 from __future__ import annotations
@@ -65,8 +64,8 @@ def _post_batch(uri: str, user: str, password: str, rows: list[dict]) -> None:
             if e.code in (401, 403):
                 raise SystemExit(
                     f"OpenObserve auth failed HTTP {e.code}. "
-                    "Set OPENOBSERVE_ROOT_EMAIL / OPENOBSERVE_ROOT_PASSWORD "
-                    "(and Vector launchd EnvironmentVariables)."
+                    "Run via `secretspec run -- ./reingest_soft_health.py` "
+                    "(and update Vector launchd EnvironmentVariables)."
                 ) from e
             if e.code == 429 or e.code >= 500:
                 time.sleep(min(60, 2**attempt))

--- a/control/tools/native-agent/rollout.py
+++ b/control/tools/native-agent/rollout.py
@@ -28,6 +28,7 @@ REPO = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO))
 sys.path.insert(0, str(REPO / "control" / "lib"))
 import stayturgid_device as dev  # noqa: E402
+
 from control.lib.fleet_targets import resolve_hosts  # noqa: E402
 
 APK = REPO / "device" / "native-agent" / "app" / "build" / "outputs" / "apk" / "debug" / "app-debug.apk"

--- a/device/termux/py/stayturgid_bridges.py
+++ b/device/termux/py/stayturgid_bridges.py
@@ -120,7 +120,7 @@ def main() -> int:
         choices=["repair"],
         help="Bridge mode: repair (stayturgid_repair.py)",
     )
-    args = parser.parse_args()
+    _ = parser.parse_args()
 
     pidfile = os.path.join(STG, "run", "bridges.pid")
     if _pidfile_alive(pidfile):

--- a/device/termux/py/stayturgid_repair.py
+++ b/device/termux/py/stayturgid_repair.py
@@ -480,8 +480,7 @@ def ensure_tailscale(have_sh=False):
     restored = _wait_for_tailscale(have_sh=have_sh)
     if not restored:
         log(
-            "Tailscale still down after CONNECT_VPN broadcast; leaving the "
-            "foreground app untouched",
+            "Tailscale still down after CONNECT_VPN broadcast; leaving the foreground app untouched",
             NOTICE,
         )
 
@@ -1226,12 +1225,10 @@ def main():
         auto_profile = "retired"
         # Shizuku: only re-apply when Shizuku is down.
         _, sf_out = sh_adb("[ -f /data/local/tmp/shizuku-fleet.json ] && echo ok || echo missing")
-        profile = "/data/local/tmp/shizuku-fleet.json"
         if "missing" in sf_out:
             _, sf_out2 = sh_adb("[ -f /sdcard/Download/shizuku-fleet.json ] && echo ok || echo missing")
             if "ok" in sf_out2:
                 sf_out = sf_out2
-                profile = "/sdcard/Download/shizuku-fleet.json"
 
         if "ok" in sf_out:
             shizuku_profile = "present"

--- a/tests/python/test_ansible_exec.py
+++ b/tests/python/test_ansible_exec.py
@@ -44,6 +44,9 @@ def test_ansible_exec_delegates_env_to_resolved_env(monkeypatch, tmp_path):
 
     assert ae.main(["ansible-playbook", "ansible/playbooks/site.yml", "--syntax-check"]) == 0
     assert seen["command"] == [
+        "secretspec",
+        "run",
+        "--",
         "ansible-playbook",
         "-e",
         f"stayturgid_repo_root={ae.REPO_ROOT}",

--- a/tests/python/test_bootstrap_apk_lock.py
+++ b/tests/python/test_bootstrap_apk_lock.py
@@ -24,22 +24,20 @@ def test_every_github_apk_is_immutably_locked():
 def test_only_x11_has_the_explicit_mutable_tag_snapshot_exception():
     mutable_aliases = {"nightly"}
     snapshots = [apk for apk in _catalog() if apk["gh_tag"] in mutable_aliases]
-    assert snapshots == [
-        next(apk for apk in _catalog() if apk["id"] == "com.termux.x11")
-    ]
+    assert snapshots == [next(apk for apk in _catalog() if apk["id"] == "com.termux.x11")]
     assert snapshots[0]["mutable_tag_snapshot"] is True
 
 
 def test_x11_snapshot_policy_is_limited_and_verified_on_every_deploy():
-    role_tasks = (
-        ROOT / "ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/main.yml"
-    ).read_text(encoding="utf-8")
+    role_tasks = (ROOT / "ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/main.yml").read_text(
+        encoding="utf-8"
+    )
     install_tasks = (
         ROOT / "ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/install_apk.yml"
     ).read_text(encoding="utf-8")
-    module = (
-        ROOT / "ansible_collections/stayturgid/android_common/plugins/modules/android_apk.py"
-    ).read_text(encoding="utf-8")
+    module = (ROOT / "ansible_collections/stayturgid/android_common/plugins/modules/android_apk.py").read_text(
+        encoding="utf-8"
+    )
 
     assert "_locked_apk.id == 'com.termux.x11' and _locked_apk.gh_tag == 'nightly'" in role_tasks
     assert 'verify_on_current: "{{ _apk.mutable_tag_snapshot | default(false) }}"' in install_tasks
@@ -64,9 +62,9 @@ def test_normal_deploy_ensures_before_it_verifies():
 
 def test_monkey_launch_is_limited_to_a_real_install():
     tasks = yaml.safe_load(
-        (
-            ROOT / "ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/install_apk.yml"
-        ).read_text(encoding="utf-8")
+        (ROOT / "ansible_collections/stayturgid/android_common/roles/bootstrap_apks/tasks/install_apk.yml").read_text(
+            encoding="utf-8"
+        )
     )
     reconcile = next(task for task in tasks if task["name"].startswith("Reconcile locked APK"))
     install = next(task for task in reconcile["block"] if task["name"].startswith("Install over ADB"))

--- a/tests/python/test_deploy_fleet.py
+++ b/tests/python/test_deploy_fleet.py
@@ -36,6 +36,9 @@ def test_run_playbook_argv_full(monkeypatch):
     monkeypatch.setattr(df.subprocess, "run", fake_run)
     df.run_playbook(df.SITE_PLAYBOOK, limit=["oneui-device", "fireos-device"], check=False, tags=None)
     assert seen[0] == [
+        "secretspec",
+        "run",
+        "--",
         "ansible-playbook",
         str(df.SITE_PLAYBOOK),
         "-e",
@@ -75,6 +78,9 @@ def test_run_playbook_argv_check_and_tags(monkeypatch):
     monkeypatch.setattr(df.subprocess, "run", fake_run)
     df.run_playbook(df.SITE_PLAYBOOK, limit=["oneui-device"], check=True, tags="app-stores")
     assert seen[0] == [
+        "secretspec",
+        "run",
+        "--",
         "ansible-playbook",
         str(df.SITE_PLAYBOOK),
         "-e",

--- a/tests/python/test_fleet_entry_guards.py
+++ b/tests/python/test_fleet_entry_guards.py
@@ -132,7 +132,7 @@ def test_deploy_termux_uses_resolved_context(tmp_path, monkeypatch) -> None:
 
     monkeypatch.setattr(dt.subprocess, "run", fake_run)
     assert dt.main(["oneui-device"]) == 0
-    playbook_calls = [(c, k) for c, k in seen if c and c[0] == "ansible-playbook"]
+    playbook_calls = [(c, k) for c, k in seen if c and "ansible-playbook" in c]
     assert playbook_calls, "ansible-playbook was not invoked"
     _, kwargs = playbook_calls[0]
     assert kwargs["env"]["ANSIBLE_CONFIG"] == str(config)

--- a/tests/python/test_serverapps.py
+++ b/tests/python/test_serverapps.py
@@ -99,38 +99,6 @@ def _write_site_map(dest: Path, body: str) -> None:
     (dest / "site-map.yml").write_text(body, encoding="utf-8")
 
 
-# --- own-mode secrets env loader --------------------------------------------
-
-
-def test_load_own_mode_secrets_env_missing_file_returns_empty(tmp_path: Path) -> None:
-    assert sa._load_own_mode_secrets_env(tmp_path / "nope.env") == {}
-
-
-def test_load_own_mode_secrets_env_parses_key_value_lines(tmp_path: Path) -> None:
-    env_file = tmp_path / "observability.env"
-    env_file.write_text(
-        "# comment\n"
-        "\n"
-        "OPENOBSERVE_ROOT_EMAIL=someone@example.com\n"
-        'OPENOBSERVE_ROOT_PASSWORD="quoted-value"\n'
-        "not-a-valid-line\n",
-        encoding="utf-8",
-    )
-    loaded = sa._load_own_mode_secrets_env(env_file)
-    assert loaded == {
-        "OPENOBSERVE_ROOT_EMAIL": "someone@example.com",
-        "OPENOBSERVE_ROOT_PASSWORD": "quoted-value",
-    }
-
-
-def test_load_own_mode_secrets_env_does_not_override_existing_env(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.setenv("OPENOBSERVE_ROOT_EMAIL", "already-set@example.com")
-    env_file = tmp_path / "observability.env"
-    env_file.write_text("OPENOBSERVE_ROOT_EMAIL=from-file@example.com\n", encoding="utf-8")
-    loaded = sa._load_own_mode_secrets_env(env_file)
-    assert "OPENOBSERVE_ROOT_EMAIL" not in loaded
-
-
 # --- mode resolution -------------------------------------------------------
 
 

--- a/tests/python/test_termux_pkg_nightly.py
+++ b/tests/python/test_termux_pkg_nightly.py
@@ -43,6 +43,9 @@ def test_nightly_runner_uses_resolved_site_config(monkeypatch, tmp_path):
     # --check skips the #152 pre-check so subprocess.run is only ansible-playbook.
     assert nightly.main(["--check", "--limit", "oneui-device"]) == 0
     assert seen["command"] == [
+        "secretspec",
+        "run",
+        "--",
         "ansible-playbook",
         str(nightly.PLAYBOOK),
         "-e",
@@ -128,10 +131,10 @@ def test_nightly_runs_precheck_before_upgrade(monkeypatch, tmp_path):
     assert nightly.main(["--limit", "s24"]) == 0
     assert len(calls) >= 2
     assert any("check_termux_pkg_updates.py" in str(c) for c in calls)
-    assert any(c and c[0] == "ansible-playbook" for c in calls)
+    assert any(c and "ansible-playbook" in c for c in calls)
     # Pre-check before ansible.
     pre_idx = next(i for i, c in enumerate(calls) if "check_termux_pkg_updates.py" in str(c))
-    ap_idx = next(i for i, c in enumerate(calls) if c and c[0] == "ansible-playbook")
+    ap_idx = next(i for i, c in enumerate(calls) if c and "ansible-playbook" in c)
     assert pre_idx < ap_idx
     assert "--limit" in calls[pre_idx]
     assert "s24" in calls[pre_idx]
@@ -172,5 +175,5 @@ def test_nightly_continues_when_precheck_times_out(monkeypatch, tmp_path):
     monkeypatch.setattr(nightly.subprocess, "run", fake_run)
 
     assert nightly.main(["--limit", "s24"]) == 0
-    assert any(c and c[0] == "ansible-playbook" for c in calls)
+    assert any(c and "ansible-playbook" in c for c in calls)
     assert any("pre-check failed" in msg for msg in logged)


### PR DESCRIPTION
This PR finalizes the migration to make secretspec the ONLY canonical path to secret values across the ops-djbclark suite.

- Refactors tools, scripts, and tests to expect the secretspec wrapper.
- Replaces obsolete test environment mocks.
- Cleans up formatting and lint issues.

Note: Item 4 (access-control implementation) is explicitly NOT included in this PR pending operator sign-off. A design doc evaluating access-control strategies has been prepared for separate review.