### PR TITLE
chore: bump ops-release.json to 1.3.2

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.3.1"
+  "version": "1.3.2"
 }


### PR DESCRIPTION
Version bump for coordinated release **ops-v1.3.2**.

Suite contents of this release:

- **stayturgid** — #252: `_secretspec` wrapper is now conditional, so CI stops dying with `sudo: unknown user _secretspec`. Restores a green `test` on master (first since 2026-08-05). No control-node behaviour change: the emitted argv is byte-identical where the privilege boundary exists.
- **site-djbclark** — #106: port 8000 claimed for `firerpa-mcp` (tailnet bind, operator sign-off recorded); `moshi-hook` note resolved to KEEP.
- **site-private** — memory-only commits (handoff b65e, port-registry note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)