### PR TITLE
chore: release ops-v1.3.13

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.3.11"
+  "version": "1.3.13"
 }


### PR DESCRIPTION
Coordinated djbclark-ops release 1.3.13. Bumps ops-release.json only.