### PR TITLE
fix(secretspec): execute target command with invoking user identity

### DIFF
--- a/control/bin/deploy_fleet.py
+++ b/control/bin/deploy_fleet.py
@@ -48,9 +48,9 @@ from control.lib.ansible_context import (
     resolved_env,
 )
 from control.lib.fleet_deploy_lock import FleetLockHeld, fleet_lock
-from control.lib.secretspec_exec import secretspec_run
 from control.lib.fleet_targets import FLEET_STATUS_VAR, offline_hosts, parse_inventory_hosts
 from control.lib.fleet_targets import inventory_list as _inventory_list
+from control.lib.secretspec_exec import secretspec_run
 
 SITE_PLAYBOOK = REPO_ROOT / "ansible" / "playbooks" / "site.yml"
 MAC_SITE_PLAYBOOK = REPO_ROOT / "ansible" / "playbooks" / "control_node" / "site.yml"

--- a/control/bin/deploy_termux.py
+++ b/control/bin/deploy_termux.py
@@ -20,7 +20,6 @@ SSH_OPTS = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=8", "-o", "LogLevel=ERR
 sys.path.insert(0, str(REPO_ROOT / "control" / "lib"))
 import adb_cli as ac
 import termux_ssh_bootstrap as boot
-from secretspec_exec import secretspec_run
 from ansible_context import (
     AnsibleConfigError,
     require_fresh_checkout,
@@ -28,6 +27,7 @@ from ansible_context import (
     resolve_ansible_context,
     resolved_env,
 )
+from secretspec_exec import secretspec_run
 
 
 def ssh_target(host: str) -> str:

--- a/control/bin/verify_drift.py
+++ b/control/bin/verify_drift.py
@@ -17,13 +17,13 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PLAYBOOK = REPO_ROOT / "ansible" / "playbooks" / "fleet" / "verify-drift.yml"
 
 sys.path.insert(0, str(REPO_ROOT / "control" / "lib"))
-from secretspec_exec import secretspec_run
 from ansible_context import (
     AnsibleConfigError,
     require_limit_hosts,
     resolve_ansible_context,
     resolved_env,
 )
+from secretspec_exec import secretspec_run
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/control/lib/secretspec_exec.py
+++ b/control/lib/secretspec_exec.py
@@ -92,6 +92,34 @@ def secretspec_command(*args: str) -> list[str]:
     and get identical semantics either way.
     """
     if wrapper_available():
+        try:
+            run_idx = args.index("run")
+            dash_idx = args.index("--")
+            if run_idx < dash_idx:
+                import shlex
+                secretspec_args = list(args[:dash_idx])
+                secretspec_args.remove("run")
+                target_cmd = list(args[dash_idx + 1:])
+                
+                secretspec_args_str = " ".join(shlex.quote(a) for a in secretspec_args)
+                export_cmd = f"sudo -n -u {SERVICE_USER} {WRAPPER_PATH} export --format shell {secretspec_args_str}".strip()
+                
+                script = (
+                    "set -e; "
+                    f"_sec_out=$({export_cmd}); "
+                    'eval "$_sec_out"; '
+                    'exec "$@"'
+                )
+                return [
+                    "/bin/bash",
+                    "-c",
+                    script,
+                    "secretspec_wrapper",
+                    *target_cmd,
+                ]
+        except ValueError:
+            pass
+
         return ["sudo", "-n", "-u", SERVICE_USER, WRAPPER_PATH, *args]
     return ["secretspec", *args]
 

--- a/control/lib/secretspec_exec.py
+++ b/control/lib/secretspec_exec.py
@@ -97,19 +97,17 @@ def secretspec_command(*args: str) -> list[str]:
             dash_idx = args.index("--")
             if run_idx < dash_idx:
                 import shlex
+
                 secretspec_args = list(args[:dash_idx])
                 secretspec_args.remove("run")
-                target_cmd = list(args[dash_idx + 1:])
-                
+                target_cmd = list(args[dash_idx + 1 :])
+
                 secretspec_args_str = " ".join(shlex.quote(a) for a in secretspec_args)
-                export_cmd = f"sudo -n -u {SERVICE_USER} {WRAPPER_PATH} export --format shell {secretspec_args_str}".strip()
-                
-                script = (
-                    "set -e; "
-                    f"_sec_out=$({export_cmd}); "
-                    'eval "$_sec_out"; '
-                    'exec "$@"'
+                export_cmd = (
+                    f"sudo -n -u {SERVICE_USER} {WRAPPER_PATH} export --format shell {secretspec_args_str}".strip()
                 )
+
+                script = f'set -e; _sec_out=$({export_cmd}); eval "$_sec_out"; exec "$@"'
                 return [
                     "/bin/bash",
                     "-c",

--- a/control/lib/termux_ssh_bootstrap.py
+++ b/control/lib/termux_ssh_bootstrap.py
@@ -17,7 +17,6 @@ if str(_COLLECTION_UTILS) not in sys.path:
     sys.path.insert(0, str(_COLLECTION_UTILS))
 
 import termux_run_as as tr
-
 from secretspec_exec import secretspec_run
 
 SSH_OPTS = ["-o", "BatchMode=yes", "-o", "LogLevel=ERROR"]

--- a/tests/python/test_ansible_exec.py
+++ b/tests/python/test_ansible_exec.py
@@ -44,13 +44,10 @@ def test_ansible_exec_delegates_env_to_resolved_env(monkeypatch, tmp_path):
 
     assert ae.main(["ansible-playbook", "ansible/playbooks/site.yml", "--syntax-check"]) == 0
     assert seen["command"] == [
-        "sudo",
-        "-n",
-        "-u",
-        "_secretspec",
-        "/usr/local/libexec/stayturgid-secretspec-wrapper.sh",
-        "run",
-        "--",
+        "/bin/bash",
+        "-c",
+        'set -e; _sec_out=$(sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh export --format shell); eval "$_sec_out"; exec "$@"',
+        "secretspec_wrapper",
         "ansible-playbook",
         "-e",
         f"stayturgid_repo_root={ae.REPO_ROOT}",

--- a/tests/python/test_deploy_fleet.py
+++ b/tests/python/test_deploy_fleet.py
@@ -36,13 +36,10 @@ def test_run_playbook_argv_full(monkeypatch):
     monkeypatch.setattr(df.subprocess, "run", fake_run)
     df.run_playbook(df.SITE_PLAYBOOK, limit=["oneui-device", "fireos-device"], check=False, tags=None)
     assert seen[0] == [
-        "sudo",
-        "-n",
-        "-u",
-        "_secretspec",
-        "/usr/local/libexec/stayturgid-secretspec-wrapper.sh",
-        "run",
-        "--",
+        "/bin/bash",
+        "-c",
+        'set -e; _sec_out=$(sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh export --format shell); eval "$_sec_out"; exec "$@"',
+        "secretspec_wrapper",
         "ansible-playbook",
         str(df.SITE_PLAYBOOK),
         "-e",
@@ -82,13 +79,10 @@ def test_run_playbook_argv_check_and_tags(monkeypatch):
     monkeypatch.setattr(df.subprocess, "run", fake_run)
     df.run_playbook(df.SITE_PLAYBOOK, limit=["oneui-device"], check=True, tags="app-stores")
     assert seen[0] == [
-        "sudo",
-        "-n",
-        "-u",
-        "_secretspec",
-        "/usr/local/libexec/stayturgid-secretspec-wrapper.sh",
-        "run",
-        "--",
+        "/bin/bash",
+        "-c",
+        'set -e; _sec_out=$(sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh export --format shell); eval "$_sec_out"; exec "$@"',
+        "secretspec_wrapper",
         "ansible-playbook",
         str(df.SITE_PLAYBOOK),
         "-e",

--- a/tests/python/test_secretspec_exec.py
+++ b/tests/python/test_secretspec_exec.py
@@ -9,8 +9,8 @@ died with `sudo: unknown user _secretspec` and master stayed red from
 
 from __future__ import annotations
 
-import secretspec_exec
 import pytest
+import secretspec_exec
 
 # Captured at import (collection time), before conftest's autouse
 # _secretspec_wrapper_present fixture swaps the module attribute for a lambda --
@@ -33,13 +33,12 @@ def force_direct(monkeypatch):
     monkeypatch.setattr(secretspec_exec, "wrapper_available", lambda: False)
 
 
-def test_wrapper_argv_is_byte_identical_to_the_pre_247_hardcoded_form():
-    # The control node must see no behaviour change whatsoever from the
-    # refactor -- this is the exact list every call site used to inline.
+def test_wrapper_argv_evaluates_secrets_in_bash():
     assert secretspec_exec.secretspec_run("ansible-playbook", "site.yml") == [
-        *WRAPPER_ARGV,
-        "run",
-        "--",
+        "/bin/bash",
+        "-c",
+        'set -e; _sec_out=$(sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh export --format shell); eval "$_sec_out"; exec "$@"',
+        "secretspec_wrapper",
         "ansible-playbook",
         "site.yml",
     ]

--- a/tests/python/test_termux_pkg_nightly.py
+++ b/tests/python/test_termux_pkg_nightly.py
@@ -43,13 +43,10 @@ def test_nightly_runner_uses_resolved_site_config(monkeypatch, tmp_path):
     # --check skips the #152 pre-check so subprocess.run is only ansible-playbook.
     assert nightly.main(["--check", "--limit", "oneui-device"]) == 0
     assert seen["command"] == [
-        "sudo",
-        "-n",
-        "-u",
-        "_secretspec",
-        "/usr/local/libexec/stayturgid-secretspec-wrapper.sh",
-        "run",
-        "--",
+        "/bin/bash",
+        "-c",
+        'set -e; _sec_out=$(sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh export --format shell); eval "$_sec_out"; exec "$@"',
+        "secretspec_wrapper",
         "ansible-playbook",
         str(nightly.PLAYBOOK),
         "-e",


### PR DESCRIPTION
Replaces the direct sudo execution of the target command with a bash wrapper evaluation strategy. Ensures that the target command runs as the invoking user, preventing permissions errors (e.g., trying to write to `/var/empty`), while successfully injecting the secretspec exported variables into the target environment without bringing them into the python process's memory.