### PR TITLE
chore: release ops-v1.3.8

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.3.7"
+  "version": "1.3.8"
 }


### PR DESCRIPTION
Forward-only coordinated patch release for the noninteractive protected-vault sync verifier.