### PR TITLE
release: ops-v1.3.1

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.3.0"
+  "version": "1.3.1"
 }


### PR DESCRIPTION
Coordinated suite version bump to `ops-v1.3.1`. Part of a three-repo cut — the release contract requires the same annotated tag and matching `ops-release.json` in `stayturgid`, `site-djbclark`, and `site-private`.

**What is actually in this release:** `site-djbclark` `registry/ports.yml` — claims port 18765 for the Hermes `signal-cli` daemon (moved off 8080 after it collided with `caddy-health`, a port this registry already recorded as having caused one prior collision), and reconciles the registry against live listeners: 9 previously-undeclared services declared, ephemeral per-session ports documented as never-claim. Plus the agent skill library evaluation doc (#100).

`stayturgid` and `site-private` carry no functional change in this release — version parity only.

Claim held: `just ops-release-claim-begin 1.3.1 cut`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)