### PR TITLE
fix(secretspec): accept macOS 0600 mode output

### DIFF
--- a/control/bin/stayturgid-secretspec-wrapper.sh
+++ b/control/bin/stayturgid-secretspec-wrapper.sh
@@ -19,7 +19,7 @@ if [ "${1:-}" = "verify-sync" ]; then
       printf 'denied: missing vault file\n' >&2
       exit 1
     }
-    [ "$(stat -f '%Mp%Lp' "$path")" = "600" ] || {
+    [ "$(stat -f '%Mp%Lp' "$path")" = "0600" ] || {
       printf 'denied: vault file mode\n' >&2
       exit 1
     }


### PR DESCRIPTION
macOS stat returns 0600 for owner-only files; compare the exact output so the protected-vault sync verifier accepts valid permissions.