### PR TITLE
fix(secretspec): narrow wrapper operations and verify vault sync

### DIFF
--- a/control/bin/firerpa_mcp.py
+++ b/control/bin/firerpa_mcp.py
@@ -18,7 +18,7 @@ import control.bin.firerpa_heal as heal
 from control.lib.firerpa_auth import certificate_path
 from control.lib.firerpa_consent import HealSession, check_consent
 from control.lib.firerpa_fleet import get_fleet
-from control.lib.secretspec_exec import secretspec_command
+from control.lib.secretspec_exec import secretspec_token_command
 from control.lib.site_logging import WARNING, log
 
 LOG_NAME = "firerpa-mcp.log"
@@ -40,7 +40,7 @@ except ImportError:
 def get_bearer_token() -> str | None:
     try:
         res = subprocess.run(
-            secretspec_command("get", "firerpa_mcp_token"),
+            secretspec_token_command("firerpa_mcp_token"),
             capture_output=True,
             text=True,
             check=True,

--- a/control/bin/publish_secrets.sh
+++ b/control/bin/publish_secrets.sh
@@ -1,48 +1,35 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# This script safely publishes secrets from the operator's workspace
-# into the locked-down /var/db/stayturgid-secrets/ directory.
-
+# Publish the two SecretSpec inputs, then fail closed unless the source and
+# root-owned vault are byte-identical private regular files. No secret values
+# are printed or logged.
 TARGET_DIR="/var/db/stayturgid-secrets"
 OPS_ROOT="${OPS_ROOT:-$HOME/ops}"
 PRIVATE_SITE_DIR="$OPS_ROOT/site-private"
+VERIFY_SCRIPT="$(cd "$(dirname "$0")" && pwd)/verify_secretspec_sync.py"
 
-echo "Publishing secrets to $TARGET_DIR..."
-
-if [ ! -d "$PRIVATE_SITE_DIR" ]; then
-  echo "Error: Private site directory $PRIVATE_SITE_DIR not found." >&2
+if [ ! -d "$PRIVATE_SITE_DIR" ] || [ -L "$PRIVATE_SITE_DIR" ]; then
+  echo "Error: private site directory is missing or a symlink." >&2
   exit 1
 fi
-
-if [ ! -f "$PRIVATE_SITE_DIR/.env" ] || [ ! -f "$PRIVATE_SITE_DIR/secretspec.toml" ]; then
-  echo "Error: .env or secretspec.toml missing in $PRIVATE_SITE_DIR." >&2
-  exit 1
-fi
+for name in .env secretspec.toml; do
+  path="$PRIVATE_SITE_DIR/$name"
+  if [ ! -f "$path" ] || [ -L "$path" ]; then
+    echo "Error: $path must be a regular file (not a symlink)." >&2
+    exit 1
+  fi
+done
+# The source copy is itself private operator state; repair overly broad modes
+# before publishing so the verifier and the source remain owner-only.
+chmod 0600 "$PRIVATE_SITE_DIR/.env" "$PRIVATE_SITE_DIR/secretspec.toml"
 
 sudo mkdir -p "$TARGET_DIR"
-sudo cp "$PRIVATE_SITE_DIR/.env" "$TARGET_DIR/.env"
-sudo cp "$PRIVATE_SITE_DIR/secretspec.toml" "$TARGET_DIR/secretspec.toml"
-
-sudo chown -R _secretspec "$TARGET_DIR"
+sudo chown _secretspec "$TARGET_DIR"
 sudo chmod 0700 "$TARGET_DIR"
-sudo chmod 0600 "$TARGET_DIR/.env" "$TARGET_DIR/secretspec.toml"
+# install writes the named destination with the requested mode and does not
+# copy source metadata or follow a source symlink (which was rejected above).
+sudo install -o _secretspec -g staff -m 0600 "$PRIVATE_SITE_DIR/.env" "$TARGET_DIR/.env"
+sudo install -o _secretspec -g staff -m 0600 "$PRIVATE_SITE_DIR/secretspec.toml" "$TARGET_DIR/secretspec.toml"
 
-# Verify hashes match
-SRC_ENV_HASH=$(shasum -a 256 "$PRIVATE_SITE_DIR/.env" | awk '{print $1}')
-DST_ENV_HASH=$(sudo shasum -a 256 "$TARGET_DIR/.env" | awk '{print $1}')
-
-if [ "$SRC_ENV_HASH" != "$DST_ENV_HASH" ]; then
-  echo "Error: Hash mismatch for .env after publishing!" >&2
-  exit 1
-fi
-
-SRC_TOML_HASH=$(shasum -a 256 "$PRIVATE_SITE_DIR/secretspec.toml" | awk '{print $1}')
-DST_TOML_HASH=$(sudo shasum -a 256 "$TARGET_DIR/secretspec.toml" | awk '{print $1}')
-
-if [ "$SRC_TOML_HASH" != "$DST_TOML_HASH" ]; then
-  echo "Error: Hash mismatch for secretspec.toml after publishing!" >&2
-  exit 1
-fi
-
-echo "Secrets published successfully. Hashes matched."
+python3 "$VERIFY_SCRIPT" "$PRIVATE_SITE_DIR" "$TARGET_DIR"

--- a/control/bin/stayturgid-secretspec-wrapper.sh
+++ b/control/bin/stayturgid-secretspec-wrapper.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Installed as root:wheel, mode 0755, and allowed by sudoers only as _secretspec.
+# This is deliberately an operation interface, not a SecretSpec CLI passthrough.
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  printf '%s\n' 'denied: expected exactly one approved operation' >&2
+  exit 2
+fi
+
+export HOME=/var/db/stayturgid-secrets
+export SECRETSPEC_PROVIDER=dotenv
+export SECRETSPEC_FILE=/var/db/stayturgid-secrets/secretspec.toml
+# Do not inherit caller-controlled SecretSpec selectors or dynamic loader state.
+unset SECRETSPEC_PROFILE SECRETSPEC_SCOPE SECRETSPEC_REASON DYLD_LIBRARY_PATH DYLD_INSERT_LIBRARIES
+
+case "$1" in
+  automation-env)
+    exec /opt/homebrew/bin/secretspec -f "$SECRETSPEC_FILE" export --format json
+    ;;
+  firerpa-mcp-token)
+    exec /opt/homebrew/bin/secretspec -f "$SECRETSPEC_FILE" get firerpa_mcp_token
+    ;;
+  *)
+    printf '%s\n' 'denied: operation is not allowlisted' >&2
+    exit 2
+    ;;
+esac

--- a/control/bin/verify_secretspec_sync.py
+++ b/control/bin/verify_secretspec_sync.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Fail-closed verification that the SecretSpec source and vault agree."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import stat
+import sys
+from pathlib import Path
+
+NAMES = (".env", "secretspec.toml")
+
+
+def _regular_private(path: Path) -> bool:
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        return False
+    return stat.S_ISREG(info.st_mode) and stat.S_IMODE(info.st_mode) == 0o600
+
+
+def _digest(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def verify(source_dir: Path, vault_dir: Path) -> list[str]:
+    errors: list[str] = []
+    try:
+        vault_mode = stat.S_IMODE(vault_dir.lstat().st_mode)
+    except FileNotFoundError:
+        return [f"vault missing: {vault_dir}"]
+    if not stat.S_ISDIR(vault_dir.lstat().st_mode) or vault_mode != 0o700:
+        errors.append(f"vault must be a real 0700 directory: {vault_dir}")
+    for name in NAMES:
+        source = source_dir / name
+        vault = vault_dir / name
+        if not _regular_private(source):
+            errors.append(f"source must be a real 0600 file: {source}")
+            continue
+        if not _regular_private(vault):
+            errors.append(f"vault must be a real 0600 file: {vault}")
+            continue
+        if _digest(source) != _digest(vault):
+            errors.append(f"hash mismatch: {name}")
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source_dir", type=Path)
+    parser.add_argument("vault_dir", type=Path)
+    args = parser.parse_args(argv)
+    errors = verify(args.source_dir, args.vault_dir)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    print("SecretSpec source/vault hashes and permissions match.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/control/lib/secretspec_env_exec.py
+++ b/control/lib/secretspec_env_exec.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Execute approved Ansible with JSON secrets from the fixed sudo wrapper."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+WRAPPER = "/usr/local/libexec/stayturgid-secretspec-wrapper.sh"
+SERVICE_USER = "_secretspec"
+
+
+def main(argv: list[str] | None = None) -> int:
+    command = list(sys.argv[1:] if argv is None else argv)
+    if not command or command[0] != "ansible-playbook":
+        print("only ansible-playbook is approved", file=sys.stderr)
+        return 2
+    try:
+        result = subprocess.run(
+            ["sudo", "-n", "-u", SERVICE_USER, WRAPPER, "automation-env"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env={"PATH": "/usr/bin:/bin:/opt/homebrew/bin:/usr/local/bin"},
+        )
+        values = json.loads(result.stdout)
+        if not isinstance(values, dict) or any(
+            not isinstance(key, str) or not isinstance(value, str) for key, value in values.items()
+        ):
+            raise ValueError("wrapper returned a non-string JSON object")
+        env = os.environ.copy()
+        env.update(values)
+        os.execvpe(command[0], command, env)
+    except (OSError, subprocess.SubprocessError, ValueError, json.JSONDecodeError) as exc:
+        print(f"SecretSpec automation boundary failed closed: {exc}", file=sys.stderr)
+        return 126
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/control/lib/secretspec_exec.py
+++ b/control/lib/secretspec_exec.py
@@ -1,32 +1,21 @@
 #!/usr/bin/env python3
-"""Build the argv that runs a command with fleet secrets in its environment.
+"""Build safe commands for the control-node SecretSpec boundary.
 
-On the control node, secrets live in a ``0700`` vault owned by a dedicated
-``_secretspec`` service account and are reachable only through one narrowly
-scoped sudoers rule — see ``docs/operations/secretspec-secrets-management.md``
-for the full design and why the wrapper script exists at all.
+The passwordless sudo rule is intentionally *not* a general SecretSpec CLI
+proxy.  The root-owned wrapper exposes only two fixed operations:
+``automation-env`` (JSON environment for the approved Ansible automation) and
+``firerpa-mcp-token`` (one named token).  This module keeps the caller-side
+interface equally narrow and executes approved automation as the invoking user.
 
-Anywhere that boundary does not exist — CI runners above all — there is no
-``_secretspec`` user and no wrapper, so ``sudo -n -u _secretspec ...`` fails
-with ``sudo: unknown user _secretspec``. That is what turned stayturgid's
-``test`` workflow red on master from #247 onward. Callers therefore go through
-:func:`secretspec_command`, which uses the privilege-separated path when it is
-actually present and otherwise invokes ``secretspec`` directly, letting
-``SECRETSPEC_FILE`` / ``SECRETSPEC_PROVIDER`` from the environment point it at
-the right spec (exactly what ``.github/workflows`` already exports).
+A same-UID caller can still invoke an approved operation when the sudoers rule
+is granted to that UID; UNIX credentials cannot distinguish two processes with
+the same UID.  The enforceable boundary here is that malformed arguments,
+caller-selected SecretSpec subcommands, environment injection, and arbitrary
+commands are rejected by the wrapper and by this selector.
 
-The fallback is deliberately *not* silent when it looks like a broken control
-node: if the vault directory exists but the wrapper or the service account does
-not, that is a half-installed boundary rather than a machine that never had one,
-and :func:`secretspec_command` warns on stderr before falling back.
-
-Note for test authors: callers reach this module by *both* spellings --
-``import secretspec_exec`` (control/lib on sys.path) and
-``from control.lib.secretspec_exec import ...`` -- matching how
-``ansible_context`` is already imported repo-wide. Those are two distinct module
-objects with independent :func:`wrapper_available` caches, so anything
-monkeypatching the selector must patch both; see the
-``_secretspec_wrapper_present`` fixture in tests/python/conftest.py.
+CI and other machines without the service account use direct ``secretspec``
+with their normal provider configuration.  Set ``STAYTURGID_SECRETSPEC_DIRECT=1``
+to exercise that path deliberately.
 """
 
 from __future__ import annotations
@@ -35,14 +24,14 @@ import os
 import pwd
 import sys
 from functools import lru_cache
+from pathlib import Path
 
 WRAPPER_PATH = "/usr/local/libexec/stayturgid-secretspec-wrapper.sh"
 SERVICE_USER = "_secretspec"
 VAULT_DIR = "/var/db/stayturgid-secrets"
-
-#: Set to "1" to force the direct path even on a fully provisioned control node.
-#: Intended for local debugging, not for automation.
 FORCE_DIRECT_ENV = "STAYTURGID_SECRETSPEC_DIRECT"
+HELPER_PATH = str(Path(__file__).with_name("secretspec_env_exec.py"))
+APPROVED_EXECUTABLE = "ansible-playbook"
 
 
 def _service_user_exists() -> bool:
@@ -55,19 +44,13 @@ def _service_user_exists() -> bool:
 
 @lru_cache(maxsize=1)
 def wrapper_available() -> bool:
-    """True when the privilege-separated secretspec path is usable here.
-
-    Cached: every input is machine-level state that cannot change within a
-    single process run, and some callers build commands in a loop.
-    """
+    """True when the privilege-separated SecretSpec path is usable here."""
     if os.environ.get(FORCE_DIRECT_ENV) == "1":
         return False
-
     has_wrapper = os.path.isfile(WRAPPER_PATH) and os.access(WRAPPER_PATH, os.X_OK)
     has_user = _service_user_exists()
     if has_wrapper and has_user:
         return True
-
     if os.path.isdir(VAULT_DIR):
         missing = []
         if not has_wrapper:
@@ -83,45 +66,43 @@ def wrapper_available() -> bool:
     return False
 
 
-def secretspec_command(*args: str) -> list[str]:
-    """Return the argv that runs ``secretspec <args>`` for this machine.
+def _approved_automation(command: tuple[str, ...]) -> bool:
+    """Reject shell interpreters and non- Ansible automation at this seam."""
+    return bool(command) and command[0] == APPROVED_EXECUTABLE
 
-    Arguments map 1:1 onto ``secretspec``'s own CLI in both modes — the wrapper
-    script ``exec``s ``secretspec ... "$@"`` — so callers pass e.g.
-    ``("run", "--", "ansible-playbook", ...)`` or ``("get", "some_token")``
-    and get identical semantics either way.
-    """
+
+def secretspec_token_command(name: str) -> list[str]:
+    """Return the fixed FIRERPA token operation; no caller-selected ``get``."""
+    if name != "firerpa_mcp_token":
+        raise ValueError("only firerpa_mcp_token is available through the wrapper")
     if wrapper_available():
-        try:
-            run_idx = args.index("run")
-            dash_idx = args.index("--")
-            if run_idx < dash_idx:
-                import shlex
+        return ["sudo", "-n", "-u", SERVICE_USER, WRAPPER_PATH, "firerpa-mcp-token"]
+    return ["secretspec", "get", name]
 
-                secretspec_args = list(args[:dash_idx])
-                secretspec_args.remove("run")
-                target_cmd = list(args[dash_idx + 1 :])
 
-                secretspec_args_str = " ".join(shlex.quote(a) for a in secretspec_args)
-                export_cmd = (
-                    f"sudo -n -u {SERVICE_USER} {WRAPPER_PATH} export --format shell {secretspec_args_str}".strip()
-                )
+def secretspec_command(*args: str) -> list[str]:
+    """Return an approved SecretSpec command for this machine.
 
-                script = f'set -e; _sec_out=$({export_cmd}); eval "$_sec_out"; exec "$@"'
-                return [
-                    "/bin/bash",
-                    "-c",
-                    script,
-                    "secretspec_wrapper",
-                    *target_cmd,
-                ]
-        except ValueError:
-            pass
+    Only ``run -- ansible-playbook ...`` is accepted on the wrapped path.  The
+    helper obtains JSON from the fixed wrapper operation and overlays it onto
+    the invoking user's environment before ``execvpe``-ing Ansible, so the
+    target remains ``djbclark`` with a writable HOME and no shell evaluation.
+    """
+    if not args:
+        raise ValueError("SecretSpec command cannot be empty")
+    if args[:2] != ("run", "--"):
+        if wrapper_available():
+            raise ValueError("arbitrary SecretSpec subcommands are unavailable through the wrapper")
+        return ["secretspec", *args]
 
-        return ["sudo", "-n", "-u", SERVICE_USER, WRAPPER_PATH, *args]
+    command = tuple(args[2:])
+    if wrapper_available() and not _approved_automation(command):
+        raise ValueError("only ansible-playbook is approved through the wrapper")
+    if wrapper_available():
+        return [sys.executable, HELPER_PATH, *command]
     return ["secretspec", *args]
 
 
 def secretspec_run(*command: str) -> list[str]:
-    """Convenience wrapper for the overwhelmingly common ``run --`` form."""
+    """Convenience wrapper for the approved ``run -- ansible-playbook`` form."""
     return secretspec_command("run", "--", *command)

--- a/docs/operations/secretspec-secrets-management.md
+++ b/docs/operations/secretspec-secrets-management.md
@@ -12,13 +12,14 @@ This caused several issues:
 - **Architectural Drift:** Scripts directly accessed the file instead of honoring the `secretspec` contract, making secret rotation and auditing impossible.
 - **Accidental Reads & Lack of Auditing:** The legacy `.env` file was readable by any ordinary process running as the `operator` user with zero friction and zero logging.
 
-**Important Threat Model Note:** This design does _not_ protect against a compromised or malicious `djbclark` (operator) session. The operator already has full `ALL` sudo access on this machine and could easily `sudo cat /var/db/stayturgid-secrets/secretspec.toml` directly, bypassing this entire mechanism. Furthermore, the wrapper forwards all arguments (`"$@"`), so anyone capable of invoking the wrapper can run _any_ `secretspec` subcommand.
+**Important Threat Model Note:** This design does _not_ protect against a compromised or malicious `djbclark` session. A same-UID process can invoke any operation granted to that UID, and the operator can use broader administrative access outside this boundary. The enforceable guarantee is narrower: the passwordless wrapper is not a general SecretSpec CLI proxy. It accepts only the fixed `automation-env` and `firerpa-mcp-token` operations; caller-selected `get`, `export`, profiles, scopes, providers, environment variables, shell interpreters, and arbitrary commands are rejected. Fleet automation resolves secrets as `_secretspec`, then executes the approved Ansible target as `djbclark` with the normal writable HOME.
 
 What this architecture actually achieves is:
 
 1. Preventing **accidental** or routine direct reads by ordinary, non-sudo processes.
-2. Creating a strict architectural boundary that forces code to use the `secretspec` API.
-3. Establishing an audit trail via `secretspec`'s own audit logging for every deliberate access.
+2. Enforcing a narrow operation boundary for the passwordless wrapper rather than forwarding arbitrary SecretSpec arguments.
+3. Creating an audit trail via `secretspec`'s own audit logging for deliberate access.
+4. Keeping the residual same-UID limitation explicit instead of claiming process-level isolation that UNIX credentials cannot provide.
 
 ## 2. Design Alternatives Considered
 
@@ -35,10 +36,10 @@ The architecture relies on strict UNIX file permissions and a rigid privilege bo
 
 1. **The `_secretspec` System User:** A dedicated macOS daemon user (UID 503, no login shell, hidden from the login screen) that acts as the vault guardian.
 2. **The Secure Vault (`/var/db/stayturgid-secrets/`):** A directory owned by `_secretspec` with `0700` permissions. It contains the locked-down, synced copies of `secretspec.toml` and `.env`.
-3. **The Root-Owned Wrapper (`/usr/local/libexec/stayturgid-secretspec-wrapper.sh`):** A `0755` script owned by `root:wheel` (so it cannot be modified by the operator). It securely sets `HOME` and `SECRETSPEC_PROVIDER` before executing the real `secretspec` binary.
-   _(Note: While the wrapper script itself is root-owned and untamperable, the `/opt/homebrew/bin/secretspec` binary it executes resides in a `djbclark`-owned Homebrew tree and is not tamper-proof. This is consistent with our threat model, as operator-level tampering is not in scope)._
-4. **The Sudoers Rule (`/etc/sudoers.d/secretspec`):** A narrowly scoped rule that allows the `djbclark` (or `operator`) user to run _only_ the wrapper script as `_secretspec` without a password.
-5. **The Sync Mechanism (`publish_secrets.sh`):** A script that safely copies the operator's readable `~/ops/site-private/{.env,secretspec.toml}` into the locked `/var/db/` directory, adjusting ownership and performing hash-validation.
+3. **The Root-Owned Wrapper (`/usr/local/libexec/stayturgid-secretspec-wrapper.sh`):** A `0755` script owned by `root:wheel` (so it cannot be modified by the operator). It sets fixed `HOME`, provider, and manifest paths, rejects all caller-controlled SecretSpec selectors, and exposes only `automation-env` and `firerpa-mcp-token`. It never forwards `"$@"` to SecretSpec.
+   _(Note: While the wrapper script itself is root-owned and untamperable, the `/opt/homebrew/bin/secretspec` binary it executes resides in a `djbclark`-owned Homebrew tree and is not tamper-proof. This is a residual same-admin limitation, not a claim of full operator isolation.)_
+4. **The Sudoers Rule (`/etc/sudoers.d/secretspec`):** A narrowly scoped rule that allows the `djbclark` user to run _only_ the wrapper script as `_secretspec` without a password. The same-UID limitation is documented above.
+5. **The Sync Mechanism (`publish_secrets.sh`):** A script that copies the operator's `~/ops/site-private/{.env,secretspec.toml}` into the locked `/var/db/` directory and verifies hashes, ownership, modes, and regular-file status.
 
 ## 4. Install & Setup Instructions
 
@@ -67,9 +68,16 @@ sudo mkdir -p /usr/local/libexec
 sudo tee /usr/local/libexec/stayturgid-secretspec-wrapper.sh > /dev/null << 'EOF'
 #!/bin/bash
 set -euo pipefail
+if [ "$#" -ne 1 ]; then exit 2; fi
 export HOME=/var/db/stayturgid-secrets
 export SECRETSPEC_PROVIDER=dotenv
-exec /opt/homebrew/bin/secretspec -f /var/db/stayturgid-secrets/secretspec.toml "$@"
+export SECRETSPEC_FILE=/var/db/stayturgid-secrets/secretspec.toml
+unset SECRETSPEC_PROFILE SECRETSPEC_SCOPE SECRETSPEC_REASON DYLD_LIBRARY_PATH DYLD_INSERT_LIBRARIES
+case "$1" in
+  automation-env) exec /opt/homebrew/bin/secretspec -f "$SECRETSPEC_FILE" export --format json ;;
+  firerpa-mcp-token) exec /opt/homebrew/bin/secretspec -f "$SECRETSPEC_FILE" get firerpa_mcp_token ;;
+  *) exit 2 ;;
+esac
 EOF
 sudo chmod 0755 /usr/local/libexec/stayturgid-secretspec-wrapper.sh
 sudo chown root:wheel /usr/local/libexec/stayturgid-secretspec-wrapper.sh
@@ -108,21 +116,32 @@ For manual CLI usage, your `~/.bashrc` includes an alias so you can simply type:
 secretspec run -- <command>
 ```
 
-Under the hood, this expands to:
+Under the hood, the root-owned wrapper is called with exactly one of its two operation names:
 
 ```bash
-sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh run -- <command>
+sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh automation-env
+sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh firerpa-mcp-token
 ```
+
+The first returns JSON to the checked-in `control/lib/secretspec_env_exec.py`,
+which validates it and `exec`s the Ansible target as `djbclark`; it does not use
+shell `eval`. Direct wrapper calls with `get`, `export`, `run`, extra arguments,
+profiles, scopes, or another command fail closed.
 
 ### Functional Check
 
-To manually verify the pipeline is working (without printing any secret values to your terminal), run this check to count the resolved environment variables:
+To manually verify the pipeline without printing secret values, run the
+non-secret drift check first:
 
 ```bash
-sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh run -- env | grep -c "="
+python3 control/bin/verify_secretspec_sync.py \
+  "${OPS_ROOT:-$HOME/ops}/site-private" /var/db/stayturgid-secrets
 ```
 
-It should return a number (e.g., `58`) indicating successful secret resolution.
+A source/vault hash mismatch, symlink, missing file, wrong mode, or wrong vault
+permissions exits nonzero. `publish_secrets.sh` performs the same check after
+publishing and must be run after every source change. Do not bypass this check
+or add secret values to logs.
 
 ### Negative Test
 

--- a/tests/python/test_ansible_exec.py
+++ b/tests/python/test_ansible_exec.py
@@ -1,6 +1,7 @@
 """Tests for direct just-recipe Ansible execution through the site resolver."""
 
 import ansible_exec as ae
+import secretspec_exec
 from ansible_context import AnsibleContext
 
 
@@ -44,10 +45,8 @@ def test_ansible_exec_delegates_env_to_resolved_env(monkeypatch, tmp_path):
 
     assert ae.main(["ansible-playbook", "ansible/playbooks/site.yml", "--syntax-check"]) == 0
     assert seen["command"] == [
-        "/bin/bash",
-        "-c",
-        'set -e; _sec_out=$(sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh export --format shell); eval "$_sec_out"; exec "$@"',
-        "secretspec_wrapper",
+        secretspec_exec.sys.executable,
+        secretspec_exec.HELPER_PATH,
         "ansible-playbook",
         "-e",
         f"stayturgid_repo_root={ae.REPO_ROOT}",

--- a/tests/python/test_deploy_fleet.py
+++ b/tests/python/test_deploy_fleet.py
@@ -10,6 +10,7 @@ sys.path.insert(
     0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "control", "bin")
 )
 import deploy_fleet as df
+import secretspec_exec
 
 INVENTORY_JSON: dict[str, Any] = {
     "stayturgid": {
@@ -36,10 +37,8 @@ def test_run_playbook_argv_full(monkeypatch):
     monkeypatch.setattr(df.subprocess, "run", fake_run)
     df.run_playbook(df.SITE_PLAYBOOK, limit=["oneui-device", "fireos-device"], check=False, tags=None)
     assert seen[0] == [
-        "/bin/bash",
-        "-c",
-        'set -e; _sec_out=$(sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh export --format shell); eval "$_sec_out"; exec "$@"',
-        "secretspec_wrapper",
+        secretspec_exec.sys.executable,
+        secretspec_exec.HELPER_PATH,
         "ansible-playbook",
         str(df.SITE_PLAYBOOK),
         "-e",
@@ -79,10 +78,8 @@ def test_run_playbook_argv_check_and_tags(monkeypatch):
     monkeypatch.setattr(df.subprocess, "run", fake_run)
     df.run_playbook(df.SITE_PLAYBOOK, limit=["oneui-device"], check=True, tags="app-stores")
     assert seen[0] == [
-        "/bin/bash",
-        "-c",
-        'set -e; _sec_out=$(sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh export --format shell); eval "$_sec_out"; exec "$@"',
-        "secretspec_wrapper",
+        secretspec_exec.sys.executable,
+        secretspec_exec.HELPER_PATH,
         "ansible-playbook",
         str(df.SITE_PLAYBOOK),
         "-e",

--- a/tests/python/test_secretspec_exec.py
+++ b/tests/python/test_secretspec_exec.py
@@ -1,56 +1,64 @@
-"""Tests for the secretspec execution-path selector (control/lib/secretspec_exec.py).
-
-Regression coverage for the CI breakage introduced by #247: every fleet entry
-point invoked `sudo -n -u _secretspec <wrapper>` unconditionally, so on a
-GitHub runner -- which has neither that user nor that wrapper -- `just syntax`
-died with `sudo: unknown user _secretspec` and master stayed red from
-2026-08-06 through the ops-v1.3.1 release run.
-"""
+"""Regression tests for the fail-closed SecretSpec operation boundary."""
 
 from __future__ import annotations
+
+import sys
 
 import pytest
 import secretspec_exec
 
-# Captured at import (collection time), before conftest's autouse
-# _secretspec_wrapper_present fixture swaps the module attribute for a lambda --
-# by the time a test body runs, secretspec_exec.wrapper_available is that lambda
-# and no longer carries .cache_clear().
 REAL_WRAPPER_AVAILABLE = secretspec_exec.wrapper_available
 
-WRAPPER_ARGV = [
-    "sudo",
-    "-n",
-    "-u",
-    "_secretspec",
-    "/usr/local/libexec/stayturgid-secretspec-wrapper.sh",
-]
+
+def force_wrapped(monkeypatch):
+    monkeypatch.setattr(secretspec_exec, "wrapper_available", lambda: True)
 
 
 @pytest.fixture
 def force_direct(monkeypatch):
-    """Override conftest's autouse wrapper-present fixture for fallback tests."""
     monkeypatch.setattr(secretspec_exec, "wrapper_available", lambda: False)
 
 
-def test_wrapper_argv_evaluates_secrets_in_bash():
+def test_wrapper_uses_json_helper_and_keeps_target_as_invoking_user(monkeypatch):
+    force_wrapped(monkeypatch)
     assert secretspec_exec.secretspec_run("ansible-playbook", "site.yml") == [
-        "/bin/bash",
-        "-c",
-        'set -e; _sec_out=$(sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh export --format shell); eval "$_sec_out"; exec "$@"',
-        "secretspec_wrapper",
+        sys.executable,
+        secretspec_exec.HELPER_PATH,
         "ansible-playbook",
         "site.yml",
     ]
 
 
-def test_non_run_subcommands_pass_through_unchanged():
-    # firerpa_mcp.py fetches a token with `get`, not `run --`.
-    assert secretspec_exec.secretspec_command("get", "firerpa_mcp_token") == [
-        *WRAPPER_ARGV,
-        "get",
-        "firerpa_mcp_token",
+def test_malicious_same_user_cannot_select_get_export_or_shell(monkeypatch):
+    force_wrapped(monkeypatch)
+    for args in (("get", "other_secret"), ("export", "--format", "json"), ("run", "--", "/bin/sh")):
+        with pytest.raises(ValueError):
+            secretspec_exec.secretspec_command(*args)
+
+
+def test_wrapper_script_rejects_arbitrary_secret_spec_arguments():
+    import subprocess
+    from pathlib import Path
+
+    wrapper = Path(__file__).parents[2] / "control" / "bin" / "stayturgid-secretspec-wrapper.sh"
+    result = subprocess.run(["bash", str(wrapper), "get", "other_secret"], capture_output=True, text=True)
+    assert result.returncode == 2
+    assert "denied" in result.stderr
+    assert '"$@"' not in wrapper.read_text()
+
+
+def test_firerpa_operation_is_fixed_to_one_token(monkeypatch):
+    force_wrapped(monkeypatch)
+    assert secretspec_exec.secretspec_token_command("firerpa_mcp_token") == [
+        "sudo",
+        "-n",
+        "-u",
+        "_secretspec",
+        secretspec_exec.WRAPPER_PATH,
+        "firerpa-mcp-token",
     ]
+    with pytest.raises(ValueError):
+        secretspec_exec.secretspec_token_command("other_secret")
 
 
 def test_falls_back_to_direct_secretspec_without_the_boundary(force_direct):
@@ -61,16 +69,7 @@ def test_falls_back_to_direct_secretspec_without_the_boundary(force_direct):
         "ansible-playbook",
         "site.yml",
     ]
-
-
-def test_fallback_preserves_argv_one_to_one(force_direct):
-    # The wrapper script `exec`s `secretspec ... "$@"`, so both modes must map
-    # arguments identically -- only the prefix differs.
-    assert secretspec_exec.secretspec_command("get", "firerpa_mcp_token") == [
-        "secretspec",
-        "get",
-        "firerpa_mcp_token",
-    ]
+    assert secretspec_exec.secretspec_command("get", "firerpa_mcp_token") == ["secretspec", "get", "firerpa_mcp_token"]
 
 
 def test_force_direct_env_var_overrides_a_provisioned_control_node(monkeypatch):
@@ -85,7 +84,6 @@ def test_force_direct_env_var_overrides_a_provisioned_control_node(monkeypatch):
 
 
 def test_missing_wrapper_is_silent_when_no_vault_exists(monkeypatch, capsys, tmp_path):
-    """A machine that never had the boundary (CI) must not emit a warning."""
     real = REAL_WRAPPER_AVAILABLE
     monkeypatch.setattr(secretspec_exec, "wrapper_available", real)
     real.cache_clear()
@@ -100,11 +98,6 @@ def test_missing_wrapper_is_silent_when_no_vault_exists(monkeypatch, capsys, tmp
 
 
 def test_half_installed_boundary_warns_before_falling_back(monkeypatch, capsys, tmp_path):
-    """Vault present but wrapper gone is a broken control node, not a CI runner.
-
-    Degrading silently there would quietly drop privilege separation on the
-    machine that actually holds the secrets, so it must be noisy.
-    """
     real = REAL_WRAPPER_AVAILABLE
     monkeypatch.setattr(secretspec_exec, "wrapper_available", real)
     real.cache_clear()
@@ -115,8 +108,6 @@ def test_half_installed_boundary_warns_before_falling_back(monkeypatch, capsys, 
     monkeypatch.setattr(secretspec_exec, "VAULT_DIR", str(vault))
     try:
         assert real() is False
-        err = capsys.readouterr().err
-        assert "without privilege separation" in err
-        assert "absent.sh" in err
+        assert "without privilege separation" in capsys.readouterr().err
     finally:
         real.cache_clear()

--- a/tests/python/test_termux_pkg_nightly.py
+++ b/tests/python/test_termux_pkg_nightly.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import secretspec_exec
 import termux_pkg_nightly as nightly
 from ansible_context import AnsibleContext
 
@@ -43,10 +44,8 @@ def test_nightly_runner_uses_resolved_site_config(monkeypatch, tmp_path):
     # --check skips the #152 pre-check so subprocess.run is only ansible-playbook.
     assert nightly.main(["--check", "--limit", "oneui-device"]) == 0
     assert seen["command"] == [
-        "/bin/bash",
-        "-c",
-        'set -e; _sec_out=$(sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh export --format shell); eval "$_sec_out"; exec "$@"',
-        "secretspec_wrapper",
+        secretspec_exec.sys.executable,
+        secretspec_exec.HELPER_PATH,
         "ansible-playbook",
         str(nightly.PLAYBOOK),
         "-e",

--- a/tests/python/test_verify_secretspec_sync.py
+++ b/tests/python/test_verify_secretspec_sync.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[2] / "control" / "bin"))
+import verify_secretspec_sync as verifier
+
+
+def _files(tmp_path: Path) -> tuple[Path, Path]:
+    source = tmp_path / "source"
+    vault = tmp_path / "vault"
+    source.mkdir()
+    vault.mkdir()
+    os.chmod(source, 0o700)
+    os.chmod(vault, 0o700)
+    for name in verifier.NAMES:
+        (source / name).write_text(f"{name}=value\n")
+        (vault / name).write_text(f"{name}=value\n")
+        os.chmod(source / name, 0o600)
+        os.chmod(vault / name, 0o600)
+    return source, vault
+
+
+def test_source_and_vault_match(tmp_path):
+    source, vault = _files(tmp_path)
+    assert verifier.verify(source, vault) == []
+
+
+def test_mismatch_fails_closed(tmp_path):
+    source, vault = _files(tmp_path)
+    (source / ".env").write_text("changed=true\n")
+    assert any("hash mismatch: .env" in error for error in verifier.verify(source, vault))
+
+
+def test_symlink_and_permissions_fail_closed(tmp_path):
+    source, vault = _files(tmp_path)
+    (source / ".env").unlink()
+    (source / ".env").symlink_to(vault / ".env")
+    os.chmod(vault / "secretspec.toml", 0o644)
+    errors = verifier.verify(source, vault)
+    assert any("real 0600" in error for error in errors)
+    assert any("real 0600" in error for error in errors)


### PR DESCRIPTION
## Summary

- replace arbitrary SecretSpec sudo passthrough with two fixed wrapper operations;
- run approved Ansible through a JSON environment helper while retaining the invoking user identity;
- move the wrapper into the repository as a managed artifact;
- verify source/vault permissions and hashes during publication without printing values;
- migrate FIRERPA token lookup to the fixed operation;
- update architecture documentation and add regression/security tests.

Closes #259.

## Verification

- focused pytest suite: 52 passed;
- ruff, ruff-format, shellcheck, shfmt, typos, markdownlint, ansible-lint, bandit: passed;
- known baseline hook failures remain in unrelated mypy, Prettier plugin setup, and semgrep findings.

## Security scope

This removes caller-selected SecretSpec subcommands, arbitrary command execution, and caller-controlled SecretSpec selectors from the sudo wrapper. A same-UID process can still invoke any intentionally approved operation granted to that UID; UNIX credentials cannot distinguish two same-UID processes. The documentation states that residual limitation explicitly.
