### PR TITLE
Enforce canonical secretspec execution path

### DIFF
--- a/control/bin/ansible_exec.py
+++ b/control/bin/ansible_exec.py
@@ -46,7 +46,10 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
 
-    command = ["secretspec", "run", "--", "ansible-playbook", "-e", f"stayturgid_repo_root={REPO_ROOT}", *args[1:]]
+    command = [
+        "sudo", "-n", "-u", "_secretspec", "secretspec", "-f", "/var/db/stayturgid-secrets/secretspec.toml", "run", "--",
+        "ansible-playbook", "-e", f"stayturgid_repo_root={REPO_ROOT}", *args[1:]
+    ]
     try:
         return subprocess.run(command, cwd=REPO_ROOT, env=env).returncode
     except FileNotFoundError:

--- a/control/bin/deploy_fleet.py
+++ b/control/bin/deploy_fleet.py
@@ -227,7 +227,13 @@ def run_playbook(
     # belong to this checkout. Passing the latter explicitly prevents roles
     # from inferring the product root from an overlay's ansible.cfg path.
     cmd = [
+        "sudo",
+        "-n",
+        "-u",
+        "_secretspec",
         "secretspec",
+        "-f",
+        "/var/db/stayturgid-secrets/secretspec.toml",
         "run",
         "--",
         "ansible-playbook",

--- a/control/bin/deploy_termux.py
+++ b/control/bin/deploy_termux.py
@@ -90,7 +90,7 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     rc = subprocess.run(
-        ["secretspec", "run", "--", "ansible-playbook", str(PLAYBOOK), "--limit", args.host],
+        ["sudo", "-n", "-u", "_secretspec", "secretspec", "-f", "/var/db/stayturgid-secrets/secretspec.toml", "run", "--", "ansible-playbook", str(PLAYBOOK), "--limit", args.host],
         env=resolved_env(REPO_ROOT),
         cwd=REPO_ROOT,
     ).returncode

--- a/control/bin/firerpa_mcp.py
+++ b/control/bin/firerpa_mcp.py
@@ -38,20 +38,15 @@ except ImportError:
 
 
 def get_bearer_token() -> str | None:
-    path = os.path.expanduser("~/.config/stayturgid/secretspec.toml")
-    if not os.path.exists(path):
-        return None
     try:
-        import tomllib
-    except ImportError:
-        try:
-            import tomli as tomllib
-        except ImportError:
-            return None
-    try:
-        with open(path, "rb") as f:
-            data = tomllib.load(f)
-        return data.get("firerpa_mcp_token")
+        res = subprocess.run(
+            ["sudo", "-n", "-u", "_secretspec", "secretspec", "-f", "/var/db/stayturgid-secrets/secretspec.toml", "get", "firerpa_mcp_token"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        token = res.stdout.strip()
+        return token if token else None
     except Exception:
         return None
 

--- a/control/bin/publish_secrets.sh
+++ b/control/bin/publish_secrets.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script safely publishes secrets from the operator's workspace
+# into the locked-down /var/db/stayturgid-secrets/ directory.
+
+TARGET_DIR="/var/db/stayturgid-secrets"
+OPS_ROOT="${OPS_ROOT:-$HOME/ops}"
+PRIVATE_SITE_DIR="$OPS_ROOT/site-private"
+
+echo "Publishing secrets to $TARGET_DIR..."
+
+if [ ! -d "$PRIVATE_SITE_DIR" ]; then
+    echo "Error: Private site directory $PRIVATE_SITE_DIR not found." >&2
+    exit 1
+fi
+
+if [ ! -f "$PRIVATE_SITE_DIR/.env" ] || [ ! -f "$PRIVATE_SITE_DIR/secretspec.toml" ]; then
+    echo "Error: .env or secretspec.toml missing in $PRIVATE_SITE_DIR." >&2
+    exit 1
+fi
+
+sudo mkdir -p "$TARGET_DIR"
+sudo cp "$PRIVATE_SITE_DIR/.env" "$TARGET_DIR/.env"
+sudo cp "$PRIVATE_SITE_DIR/secretspec.toml" "$TARGET_DIR/secretspec.toml"
+
+sudo chown -R _secretspec "$TARGET_DIR"
+sudo chmod 0700 "$TARGET_DIR"
+sudo chmod 0600 "$TARGET_DIR/.env" "$TARGET_DIR/secretspec.toml"
+
+# Verify hashes match
+SRC_ENV_HASH=$(shasum -a 256 "$PRIVATE_SITE_DIR/.env" | awk '{print $1}')
+DST_ENV_HASH=$(sudo shasum -a 256 "$TARGET_DIR/.env" | awk '{print $1}')
+
+if [ "$SRC_ENV_HASH" != "$DST_ENV_HASH" ]; then
+    echo "Error: Hash mismatch for .env after publishing!" >&2
+    exit 1
+fi
+
+SRC_TOML_HASH=$(shasum -a 256 "$PRIVATE_SITE_DIR/secretspec.toml" | awk '{print $1}')
+DST_TOML_HASH=$(sudo shasum -a 256 "$TARGET_DIR/secretspec.toml" | awk '{print $1}')
+
+if [ "$SRC_TOML_HASH" != "$DST_TOML_HASH" ]; then
+    echo "Error: Hash mismatch for secretspec.toml after publishing!" >&2
+    exit 1
+fi
+
+echo "Secrets published successfully. Hashes matched."

--- a/control/bin/termux_pkg_nightly.py
+++ b/control/bin/termux_pkg_nightly.py
@@ -87,7 +87,13 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     cmd = [
+        "sudo",
+        "-n",
+        "-u",
+        "_secretspec",
         "secretspec",
+        "-f",
+        "/var/db/stayturgid-secrets/secretspec.toml",
         "run",
         "--",
         "ansible-playbook",

--- a/control/bin/verify_drift.py
+++ b/control/bin/verify_drift.py
@@ -49,7 +49,7 @@ def main(argv: list[str] | None = None) -> int:
     env["ANSIBLE_STDOUT_CALLBACK"] = "default"
 
     proc = subprocess.run(
-        ["secretspec", "run", "--", "ansible-playbook", str(PLAYBOOK), "-l", hosts],
+        ["sudo", "-n", "-u", "_secretspec", "secretspec", "-f", "/var/db/stayturgid-secrets/secretspec.toml", "run", "--", "ansible-playbook", str(PLAYBOOK), "-l", hosts],
         env=env,
         timeout=120,
     )

--- a/control/lib/termux_ssh_bootstrap.py
+++ b/control/lib/termux_ssh_bootstrap.py
@@ -164,7 +164,7 @@ def run_bootstrap_playbook(
         stdout=subprocess.DEVNULL,
         cwd=repo_root,
     )
-    cmd = ["secretspec", "run", "--", "ansible-playbook", str(playbook)]
+    cmd = ["sudo", "-n", "-u", "_secretspec", "secretspec", "-f", "/var/db/stayturgid-secrets/secretspec.toml", "run", "--", "ansible-playbook", str(playbook)]
     if hosts:
         cmd.extend(["--limit", ",".join(hosts)])
     return subprocess.run(cmd, env=env, cwd=repo_root).returncode

--- a/control/site_contract/serverapps.py
+++ b/control/site_contract/serverapps.py
@@ -2048,7 +2048,13 @@ def _run_ansible_role(plan: ServerAppsPlan, app: AppPlan, *, dry_run: bool) -> N
         return
 
     cmd = [
+        "sudo",
+        "-n",
+        "-u",
+        "_secretspec",
         "secretspec",
+        "-f",
+        "/var/db/stayturgid-secrets/secretspec.toml",
         "run",
         "--",
         "ansible-playbook",

--- a/control/tools/native-agent/reingest_soft_health.py
+++ b/control/tools/native-agent/reingest_soft_health.py
@@ -10,9 +10,9 @@ Never deletes or truncates the JSONL. Skips corrupt lines. Batches POSTs with
 retries on 5xx / connection errors (not on permanent 4xx except 429).
 
 Usage:
-  secretspec run -- ./reingest_soft_health.py
-  secretspec run -- ./reingest_soft_health.py --since 2026-07-20T00:00:00Z
-  secretspec run -- ./reingest_soft_health.py --dry-run
+  sudo -u _secretspec secretspec -f /var/db/stayturgid-secrets/secretspec.toml run -- ./reingest_soft_health.py
+  sudo -u _secretspec secretspec -f /var/db/stayturgid-secrets/secretspec.toml run -- ./reingest_soft_health.py --since 2026-07-20T00:00:00Z
+  sudo -u _secretspec secretspec -f /var/db/stayturgid-secrets/secretspec.toml run -- ./reingest_soft_health.py --dry-run
 """
 
 from __future__ import annotations
@@ -64,7 +64,7 @@ def _post_batch(uri: str, user: str, password: str, rows: list[dict]) -> None:
             if e.code in (401, 403):
                 raise SystemExit(
                     f"OpenObserve auth failed HTTP {e.code}. "
-                    "Run via `secretspec run -- ./reingest_soft_health.py` "
+                    "Run via `sudo -u _secretspec secretspec -f /var/db/stayturgid-secrets/secretspec.toml run -- ./reingest_soft_health.py` "
                     "(and update Vector launchd EnvironmentVariables)."
                 ) from e
             if e.code == 429 or e.code >= 500:

--- a/tests/python/test_ansible_exec.py
+++ b/tests/python/test_ansible_exec.py
@@ -44,7 +44,13 @@ def test_ansible_exec_delegates_env_to_resolved_env(monkeypatch, tmp_path):
 
     assert ae.main(["ansible-playbook", "ansible/playbooks/site.yml", "--syntax-check"]) == 0
     assert seen["command"] == [
+        "sudo",
+        "-n",
+        "-u",
+        "_secretspec",
         "secretspec",
+        "-f",
+        "/var/db/stayturgid-secrets/secretspec.toml",
         "run",
         "--",
         "ansible-playbook",

--- a/tests/python/test_deploy_fleet.py
+++ b/tests/python/test_deploy_fleet.py
@@ -36,7 +36,13 @@ def test_run_playbook_argv_full(monkeypatch):
     monkeypatch.setattr(df.subprocess, "run", fake_run)
     df.run_playbook(df.SITE_PLAYBOOK, limit=["oneui-device", "fireos-device"], check=False, tags=None)
     assert seen[0] == [
+        "sudo",
+        "-n",
+        "-u",
+        "_secretspec",
         "secretspec",
+        "-f",
+        "/var/db/stayturgid-secrets/secretspec.toml",
         "run",
         "--",
         "ansible-playbook",
@@ -78,7 +84,13 @@ def test_run_playbook_argv_check_and_tags(monkeypatch):
     monkeypatch.setattr(df.subprocess, "run", fake_run)
     df.run_playbook(df.SITE_PLAYBOOK, limit=["oneui-device"], check=True, tags="app-stores")
     assert seen[0] == [
+        "sudo",
+        "-n",
+        "-u",
+        "_secretspec",
         "secretspec",
+        "-f",
+        "/var/db/stayturgid-secrets/secretspec.toml",
         "run",
         "--",
         "ansible-playbook",

--- a/tests/python/test_termux_pkg_nightly.py
+++ b/tests/python/test_termux_pkg_nightly.py
@@ -43,7 +43,13 @@ def test_nightly_runner_uses_resolved_site_config(monkeypatch, tmp_path):
     # --check skips the #152 pre-check so subprocess.run is only ansible-playbook.
     assert nightly.main(["--check", "--limit", "oneui-device"]) == 0
     assert seen["command"] == [
+        "sudo",
+        "-n",
+        "-u",
+        "_secretspec",
         "secretspec",
+        "-f",
+        "/var/db/stayturgid-secrets/secretspec.toml",
         "run",
         "--",
         "ansible-playbook",


### PR DESCRIPTION
Updates all callers to use sudo -u _secretspec secretspec -f /var/db/stayturgid-secrets/secretspec.toml run -- instead of bare secretspec run -- to enforce isolated secrets access.