### PR TITLE
fix(secrets): fall back to direct secretspec where the privilege boundary is absent

### DIFF
--- a/control/bin/ansible_exec.py
+++ b/control/bin/ansible_exec.py
@@ -23,6 +23,7 @@ from control.lib.ansible_context import (
     resolve_ansible_context,
     resolved_env,
 )
+from control.lib.secretspec_exec import secretspec_run
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -46,19 +47,12 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
 
-    command = [
-        "sudo",
-        "-n",
-        "-u",
-        "_secretspec",
-        "/usr/local/libexec/stayturgid-secretspec-wrapper.sh",
-        "run",
-        "--",
+    command = secretspec_run(
         "ansible-playbook",
         "-e",
         f"stayturgid_repo_root={REPO_ROOT}",
         *args[1:],
-    ]
+    )
     try:
         return subprocess.run(command, cwd=REPO_ROOT, env=env).returncode
     except FileNotFoundError:

--- a/control/bin/deploy_fleet.py
+++ b/control/bin/deploy_fleet.py
@@ -48,6 +48,7 @@ from control.lib.ansible_context import (
     resolved_env,
 )
 from control.lib.fleet_deploy_lock import FleetLockHeld, fleet_lock
+from control.lib.secretspec_exec import secretspec_run
 from control.lib.fleet_targets import FLEET_STATUS_VAR, offline_hosts, parse_inventory_hosts
 from control.lib.fleet_targets import inventory_list as _inventory_list
 
@@ -226,19 +227,12 @@ def run_playbook(
     # Inventory belongs to the active site config, while product files always
     # belong to this checkout. Passing the latter explicitly prevents roles
     # from inferring the product root from an overlay's ansible.cfg path.
-    cmd = [
-        "sudo",
-        "-n",
-        "-u",
-        "_secretspec",
-        "/usr/local/libexec/stayturgid-secretspec-wrapper.sh",
-        "run",
-        "--",
+    cmd = secretspec_run(
         "ansible-playbook",
         str(playbook),
         "-e",
         f"stayturgid_repo_root={REPO_ROOT}",
-    ]
+    )
     if limit:
         cmd.extend(["--limit", ",".join(limit)])
     if check:

--- a/control/bin/deploy_termux.py
+++ b/control/bin/deploy_termux.py
@@ -20,6 +20,7 @@ SSH_OPTS = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=8", "-o", "LogLevel=ERR
 sys.path.insert(0, str(REPO_ROOT / "control" / "lib"))
 import adb_cli as ac
 import termux_ssh_bootstrap as boot
+from secretspec_exec import secretspec_run
 from ansible_context import (
     AnsibleConfigError,
     require_fresh_checkout,
@@ -90,19 +91,12 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     rc = subprocess.run(
-        [
-            "sudo",
-            "-n",
-            "-u",
-            "_secretspec",
-            "/usr/local/libexec/stayturgid-secretspec-wrapper.sh",
-            "run",
-            "--",
+        secretspec_run(
             "ansible-playbook",
             str(PLAYBOOK),
             "--limit",
             args.host,
-        ],
+        ),
         env=resolved_env(REPO_ROOT),
         cwd=REPO_ROOT,
     ).returncode

--- a/control/bin/firerpa_mcp.py
+++ b/control/bin/firerpa_mcp.py
@@ -18,6 +18,7 @@ import control.bin.firerpa_heal as heal
 from control.lib.firerpa_auth import certificate_path
 from control.lib.firerpa_consent import HealSession, check_consent
 from control.lib.firerpa_fleet import get_fleet
+from control.lib.secretspec_exec import secretspec_command
 from control.lib.site_logging import WARNING, log
 
 LOG_NAME = "firerpa-mcp.log"
@@ -39,15 +40,7 @@ except ImportError:
 def get_bearer_token() -> str | None:
     try:
         res = subprocess.run(
-            [
-                "sudo",
-                "-n",
-                "-u",
-                "_secretspec",
-                "/usr/local/libexec/stayturgid-secretspec-wrapper.sh",
-                "get",
-                "firerpa_mcp_token",
-            ],
+            secretspec_command("get", "firerpa_mcp_token"),
             capture_output=True,
             text=True,
             check=True,

--- a/control/bin/termux_pkg_nightly.py
+++ b/control/bin/termux_pkg_nightly.py
@@ -29,6 +29,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from control.lib.ansible_context import AnsibleConfigError, require_inventory, resolve_ansible_context, resolved_env
 from control.lib.fleet_deploy_lock import FleetLockHeld, fleet_lock
+from control.lib.secretspec_exec import secretspec_run
 
 PLAYBOOK = REPO_ROOT / "ansible" / "playbooks" / "fleet" / "termux-pkg-upgrade.yml"
 CHECK_UPDATES = REPO_ROOT / "control" / "bin" / "check_termux_pkg_updates.py"
@@ -86,19 +87,12 @@ def main(argv: list[str] | None = None) -> int:
         log("ERROR: %s" % exc)
         return 2
 
-    cmd = [
-        "sudo",
-        "-n",
-        "-u",
-        "_secretspec",
-        "/usr/local/libexec/stayturgid-secretspec-wrapper.sh",
-        "run",
-        "--",
+    cmd = secretspec_run(
         "ansible-playbook",
         str(PLAYBOOK),
         "-e",
         "stayturgid_repo_root=%s" % REPO_ROOT,
-    ]
+    )
     if args.limit:
         cmd.extend(["--limit", args.limit])
     if check:

--- a/control/bin/verify_drift.py
+++ b/control/bin/verify_drift.py
@@ -17,6 +17,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PLAYBOOK = REPO_ROOT / "ansible" / "playbooks" / "fleet" / "verify-drift.yml"
 
 sys.path.insert(0, str(REPO_ROOT / "control" / "lib"))
+from secretspec_exec import secretspec_run
 from ansible_context import (
     AnsibleConfigError,
     require_limit_hosts,
@@ -49,19 +50,12 @@ def main(argv: list[str] | None = None) -> int:
     env["ANSIBLE_STDOUT_CALLBACK"] = "default"
 
     proc = subprocess.run(
-        [
-            "sudo",
-            "-n",
-            "-u",
-            "_secretspec",
-            "/usr/local/libexec/stayturgid-secretspec-wrapper.sh",
-            "run",
-            "--",
+        secretspec_run(
             "ansible-playbook",
             str(PLAYBOOK),
             "-l",
             hosts,
-        ],
+        ),
         env=env,
         timeout=120,
     )

--- a/control/lib/secretspec_exec.py
+++ b/control/lib/secretspec_exec.py
@@ -19,6 +19,14 @@ The fallback is deliberately *not* silent when it looks like a broken control
 node: if the vault directory exists but the wrapper or the service account does
 not, that is a half-installed boundary rather than a machine that never had one,
 and :func:`secretspec_command` warns on stderr before falling back.
+
+Note for test authors: callers reach this module by *both* spellings --
+``import secretspec_exec`` (control/lib on sys.path) and
+``from control.lib.secretspec_exec import ...`` -- matching how
+``ansible_context`` is already imported repo-wide. Those are two distinct module
+objects with independent :func:`wrapper_available` caches, so anything
+monkeypatching the selector must patch both; see the
+``_secretspec_wrapper_present`` fixture in tests/python/conftest.py.
 """
 
 from __future__ import annotations

--- a/control/lib/secretspec_exec.py
+++ b/control/lib/secretspec_exec.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Build the argv that runs a command with fleet secrets in its environment.
+
+On the control node, secrets live in a ``0700`` vault owned by a dedicated
+``_secretspec`` service account and are reachable only through one narrowly
+scoped sudoers rule — see ``docs/operations/secretspec-secrets-management.md``
+for the full design and why the wrapper script exists at all.
+
+Anywhere that boundary does not exist — CI runners above all — there is no
+``_secretspec`` user and no wrapper, so ``sudo -n -u _secretspec ...`` fails
+with ``sudo: unknown user _secretspec``. That is what turned stayturgid's
+``test`` workflow red on master from #247 onward. Callers therefore go through
+:func:`secretspec_command`, which uses the privilege-separated path when it is
+actually present and otherwise invokes ``secretspec`` directly, letting
+``SECRETSPEC_FILE`` / ``SECRETSPEC_PROVIDER`` from the environment point it at
+the right spec (exactly what ``.github/workflows`` already exports).
+
+The fallback is deliberately *not* silent when it looks like a broken control
+node: if the vault directory exists but the wrapper or the service account does
+not, that is a half-installed boundary rather than a machine that never had one,
+and :func:`secretspec_command` warns on stderr before falling back.
+"""
+
+from __future__ import annotations
+
+import os
+import pwd
+import sys
+from functools import lru_cache
+
+WRAPPER_PATH = "/usr/local/libexec/stayturgid-secretspec-wrapper.sh"
+SERVICE_USER = "_secretspec"
+VAULT_DIR = "/var/db/stayturgid-secrets"
+
+#: Set to "1" to force the direct path even on a fully provisioned control node.
+#: Intended for local debugging, not for automation.
+FORCE_DIRECT_ENV = "STAYTURGID_SECRETSPEC_DIRECT"
+
+
+def _service_user_exists() -> bool:
+    try:
+        pwd.getpwnam(SERVICE_USER)
+    except KeyError:
+        return False
+    return True
+
+
+@lru_cache(maxsize=1)
+def wrapper_available() -> bool:
+    """True when the privilege-separated secretspec path is usable here.
+
+    Cached: every input is machine-level state that cannot change within a
+    single process run, and some callers build commands in a loop.
+    """
+    if os.environ.get(FORCE_DIRECT_ENV) == "1":
+        return False
+
+    has_wrapper = os.path.isfile(WRAPPER_PATH) and os.access(WRAPPER_PATH, os.X_OK)
+    has_user = _service_user_exists()
+    if has_wrapper and has_user:
+        return True
+
+    if os.path.isdir(VAULT_DIR):
+        missing = []
+        if not has_wrapper:
+            missing.append(f"wrapper {WRAPPER_PATH}")
+        if not has_user:
+            missing.append(f"user {SERVICE_USER}")
+        print(
+            f"WARNING: {VAULT_DIR} exists but {' and '.join(missing)} missing — "
+            "falling back to direct secretspec, without privilege separation. "
+            "See docs/operations/secretspec-secrets-management.md to repair.",
+            file=sys.stderr,
+        )
+    return False
+
+
+def secretspec_command(*args: str) -> list[str]:
+    """Return the argv that runs ``secretspec <args>`` for this machine.
+
+    Arguments map 1:1 onto ``secretspec``'s own CLI in both modes — the wrapper
+    script ``exec``s ``secretspec ... "$@"`` — so callers pass e.g.
+    ``("run", "--", "ansible-playbook", ...)`` or ``("get", "some_token")``
+    and get identical semantics either way.
+    """
+    if wrapper_available():
+        return ["sudo", "-n", "-u", SERVICE_USER, WRAPPER_PATH, *args]
+    return ["secretspec", *args]
+
+
+def secretspec_run(*command: str) -> list[str]:
+    """Convenience wrapper for the overwhelmingly common ``run --`` form."""
+    return secretspec_command("run", "--", *command)

--- a/control/lib/termux_ssh_bootstrap.py
+++ b/control/lib/termux_ssh_bootstrap.py
@@ -18,6 +18,8 @@ if str(_COLLECTION_UTILS) not in sys.path:
 
 import termux_run_as as tr
 
+from secretspec_exec import secretspec_run
+
 SSH_OPTS = ["-o", "BatchMode=yes", "-o", "LogLevel=ERROR"]
 
 # Re-export discovery helpers for tests and callers.
@@ -164,17 +166,7 @@ def run_bootstrap_playbook(
         stdout=subprocess.DEVNULL,
         cwd=repo_root,
     )
-    cmd = [
-        "sudo",
-        "-n",
-        "-u",
-        "_secretspec",
-        "/usr/local/libexec/stayturgid-secretspec-wrapper.sh",
-        "run",
-        "--",
-        "ansible-playbook",
-        str(playbook),
-    ]
+    cmd = secretspec_run("ansible-playbook", str(playbook))
     if hosts:
         cmd.extend(["--limit", ",".join(hosts)])
     return subprocess.run(cmd, env=env, cwd=repo_root).returncode

--- a/control/site_contract/serverapps.py
+++ b/control/site_contract/serverapps.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, Sequence, TextIO
 
+from control.lib.secretspec_exec import secretspec_run
 from control.site_contract.site_map import SiteMap, SiteMapError, load_site_map
 from control.site_contract.site_sync import (
     EXIT_OK,
@@ -2047,21 +2048,14 @@ def _run_ansible_role(plan: ServerAppsPlan, app: AppPlan, *, dry_run: bool) -> N
     if dry_run:
         return
 
-    cmd = [
-        "sudo",
-        "-n",
-        "-u",
-        "_secretspec",
-        "/usr/local/libexec/stayturgid-secretspec-wrapper.sh",
-        "run",
-        "--",
+    cmd = secretspec_run(
         "ansible-playbook",
         "-i",
         "localhost,",
         "-c",
         "local",
         str(playbook),
-    ]
+    )
     for key, value in app.ansible_extra.items():
         cmd.extend(["-e", f"{key}={value}"])
 

--- a/docs/operations/secretspec-secrets-management.md
+++ b/docs/operations/secretspec-secrets-management.md
@@ -12,7 +12,7 @@ This caused several issues:
 - **Architectural Drift:** Scripts directly accessed the file instead of honoring the `secretspec` contract, making secret rotation and auditing impossible.
 - **Accidental Reads & Lack of Auditing:** The legacy `.env` file was readable by any ordinary process running as the `operator` user with zero friction and zero logging.
 
-**Important Threat Model Note:** This design does *not* protect against a compromised or malicious `djbclark` (operator) session. The operator already has full `ALL` sudo access on this machine and could easily `sudo cat /var/db/stayturgid-secrets/secretspec.toml` directly, bypassing this entire mechanism. Furthermore, the wrapper forwards all arguments (`"$@"`), so anyone capable of invoking the wrapper can run *any* `secretspec` subcommand.
+**Important Threat Model Note:** This design does _not_ protect against a compromised or malicious `djbclark` (operator) session. The operator already has full `ALL` sudo access on this machine and could easily `sudo cat /var/db/stayturgid-secrets/secretspec.toml` directly, bypassing this entire mechanism. Furthermore, the wrapper forwards all arguments (`"$@"`), so anyone capable of invoking the wrapper can run _any_ `secretspec` subcommand.
 
 What this architecture actually achieves is:
 
@@ -26,7 +26,7 @@ When designing this boundary, we evaluated several approaches. The core constrai
 
 - **1Password Service Account / Vault (Rejected):** While highly secure, moving to a 1Password Service Account replaces the `.env` file with a Service Account token on disk. This just moves the "confused deputy" problem rather than solving it. Additionally, it injects network latency and relies on 1Password uptime, which breaks local testing during network partitions.
 - **SETENV Sudoers Rule (Rejected):** We considered allowing `operator` to run `secretspec` via `sudo` with the `SETENV` privilege to inject necessary variables. This was rejected because it allows the caller to inject arbitrary, potentially dangerous environment variables into the privileged `secretspec` process.
-- **Whitelisting `env` in Sudoers (Rejected):** Whitelisting the bare `/usr/bin/env` binary in `sudoers` to run as `_secretspec` would allow the caller to execute *any* binary as `_secretspec`, entirely defeating the restriction boundary.
+- **Whitelisting `env` in Sudoers (Rejected):** Whitelisting the bare `/usr/bin/env` binary in `sudoers` to run as `_secretspec` would allow the caller to execute _any_ binary as `_secretspec`, entirely defeating the restriction boundary.
 - **Dedicated System User + Sudo Wrapper (Chosen):** We created a dedicated, locked-down system user (`_secretspec`) that owns the synced secrets. The `operator` user is permitted via a strictly scoped `sudoers` rule to run exactly one wrapper script, which securely bakes in the required environment variables.
 
 ## 3. Architecture as Built
@@ -36,8 +36,8 @@ The architecture relies on strict UNIX file permissions and a rigid privilege bo
 1. **The `_secretspec` System User:** A dedicated macOS daemon user (UID 503, no login shell, hidden from the login screen) that acts as the vault guardian.
 2. **The Secure Vault (`/var/db/stayturgid-secrets/`):** A directory owned by `_secretspec` with `0700` permissions. It contains the locked-down, synced copies of `secretspec.toml` and `.env`.
 3. **The Root-Owned Wrapper (`/usr/local/libexec/stayturgid-secretspec-wrapper.sh`):** A `0755` script owned by `root:wheel` (so it cannot be modified by the operator). It securely sets `HOME` and `SECRETSPEC_PROVIDER` before executing the real `secretspec` binary.
-   *(Note: While the wrapper script itself is root-owned and untamperable, the `/opt/homebrew/bin/secretspec` binary it executes resides in a `djbclark`-owned Homebrew tree and is not tamper-proof. This is consistent with our threat model, as operator-level tampering is not in scope).*
-4. **The Sudoers Rule (`/etc/sudoers.d/secretspec`):** A narrowly scoped rule that allows the `djbclark` (or `operator`) user to run *only* the wrapper script as `_secretspec` without a password.
+   _(Note: While the wrapper script itself is root-owned and untamperable, the `/opt/homebrew/bin/secretspec` binary it executes resides in a `djbclark`-owned Homebrew tree and is not tamper-proof. This is consistent with our threat model, as operator-level tampering is not in scope)._
+4. **The Sudoers Rule (`/etc/sudoers.d/secretspec`):** A narrowly scoped rule that allows the `djbclark` (or `operator`) user to run _only_ the wrapper script as `_secretspec` without a password.
 5. **The Sync Mechanism (`publish_secrets.sh`):** A script that safely copies the operator's readable `~/ops/site-private/{.env,secretspec.toml}` into the locked `/var/db/` directory, adjusting ownership and performing hash-validation.
 
 ## 4. Install & Setup Instructions
@@ -48,6 +48,7 @@ The architecture relies on strict UNIX file permissions and a rigid privilege bo
 If you are setting this up fresh on a new machine, follow this exact sequence:
 
 **1. Create the `_secretspec` user and vault directory:**
+
 ```bash
 # Create the service account (auto-assigned uid 503, verify with `id _secretspec`)
 sudo sysadminctl -addUser _secretspec -fullName "Secretspec Service Account" -home /var/empty -shell /usr/bin/false
@@ -60,6 +61,7 @@ sudo chmod 0700 /var/db/stayturgid-secrets
 ```
 
 **2. Create the Root-Owned Wrapper Script:**
+
 ```bash
 sudo mkdir -p /usr/local/libexec
 sudo tee /usr/local/libexec/stayturgid-secretspec-wrapper.sh > /dev/null << 'EOF'
@@ -74,6 +76,7 @@ sudo chown root:wheel /usr/local/libexec/stayturgid-secretspec-wrapper.sh
 ```
 
 **3. Validate and Install the Sudoers Rule:**
+
 > [!WARNING]
 > You **must** validate your sudoers file with `visudo -c` before installing it. A syntax error in `/etc/sudoers.d/` can completely lock you out of `sudo` machine-wide.
 
@@ -87,6 +90,7 @@ rm "$TMPFILE"
 ```
 
 **4. Publish the Secrets:**
+
 ```bash
 # This syncs your local site-private secrets into the vault
 bash control/bin/publish_secrets.sh
@@ -99,10 +103,13 @@ bash control/bin/publish_secrets.sh
 All Python automation scripts (like `ansible_exec.py`, `deploy_fleet.py`) have been updated to use the wrapper.
 
 For manual CLI usage, your `~/.bashrc` includes an alias so you can simply type:
+
 ```bash
 secretspec run -- <command>
 ```
+
 Under the hood, this expands to:
+
 ```bash
 sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh run -- <command>
 ```
@@ -110,19 +117,23 @@ sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh run -
 ### Functional Check
 
 To manually verify the pipeline is working (without printing any secret values to your terminal), run this check to count the resolved environment variables:
+
 ```bash
 sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh run -- env | grep -c "="
 ```
+
 It should return a number (e.g., `58`) indicating successful secret resolution.
 
 ### Negative Test
 
 To verify that discretionary filesystem permission enforcement is working for a regular non-sudo process, run the following:
+
 ```bash
 ls -la /var/db/stayturgid-secrets
 cat /var/db/stayturgid-secrets/secretspec.toml
 ```
-Both commands should instantly fail with `Permission denied`. *(Note: This demonstrates discretionary permission enforcement for ordinary processes; it is not a comprehensive security guarantee against a root-capable user).*
+
+Both commands should instantly fail with `Permission denied`. _(Note: This demonstrates discretionary permission enforcement for ordinary processes; it is not a comprehensive security guarantee against a root-capable user)._
 
 ### Updating Secrets
 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -57,3 +57,28 @@ def _fleet_lock_path(tmp_path, monkeypatch) -> None:
     and leaving test runs non-hermetic/non-parallel-safe.
     """
     monkeypatch.setenv("STAYTURGID_FLEET_LOCK_PATH", str(tmp_path / "fleet-deploy.lock"))
+
+
+@pytest.fixture(autouse=True)
+def _secretspec_wrapper_present(monkeypatch) -> Iterator[None]:
+    """Pin secretspec_exec to the privilege-separated wrapper path.
+
+    Call sites build their argv via control/lib/secretspec_exec.py, which picks
+    the wrapper form only when the `_secretspec` user and wrapper script exist.
+    That is true on the control node and false on a CI runner, so tests
+    asserting an exact argv would otherwise pass locally and fail in CI --
+    precisely the local/CI divergence this module was added to fix.
+
+    Tests that specifically exercise the fallback re-patch `wrapper_available`
+    themselves; the later monkeypatch wins over this autouse one.
+    """
+    import secretspec_exec
+
+    # Hold the real (lru_cached) function: after monkeypatch replaces the module
+    # attribute, `secretspec_exec.wrapper_available` no longer carries
+    # .cache_clear(), and this fixture's teardown runs before monkeypatch's undo.
+    real = secretspec_exec.wrapper_available
+    real.cache_clear()
+    monkeypatch.setattr(secretspec_exec, "wrapper_available", lambda: True)
+    yield
+    real.cache_clear()

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -71,14 +71,28 @@ def _secretspec_wrapper_present(monkeypatch) -> Iterator[None]:
 
     Tests that specifically exercise the fallback re-patch `wrapper_available`
     themselves; the later monkeypatch wins over this autouse one.
-    """
-    import secretspec_exec
 
-    # Hold the real (lru_cached) function: after monkeypatch replaces the module
-    # attribute, `secretspec_exec.wrapper_available` no longer carries
-    # .cache_clear(), and this fixture's teardown runs before monkeypatch's undo.
-    real = secretspec_exec.wrapper_available
-    real.cache_clear()
-    monkeypatch.setattr(secretspec_exec, "wrapper_available", lambda: True)
+    Both spellings must be patched. conftest puts `control/lib` *and* the repo
+    root on sys.path, so `import secretspec_exec` and
+    `from control.lib.secretspec_exec import ...` produce two independent module
+    objects, each with its own `wrapper_available` and its own lru_cache — and
+    the call sites are split across both conventions (matching how
+    ansible_context is already imported repo-wide). Patching only one leaves the
+    other live, which passes on a control node (where the real function returns
+    True anyway) and fails in CI.
+    """
+    import importlib
+
+    reals = []
+    for name in ("secretspec_exec", "control.lib.secretspec_exec"):
+        module = importlib.import_module(name)
+        # Hold the real (lru_cached) function: once monkeypatch replaces the
+        # attribute it no longer carries .cache_clear(), and this fixture's
+        # teardown runs before monkeypatch's undo.
+        real = module.wrapper_available
+        real.cache_clear()
+        monkeypatch.setattr(module, "wrapper_available", lambda: True)
+        reals.append(real)
     yield
-    real.cache_clear()
+    for real in reals:
+        real.cache_clear()

--- a/tests/python/test_secretspec_exec.py
+++ b/tests/python/test_secretspec_exec.py
@@ -1,0 +1,123 @@
+"""Tests for the secretspec execution-path selector (control/lib/secretspec_exec.py).
+
+Regression coverage for the CI breakage introduced by #247: every fleet entry
+point invoked `sudo -n -u _secretspec <wrapper>` unconditionally, so on a
+GitHub runner -- which has neither that user nor that wrapper -- `just syntax`
+died with `sudo: unknown user _secretspec` and master stayed red from
+2026-08-06 through the ops-v1.3.1 release run.
+"""
+
+from __future__ import annotations
+
+import secretspec_exec
+import pytest
+
+# Captured at import (collection time), before conftest's autouse
+# _secretspec_wrapper_present fixture swaps the module attribute for a lambda --
+# by the time a test body runs, secretspec_exec.wrapper_available is that lambda
+# and no longer carries .cache_clear().
+REAL_WRAPPER_AVAILABLE = secretspec_exec.wrapper_available
+
+WRAPPER_ARGV = [
+    "sudo",
+    "-n",
+    "-u",
+    "_secretspec",
+    "/usr/local/libexec/stayturgid-secretspec-wrapper.sh",
+]
+
+
+@pytest.fixture
+def force_direct(monkeypatch):
+    """Override conftest's autouse wrapper-present fixture for fallback tests."""
+    monkeypatch.setattr(secretspec_exec, "wrapper_available", lambda: False)
+
+
+def test_wrapper_argv_is_byte_identical_to_the_pre_247_hardcoded_form():
+    # The control node must see no behaviour change whatsoever from the
+    # refactor -- this is the exact list every call site used to inline.
+    assert secretspec_exec.secretspec_run("ansible-playbook", "site.yml") == [
+        *WRAPPER_ARGV,
+        "run",
+        "--",
+        "ansible-playbook",
+        "site.yml",
+    ]
+
+
+def test_non_run_subcommands_pass_through_unchanged():
+    # firerpa_mcp.py fetches a token with `get`, not `run --`.
+    assert secretspec_exec.secretspec_command("get", "firerpa_mcp_token") == [
+        *WRAPPER_ARGV,
+        "get",
+        "firerpa_mcp_token",
+    ]
+
+
+def test_falls_back_to_direct_secretspec_without_the_boundary(force_direct):
+    assert secretspec_exec.secretspec_run("ansible-playbook", "site.yml") == [
+        "secretspec",
+        "run",
+        "--",
+        "ansible-playbook",
+        "site.yml",
+    ]
+
+
+def test_fallback_preserves_argv_one_to_one(force_direct):
+    # The wrapper script `exec`s `secretspec ... "$@"`, so both modes must map
+    # arguments identically -- only the prefix differs.
+    assert secretspec_exec.secretspec_command("get", "firerpa_mcp_token") == [
+        "secretspec",
+        "get",
+        "firerpa_mcp_token",
+    ]
+
+
+def test_force_direct_env_var_overrides_a_provisioned_control_node(monkeypatch):
+    real = REAL_WRAPPER_AVAILABLE
+    monkeypatch.setattr(secretspec_exec, "wrapper_available", real)
+    real.cache_clear()
+    monkeypatch.setenv(secretspec_exec.FORCE_DIRECT_ENV, "1")
+    try:
+        assert real() is False
+    finally:
+        real.cache_clear()
+
+
+def test_missing_wrapper_is_silent_when_no_vault_exists(monkeypatch, capsys, tmp_path):
+    """A machine that never had the boundary (CI) must not emit a warning."""
+    real = REAL_WRAPPER_AVAILABLE
+    monkeypatch.setattr(secretspec_exec, "wrapper_available", real)
+    real.cache_clear()
+    monkeypatch.delenv(secretspec_exec.FORCE_DIRECT_ENV, raising=False)
+    monkeypatch.setattr(secretspec_exec, "WRAPPER_PATH", str(tmp_path / "absent.sh"))
+    monkeypatch.setattr(secretspec_exec, "VAULT_DIR", str(tmp_path / "absent-vault"))
+    try:
+        assert real() is False
+        assert capsys.readouterr().err == ""
+    finally:
+        real.cache_clear()
+
+
+def test_half_installed_boundary_warns_before_falling_back(monkeypatch, capsys, tmp_path):
+    """Vault present but wrapper gone is a broken control node, not a CI runner.
+
+    Degrading silently there would quietly drop privilege separation on the
+    machine that actually holds the secrets, so it must be noisy.
+    """
+    real = REAL_WRAPPER_AVAILABLE
+    monkeypatch.setattr(secretspec_exec, "wrapper_available", real)
+    real.cache_clear()
+    monkeypatch.delenv(secretspec_exec.FORCE_DIRECT_ENV, raising=False)
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    monkeypatch.setattr(secretspec_exec, "WRAPPER_PATH", str(tmp_path / "absent.sh"))
+    monkeypatch.setattr(secretspec_exec, "VAULT_DIR", str(vault))
+    try:
+        assert real() is False
+        err = capsys.readouterr().err
+        assert "without privilege separation" in err
+        assert "absent.sh" in err
+    finally:
+        real.cache_clear()


### PR DESCRIPTION
## Why master is red

`#247` made every fleet entry point invoke the privilege-separated wrapper **unconditionally**:

```
sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh run -- ...
```

The `_secretspec` user, the `/var/db/stayturgid-secrets` vault and that wrapper script exist **only on the control node**. On a GitHub runner the call dies:

```
sudo: unknown user _secretspec
sudo: error initializing audit plugin sudoers_audit
error: recipe `_syntax_impl` failed on line 169 with exit code 1
```

`test` has failed on master from #247's own merge (2026-08-06) through the **ops-v1.3.1 release run** (`31181118340`) — i.e. v1.3.1 was tagged from a red master. The redness is CI-environment-only; released behaviour on the control node was never affected.

## What this does

Adds `control/lib/secretspec_exec.py` as the single place that decides which path to use, and routes all **eight** call sites through it (audited repo-wide, not just the two that surfaced):

| File |
|---|
| `control/bin/ansible_exec.py` |
| `control/bin/deploy_fleet.py` |
| `control/bin/deploy_termux.py` |
| `control/bin/firerpa_mcp.py` |
| `control/bin/termux_pkg_nightly.py` |
| `control/bin/verify_drift.py` |
| `control/lib/termux_ssh_bootstrap.py` |
| `control/site_contract/serverapps.py` |

`just/fleet.just`'s `_secretspec_check_impl` already called plain `secretspec` and needed no change; `publish_secrets.sh`'s `chown _secretspec` is vault setup, not execution.

### No behaviour change where the boundary exists

On a provisioned control node the emitted argv is **byte-identical** to the list each site used to inline — verified on this Mac and locked in by a test. Arguments map 1:1 in both modes because the wrapper `exec`s `secretspec ... "$@"`.

Elsewhere it degrades to plain `secretspec`, honouring `SECRETSPEC_FILE` / `SECRETSPEC_PROVIDER` — exactly what `.github/workflows/test.yml` already exports.

### The fallback is deliberately not always silent

A machine that never had the boundary (CI) falls back quietly. But if the **vault directory exists** while the wrapper or service account is missing, that's a half-installed control node, and silently degrading would drop privilege separation on the machine actually holding the secrets. That case warns on stderr first.

`STAYTURGID_SECRETSPEC_DIRECT=1` forces the direct path for local debugging.

## Verification

The exact command CI failed on, re-run locally with the fallback forced:

```
$ STAYTURGID_SECRETSPEC_DIRECT=1 SECRETSPEC_FILE=.github/ci-secretspec.toml \
  SECRETSPEC_PROVIDER=dotenv ANSIBLE_CONFIG=ansible/ansible.cfg \
  python3 control/bin/ansible_exec.py ansible-playbook ansible/playbooks/site.yml --syntax-check
playbook: ansible/playbooks/site.yml
EXIT=0
```

- `just check` — 18/18 ok (was 17/18)
- `just test` — RESULT: PASS, **727 passed, 1 skipped**
- New `tests/python/test_secretspec_exec.py` — 7 tests covering both branches, argv 1:1 mapping, the env override, and the half-installed warning

### Test-fixture note

Tests asserting the exact argv would otherwise pass locally and fail in CI — the very divergence this PR fixes. `tests/python/conftest.py` gains an autouse fixture pinning `wrapper_available()` to the wrapper path so those assertions are environment-independent; fallback tests re-patch it themselves.

## Unrelated fix also included

`docs/operations/secretspec-secrets-management.md` (added by #248) fails `prettier --check` on master today, independently keeping `just check` red. Reformatted here so master can actually go green; no prose changed.

## Known-unrelated local noise

`just lint` fails locally on `drift: FAIL — 24 violation(s)` and a missing Chrome for puppeteer. Both reproduce **identically on clean `origin/master`** with this branch stashed, and the last fully green CI run (`31020765715`, #244) passed `just lint` — the drift hits come from a local site overlay's real device aliases, not from CI's generic inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)