### PR TITLE
fix(secretspec): verify protected vault as root

### DIFF
--- a/control/bin/publish_secrets.sh
+++ b/control/bin/publish_secrets.sh
@@ -32,4 +32,6 @@ sudo chmod 0700 "$TARGET_DIR"
 sudo install -o _secretspec -g staff -m 0600 "$PRIVATE_SITE_DIR/.env" "$TARGET_DIR/.env"
 sudo install -o _secretspec -g staff -m 0600 "$PRIVATE_SITE_DIR/secretspec.toml" "$TARGET_DIR/secretspec.toml"
 
-python3 "$VERIFY_SCRIPT" "$PRIVATE_SITE_DIR" "$TARGET_DIR"
+# The vault is intentionally unreadable to the operator; verify both sides as
+# root without printing secret values.
+sudo -n python3 "$VERIFY_SCRIPT" "$PRIVATE_SITE_DIR" "$TARGET_DIR"


### PR DESCRIPTION
Fix the released SecretSpec publication script so its post-copy verifier can read the intentionally protected vault. The verifier runs through sudo -n and still prints only hashes/permissions, never secret values. Required for the ops-v1.3.6 live deployment path.