### PR TITLE
fix(secretspec): use numeric macOS mode format

### DIFF
--- a/control/bin/stayturgid-secretspec-wrapper.sh
+++ b/control/bin/stayturgid-secretspec-wrapper.sh
@@ -19,7 +19,7 @@ if [ "${1:-}" = "verify-sync" ]; then
       printf 'denied: missing vault file\n' >&2
       exit 1
     }
-    [ "$(stat -f '%Mp%Lp' "$path")" = "0600" ] || {
+    [ "$(stat -f '%OLp' "$path")" = "600" ] || {
       printf 'denied: vault file mode\n' >&2
       exit 1
     }


### PR DESCRIPTION
Use macOS stat %OLp to compare the permission bits numerically as 600, avoiding string-format ambiguity in the protected-vault verifier.