### PR TITLE
chore: release ops-v1.3.9

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.3.8"
+  "version": "1.3.9"
 }


### PR DESCRIPTION
Forward-only release for the publisher PATH fix.