### PR TITLE
chore: release ops-v1.3.7

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.3.6"
+  "version": "1.3.7"
 }


### PR DESCRIPTION
Forward-only coordinated patch release for the protected-vault verifier hotfix.