### PR TITLE
fix(secretspec): keep sync verification passwordless

### DIFF
--- a/control/bin/publish_secrets.sh
+++ b/control/bin/publish_secrets.sh
@@ -7,7 +7,6 @@ set -euo pipefail
 TARGET_DIR="/var/db/stayturgid-secrets"
 OPS_ROOT="${OPS_ROOT:-$HOME/ops}"
 PRIVATE_SITE_DIR="$OPS_ROOT/site-private"
-VERIFY_SCRIPT="$(cd "$(dirname "$0")" && pwd)/verify_secretspec_sync.py"
 
 if [ ! -d "$PRIVATE_SITE_DIR" ] || [ -L "$PRIVATE_SITE_DIR" ]; then
   echo "Error: private site directory is missing or a symlink." >&2
@@ -32,6 +31,9 @@ sudo chmod 0700 "$TARGET_DIR"
 sudo install -o _secretspec -g staff -m 0600 "$PRIVATE_SITE_DIR/.env" "$TARGET_DIR/.env"
 sudo install -o _secretspec -g staff -m 0600 "$PRIVATE_SITE_DIR/secretspec.toml" "$TARGET_DIR/secretspec.toml"
 
-# The vault is intentionally unreadable to the operator; verify both sides as
-# root without printing secret values.
-sudo -n python3 "$VERIFY_SCRIPT" "$PRIVATE_SITE_DIR" "$TARGET_DIR"
+# The operator hashes the source files; the protected service user compares
+# those digests against the vault without exposing either file or requiring a
+# broad root sudo permission.
+SRC_ENV_HASH=$(shasum -a 256 "$PRIVATE_SITE_DIR/.env" | awk '{print $1}')
+SRC_TOML_HASH=$(shasum -a 256 "$PRIVATE_SITE_DIR/secretspec.toml" | awk '{print $1}')
+sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh verify-sync "$SRC_ENV_HASH" "$SRC_TOML_HASH"

--- a/control/bin/stayturgid-secretspec-wrapper.sh
+++ b/control/bin/stayturgid-secretspec-wrapper.sh
@@ -3,16 +3,31 @@
 # This is deliberately an operation interface, not a SecretSpec CLI passthrough.
 set -euo pipefail
 
-if [ "$#" -ne 1 ]; then
-  printf '%s\n' 'denied: expected exactly one approved operation' >&2
-  exit 2
-fi
-
 export HOME=/var/db/stayturgid-secrets
 export SECRETSPEC_PROVIDER=dotenv
 export SECRETSPEC_FILE=/var/db/stayturgid-secrets/secretspec.toml
 # Do not inherit caller-controlled SecretSpec selectors or dynamic loader state.
 unset SECRETSPEC_PROFILE SECRETSPEC_SCOPE SECRETSPEC_REASON DYLD_LIBRARY_PATH DYLD_INSERT_LIBRARIES
+
+if [ "${1:-}" = "verify-sync" ]; then
+  if [ "$#" -ne 3 ] || ! [[ "$2" =~ ^[[:xdigit:]]{64}$ ]] || ! [[ "$3" =~ ^[[:xdigit:]]{64}$ ]]; then
+    printf '%s\n' 'denied: verify-sync requires two SHA-256 digests' >&2
+    exit 2
+  fi
+  for path in "$SECRETSPEC_FILE" "$HOME/.env"; do
+    [ -f "$path" ] || { printf 'denied: missing vault file\n' >&2; exit 1; }
+    [ "$(stat -f '%Mp%Lp' "$path")" = "600" ] || { printf 'denied: vault file mode\n' >&2; exit 1; }
+  done
+  [ "$(shasum -a 256 "$HOME/.env" | cut -d ' ' -f 1)" = "$2" ] || { printf 'denied: .env hash mismatch\n' >&2; exit 1; }
+  [ "$(shasum -a 256 "$SECRETSPEC_FILE" | cut -d ' ' -f 1)" = "$3" ] || { printf 'denied: manifest hash mismatch\n' >&2; exit 1; }
+  printf '%s\n' 'SecretSpec source/vault hashes and permissions match.'
+  exit 0
+fi
+
+if [ "$#" -ne 1 ]; then
+  printf '%s\n' 'denied: expected exactly one approved operation' >&2
+  exit 2
+fi
 
 case "$1" in
   automation-env)

--- a/control/bin/stayturgid-secretspec-wrapper.sh
+++ b/control/bin/stayturgid-secretspec-wrapper.sh
@@ -15,11 +15,23 @@ if [ "${1:-}" = "verify-sync" ]; then
     exit 2
   fi
   for path in "$SECRETSPEC_FILE" "$HOME/.env"; do
-    [ -f "$path" ] || { printf 'denied: missing vault file\n' >&2; exit 1; }
-    [ "$(stat -f '%Mp%Lp' "$path")" = "600" ] || { printf 'denied: vault file mode\n' >&2; exit 1; }
+    [ -f "$path" ] || {
+      printf 'denied: missing vault file\n' >&2
+      exit 1
+    }
+    [ "$(stat -f '%Mp%Lp' "$path")" = "600" ] || {
+      printf 'denied: vault file mode\n' >&2
+      exit 1
+    }
   done
-  [ "$(shasum -a 256 "$HOME/.env" | cut -d ' ' -f 1)" = "$2" ] || { printf 'denied: .env hash mismatch\n' >&2; exit 1; }
-  [ "$(shasum -a 256 "$SECRETSPEC_FILE" | cut -d ' ' -f 1)" = "$3" ] || { printf 'denied: manifest hash mismatch\n' >&2; exit 1; }
+  [ "$(shasum -a 256 "$HOME/.env" | cut -d ' ' -f 1)" = "$2" ] || {
+    printf 'denied: .env hash mismatch\n' >&2
+    exit 1
+  }
+  [ "$(shasum -a 256 "$SECRETSPEC_FILE" | cut -d ' ' -f 1)" = "$3" ] || {
+    printf 'denied: manifest hash mismatch\n' >&2
+    exit 1
+  }
   printf '%s\n' 'SecretSpec source/vault hashes and permissions match.'
   exit 0
 fi


### PR DESCRIPTION
The released publish script must verify the protected vault without broad root sudo or a password prompt. Hash source files as the operator, then use the allowlisted _secretspec wrapper to validate vault hashes and modes. No secret values are printed.