### PR TITLE
fix: migrate stayturgid Hermes notify target 22082 -> 22158

### DIFF
--- a/control/bin/check_apk_updates.py
+++ b/control/bin/check_apk_updates.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 
 import yaml
 
-HERMES_TARGET = "telegram:838808636:22082"
+HERMES_TARGET = "telegram:838808636:22158"
 STATE_PATH = os.path.expanduser("~/.local/state/stayturgid/apk-updates.json")
 
 # This project's own release is tracked separately (native-agent release

--- a/control/bin/check_termux_pkg_updates.py
+++ b/control/bin/check_termux_pkg_updates.py
@@ -40,7 +40,7 @@ for _p in (str(_LIB), str(_REPO)):
 
 import stayturgid_device as dev  # noqa: E402
 
-HERMES_TARGET = "telegram:838808636:22082"
+HERMES_TARGET = "telegram:838808636:22158"
 STATE_PATH = os.path.expanduser("~/.local/state/stayturgid/termux-pkg-updates.json")
 
 TERMUX_PREFIX = "/data/data/com.termux/files/usr"


### PR DESCRIPTION
## Summary
- Completes the Hermes Telegram ping-target migration (Inbox `22158`) for the two update-checker scripts (`check_apk_updates.py`, `check_termux_pkg_updates.py`) that were still pointed at the retired Moshi-webhook-era target `22082`.
- The rest of the fleet (site-private memory, `context_size_nudge.py` hook) already migrated to `22158`; this was the last stayturgid-side straggler.
- No behavior change beyond the notify target string.

## Test plan
- [x] `just test` — 731 passed, 1 skipped (pre-existing environmental skip, not caused by this change), lint/format/drift/secrets all clean.