### PR TITLE
chore: bump ops-release.json to 1.3.0

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.2.9"
+  "version": "1.3.0"
 }


### PR DESCRIPTION
Coordinated ops release 1.3.0. See site-djbclark docs/OPS-RELEASES.md for the release contract.