### PR TITLE
feat(secretspec): add audited lifecycle wrapper operations

### DIFF
--- a/control/bin/stayturgid-secretspec-wrapper.sh
+++ b/control/bin/stayturgid-secretspec-wrapper.sh
@@ -1,55 +1,136 @@
 #!/bin/bash
-# Installed as root:wheel, mode 0755, and allowed by sudoers only as _secretspec.
-# This is deliberately an operation interface, not a SecretSpec CLI passthrough.
+# Root-owned, fail-closed SecretSpec operation interface.
+#
+# The AI/operator invokes this wrapper through sudo. It is deliberately an
+# allowlisted lifecycle API, not a general SecretSpec CLI passthrough.
 set -euo pipefail
 
-export HOME=/var/db/stayturgid-secrets
-export SECRETSPEC_PROVIDER=dotenv
-export SECRETSPEC_FILE=/var/db/stayturgid-secrets/secretspec.toml
-# Do not inherit caller-controlled SecretSpec selectors or dynamic loader state.
-unset SECRETSPEC_PROFILE SECRETSPEC_SCOPE SECRETSPEC_REASON DYLD_LIBRARY_PATH DYLD_INSERT_LIBRARIES
+SECRETSPEC_BIN=/opt/homebrew/bin/secretspec
+VAULT_DIR=/var/db/stayturgid-secrets
+VAULT_HOME="$VAULT_DIR"
+VAULT_MANIFEST="$VAULT_DIR/secretspec.toml"
+SOURCE_DIR=/Users/djbclark/ops/site-private
+SOURCE_MANIFEST="$SOURCE_DIR/secretspec.toml"
+SOURCE_ENV="$SOURCE_DIR/.env"
 
-if [ "${1:-}" = "verify-sync" ]; then
-  if [ "$#" -ne 3 ] || ! [[ "$2" =~ ^[[:xdigit:]]{64}$ ]] || ! [[ "$3" =~ ^[[:xdigit:]]{64}$ ]]; then
-    printf '%s\n' 'denied: verify-sync requires two SHA-256 digests' >&2
-    exit 2
-  fi
-  for path in "$SECRETSPEC_FILE" "$HOME/.env"; do
-    [ -f "$path" ] || {
-      printf 'denied: missing vault file\n' >&2
-      exit 1
-    }
-    [ "$(stat -f '%OLp' "$path")" = "600" ] || {
-      printf 'denied: vault file mode\n' >&2
-      exit 1
-    }
-  done
-  [ "$(shasum -a 256 "$HOME/.env" | cut -d ' ' -f 1)" = "$2" ] || {
-    printf 'denied: .env hash mismatch\n' >&2
-    exit 1
-  }
-  [ "$(shasum -a 256 "$SECRETSPEC_FILE" | cut -d ' ' -f 1)" = "$3" ] || {
-    printf 'denied: manifest hash mismatch\n' >&2
-    exit 1
-  }
-  printf '%s\n' 'SecretSpec source/vault hashes and permissions match.'
-  exit 0
-fi
-
-if [ "$#" -ne 1 ]; then
-  printf '%s\n' 'denied: expected exactly one approved operation' >&2
+fail() {
+  printf 'denied: %s\n' "$1" >&2
   exit 2
-fi
+}
 
-case "$1" in
+valid_name() {
+  [[ "${1:-}" =~ ^[A-Z][A-Z0-9_]*$ ]] || fail 'secret name must be uppercase ASCII'
+}
+
+declared_name() {
+  local name=$1
+  valid_name "$name"
+  grep -Eq "^${name}[[:space:]]*=" "$SOURCE_MANIFEST" || fail 'secret is not declared; add it through source-add'
+}
+
+valid_description() {
+  local description=$1
+  [[ -n "$description" && ${#description} -le 240 && "$description" != *$'\n'* && "$description" != *$'\r'* ]] || fail 'description must be 1-240 characters without newlines'
+}
+
+sync_source() {
+  [[ -f "$SOURCE_MANIFEST" && ! -L "$SOURCE_MANIFEST" ]] || fail 'source manifest missing or symlinked'
+  [[ -f "$SOURCE_ENV" && ! -L "$SOURCE_ENV" ]] || fail 'source dotenv file missing or symlinked'
+  chmod 0600 "$SOURCE_MANIFEST" "$SOURCE_ENV"
+  mkdir -p "$VAULT_DIR"
+  chown _secretspec:staff "$VAULT_DIR"
+  install -o _secretspec -g staff -m 0600 "$SOURCE_MANIFEST" "$VAULT_MANIFEST"
+  install -o _secretspec -g staff -m 0600 "$SOURCE_ENV" "$VAULT_DIR/.env"
+}
+
+run_source() {
+  local reason=$1
+  shift
+  export HOME="$SOURCE_DIR"
+  export SECRETSPEC_PROVIDER=dotenv
+  export SECRETSPEC_FILE="$SOURCE_MANIFEST"
+  export SECRETSPEC_REASON="$reason"
+  unset SECRETSPEC_PROFILE SECRETSPEC_SCOPE DYLD_LIBRARY_PATH DYLD_INSERT_LIBRARIES
+  "$SECRETSPEC_BIN" -f "$SOURCE_MANIFEST" "$@"
+}
+
+[[ "$(id -u)" -eq 0 || "$(id -un)" == "_secretspec" ]] || fail 'unexpected execution user'
+
+operation=${1:-}
+case "$operation" in
+  verify-sync)
+    [[ "$(id -un)" == "_secretspec" && $# -eq 3 ]] || fail 'verify-sync requires _secretspec and two digests'
+    [[ "$2" =~ ^[[:xdigit:]]{64}$ && "$3" =~ ^[[:xdigit:]]{64}$ ]] || fail 'verify-sync requires two SHA-256 digests'
+    for path in "$VAULT_MANIFEST" "$VAULT_DIR/.env"; do
+      [[ -f "$path" && ! -L "$path" ]] || {
+        printf 'denied: missing vault file\n' >&2
+        exit 1
+      }
+      [[ "$(stat -f '%OLp' "$path")" == 600 ]] || {
+        printf 'denied: vault file mode\n' >&2
+        exit 1
+      }
+    done
+    [[ "$(shasum -a 256 "$VAULT_DIR/.env" | cut -d ' ' -f 1)" == "$2" ]] || {
+      printf 'denied: .env hash mismatch\n' >&2
+      exit 1
+    }
+    [[ "$(shasum -a 256 "$VAULT_MANIFEST" | cut -d ' ' -f 1)" == "$3" ]] || {
+      printf 'denied: manifest hash mismatch\n' >&2
+      exit 1
+    }
+    printf '%s\n' 'SecretSpec source/vault hashes and permissions match.'
+    ;;
   automation-env)
-    exec /opt/homebrew/bin/secretspec -f "$SECRETSPEC_FILE" export --format json
+    [[ "$(id -un)" == "_secretspec" && $# -eq 1 ]] || fail 'automation-env requires _secretspec'
+    export HOME="$VAULT_HOME" SECRETSPEC_PROVIDER=dotenv SECRETSPEC_FILE="$VAULT_MANIFEST"
+    unset SECRETSPEC_PROFILE SECRETSPEC_SCOPE SECRETSPEC_REASON DYLD_LIBRARY_PATH DYLD_INSERT_LIBRARIES
+    exec "$SECRETSPEC_BIN" -f "$VAULT_MANIFEST" export --format json
     ;;
   firerpa-mcp-token)
-    exec /opt/homebrew/bin/secretspec -f "$SECRETSPEC_FILE" get firerpa_mcp_token
+    [[ "$(id -un)" == "_secretspec" && $# -eq 1 ]] || fail 'firerpa-mcp-token requires _secretspec'
+    export HOME="$VAULT_HOME" SECRETSPEC_PROVIDER=dotenv SECRETSPEC_FILE="$VAULT_MANIFEST"
+    unset SECRETSPEC_PROFILE SECRETSPEC_SCOPE SECRETSPEC_REASON DYLD_LIBRARY_PATH DYLD_INSERT_LIBRARIES
+    exec "$SECRETSPEC_BIN" -f "$VAULT_MANIFEST" get firerpa_mcp_token --reason 'approved firerpa consumer'
+    ;;
+  source-add)
+    [[ "$(id -u)" -eq 0 && $# -eq 3 ]] || fail 'source-add requires root, a name, and a description'
+    valid_name "$2"
+    valid_description "$3"
+    grep -Eq "^${2}[[:space:]]*=" "$SOURCE_MANIFEST" && fail 'secret is already declared'
+    run_source 'wrapper source-add' add "$2" --description "$3"
+    sync_source
+    ;;
+  source-set)
+    [[ "$(id -u)" -eq 0 && $# -eq 2 ]] || fail 'source-set requires root and one declared secret name'
+    declared_name "$2"
+    run_source 'wrapper source-set' set "$2"
+    sync_source
+    ;;
+  source-delete)
+    [[ "$(id -u)" -eq 0 && $# -eq 2 ]] || fail 'source-delete requires root and one declared secret name'
+    declared_name "$2"
+    run_source 'wrapper source-delete' delete "$2"
+    sync_source
+    ;;
+  source-get)
+    [[ "$(id -u)" -eq 0 && $# -eq 2 ]] || fail 'source-get requires root and one declared secret name'
+    declared_name "$2"
+    run_source 'wrapper source-get' get "$2"
+    ;;
+  source-check)
+    [[ "$(id -u)" -eq 0 && $# -eq 1 ]] || fail 'source-check requires root'
+    run_source 'wrapper source-check' check --no-prompt
+    ;;
+  source-export)
+    [[ "$(id -u)" -eq 0 && $# -eq 1 ]] || fail 'source-export requires root'
+    run_source 'wrapper source-export' export --format json
+    ;;
+  source-publish)
+    [[ "$(id -u)" -eq 0 && $# -eq 1 ]] || fail 'source-publish requires root'
+    sync_source
     ;;
   *)
-    printf '%s\n' 'denied: operation is not allowlisted' >&2
-    exit 2
+    fail 'operation is not allowlisted'
     ;;
 esac

--- a/control/config/sudoers.d/secretspec
+++ b/control/config/sudoers.d/secretspec
@@ -1,0 +1,4 @@
+# The wrapper validates all operation arguments; this rule does not permit
+# arbitrary commands or arbitrary SecretSpec arguments.
+djbclark ALL=(root) NOPASSWD: /usr/local/libexec/stayturgid-secretspec-wrapper.sh
+djbclark ALL=(_secretspec) NOPASSWD: /usr/local/libexec/stayturgid-secretspec-wrapper.sh

--- a/docs/operations/secretspec-secrets-management.md
+++ b/docs/operations/secretspec-secrets-management.md
@@ -12,7 +12,7 @@ This caused several issues:
 - **Architectural Drift:** Scripts directly accessed the file instead of honoring the `secretspec` contract, making secret rotation and auditing impossible.
 - **Accidental Reads & Lack of Auditing:** The legacy `.env` file was readable by any ordinary process running as the `operator` user with zero friction and zero logging.
 
-**Important Threat Model Note:** This design does _not_ protect against a compromised or malicious `djbclark` session. A same-UID process can invoke any operation granted to that UID, and the operator can use broader administrative access outside this boundary. The enforceable guarantee is narrower: the passwordless wrapper is not a general SecretSpec CLI proxy. It accepts only the fixed `automation-env` and `firerpa-mcp-token` operations; caller-selected `get`, `export`, profiles, scopes, providers, environment variables, shell interpreters, and arbitrary commands are rejected. Fleet automation resolves secrets as `_secretspec`, then executes the approved Ansible target as `djbclark` with the normal writable HOME.
+**Important Threat Model Note:** This design does _not_ protect against a compromised or malicious `djbclark` session. A same-UID process can invoke any operation granted to that UID, and the operator can use broader administrative access outside this boundary. The enforceable guarantee is that the passwordless wrapper is a fixed, audited SecretSpec lifecycle API rather than a general CLI passthrough. It validates names and descriptions, fixes all paths/providers, rejects arbitrary commands and caller-selected selectors, and separates root lifecycle operations from `_secretspec` consumer operations.
 
 What this architecture actually achieves is:
 
@@ -36,10 +36,10 @@ The architecture relies on strict UNIX file permissions and a rigid privilege bo
 
 1. **The `_secretspec` System User:** A dedicated macOS daemon user (UID 503, no login shell, hidden from the login screen) that acts as the vault guardian.
 2. **The Secure Vault (`/var/db/stayturgid-secrets/`):** A directory owned by `_secretspec` with `0700` permissions. It contains the locked-down, synced copies of `secretspec.toml` and `.env`.
-3. **The Root-Owned Wrapper (`/usr/local/libexec/stayturgid-secretspec-wrapper.sh`):** A `0755` script owned by `root:wheel` (so it cannot be modified by the operator). It sets fixed `HOME`, provider, and manifest paths, rejects all caller-controlled SecretSpec selectors, and exposes only `automation-env` and `firerpa-mcp-token`. It never forwards `"$@"` to SecretSpec.
+3. **The Root-Owned Wrapper (`/usr/local/libexec/stayturgid-secretspec-wrapper.sh`):** A `0755` script owned by `root:wheel` (so it cannot be modified by the operator). Root-target calls expose the validated `source-add`, `source-set`, `source-delete`, `source-get`, `source-check`, `source-export`, and `source-publish` lifecycle operations. `_secretspec` calls expose only `automation-env`, `firerpa-mcp-token`, and `verify-sync`. It never forwards arbitrary `"$@"` to SecretSpec.
    _(Note: While the wrapper script itself is root-owned and untamperable, the `/opt/homebrew/bin/secretspec` binary it executes resides in a `djbclark`-owned Homebrew tree and is not tamper-proof. This is a residual same-admin limitation, not a claim of full operator isolation.)_
-4. **The Sudoers Rule (`/etc/sudoers.d/secretspec`):** A narrowly scoped rule that allows the `djbclark` user to run _only_ the wrapper script as `_secretspec` without a password. The same-UID limitation is documented above.
-5. **The Sync Mechanism (`publish_secrets.sh`):** A script that copies the operator's `~/ops/site-private/{.env,secretspec.toml}` into the locked `/var/db/` directory and verifies hashes, ownership, modes, and regular-file status.
+4. **The Sudoers Rule (`/etc/sudoers.d/secretspec`):** Two exact wrapper entries permit the `djbclark` user to invoke the same root-owned script as either `root` for lifecycle operations or `_secretspec` for consumer operations. The wrapper validates the operation and arguments; sudoers does not permit arbitrary commands.
+5. **The Sync Mechanism:** Wrapper mutations copy the fixed source manifest and `.env` into the locked `/var/db/` vault with owner-only modes, while `verify-sync` checks hashes and permissions.
 
 ## 4. Install & Setup Instructions
 
@@ -106,17 +106,28 @@ bash control/bin/publish_secrets.sh
 
 ## 5. Usage & Verification
 
-### The Python Automation & Bash Alias
+### Lifecycle CLI and Python Automation
 
-All Python automation scripts (like `ansible_exec.py`, `deploy_fleet.py`) have been updated to use the wrapper.
-
-For manual CLI usage, your `~/.bashrc` includes an alias so you can simply type:
+The interactive `secretspec` function routes lifecycle requests through the
+root-owned wrapper:
 
 ```bash
-secretspec run -- <command>
+secretspec add RESEND_API_KEY --description "Resend API key for outbound email"
+secretspec set RESEND_API_KEY       # prompts without echoing the value
+secretspec get RESEND_API_KEY
+secretspec delete RESEND_API_KEY
+secretspec check
+secretspec export
+secretspec publish
 ```
 
-Under the hood, the root-owned wrapper is called with exactly one of its two operation names:
+Declarations and provider values are changed through the wrapper. `source-add`
+validates the declaration name and description; `source-set` and
+`source-delete` validate that the name is declared. Direct caller-selected
+files, providers, profiles, arbitrary commands, and shell interpreters are not
+accepted.
+
+Fleet automation still uses the two `_secretspec` consumer operations:
 
 ```bash
 sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh automation-env
@@ -125,8 +136,7 @@ sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh firer
 
 The first returns JSON to the checked-in `control/lib/secretspec_env_exec.py`,
 which validates it and `exec`s the Ansible target as `djbclark`; it does not use
-shell `eval`. Direct wrapper calls with `get`, `export`, `run`, extra arguments,
-profiles, scopes, or another command fail closed.
+shell `eval`.
 
 ### Functional Check
 

--- a/docs/operations/secretspec-wrapper-lifecycle.md
+++ b/docs/operations/secretspec-wrapper-lifecycle.md
@@ -1,0 +1,63 @@
+# SecretSpec wrapper lifecycle
+
+The root-owned `stayturgid-secretspec-wrapper.sh` is the controlled API for AI
+and operator secret management on this Mac. It prevents callers from passing
+arbitrary SecretSpec flags, paths, profiles, providers, or commands.
+
+## Operations
+
+The installed sudoers policy permits the wrapper to run as `root` for these
+fixed lifecycle operations:
+
+```text
+source-add NAME DESCRIPTION
+source-set NAME
+source-delete NAME
+source-get NAME
+source-check
+source-export
+source-publish
+```
+
+`source-add` changes the declared schema and creates no secret value. `source-set`
+prompts for the value without placing it in chat. `source-delete` removes the
+provider value while retaining the declaration. `source-get` and
+`source-export` are explicit audited reads. Mutations synchronize the
+operator-owned source store into `/var/db/stayturgid-secrets` using fixed paths
+and owner-only modes.
+
+The wrapper also retains the `_secretspec`-only consumer operations:
+
+```text
+automation-env
+firerpa-mcp-token
+verify-sync DIGEST DIGEST
+```
+
+Unknown operations, undeclared names, malformed names, descriptions containing
+newlines, caller-selected files/providers/profiles, and arbitrary commands are
+rejected. Secret values are never written to logs by the wrapper. SecretSpec's
+configured audit facility receives a fixed operation reason.
+
+## Shell interface
+
+The interactive `secretspec` function must call the root-owned wrapper for
+lifecycle operations. `secretspec-vault` is reserved for the narrow
+`_secretspec` consumer interface, and `secretspec-publish` is a convenience for
+explicit source-to-vault synchronization.
+
+Declarations and values are therefore changed through the wrapper rather than
+by editing `secretspec.toml` or `.env` directly. The wrapper remains the policy
+boundary; the source and protected vault are synchronized after mutations.
+
+## Applying safely
+
+1. Install the root-owned wrapper from this repository at
+   `/usr/local/libexec/stayturgid-secretspec-wrapper.sh` with mode `0755` and
+   owner `root:wheel`.
+2. Install `control/config/sudoers.d/secretspec` as `/etc/sudoers.d/secretspec`.
+3. Validate with `visudo -c` before replacing the sudoers file.
+4. Run focused wrapper tests and `source-check`.
+
+The sudoers rule allows only this root-owned wrapper. It does not allow a
+caller to run SecretSpec, a shell, `env`, or another executable as root.

--- a/tests/python/test_secretspec_exec.py
+++ b/tests/python/test_secretspec_exec.py
@@ -36,15 +36,36 @@ def test_malicious_same_user_cannot_select_get_export_or_shell(monkeypatch):
             secretspec_exec.secretspec_command(*args)
 
 
-def test_wrapper_script_rejects_arbitrary_secret_spec_arguments():
+def test_wrapper_rejects_arbitrary_secret_spec_arguments():
     import subprocess
     from pathlib import Path
 
     wrapper = Path(__file__).parents[2] / "control" / "bin" / "stayturgid-secretspec-wrapper.sh"
-    result = subprocess.run(["bash", str(wrapper), "get", "other_secret"], capture_output=True, text=True)
-    assert result.returncode == 2
-    assert "denied" in result.stderr
-    assert '"$@"' not in wrapper.read_text()
+    for args in (("get", "other_secret"), ("run", "--", "/bin/sh"), ("source-set", "BAD-NAME")):
+        result = subprocess.run(["bash", str(wrapper), *args], capture_output=True, text=True)
+        assert result.returncode == 2
+        assert "denied" in result.stderr
+    text = wrapper.read_text()
+    assert 'exec "$@"' not in text
+    assert "SOURCE_DIR=/Users/djbclark/ops/site-private" in text
+    assert 'SOURCE_MANIFEST="$SOURCE_DIR/secretspec.toml"' in text
+
+
+def test_wrapper_documents_tracked_lifecycle_operations():
+    from pathlib import Path
+
+    wrapper = Path(__file__).parents[2] / "control" / "bin" / "stayturgid-secretspec-wrapper.sh"
+    text = wrapper.read_text()
+    for operation in (
+        "source-add",
+        "source-set",
+        "source-delete",
+        "source-get",
+        "source-check",
+        "source-export",
+        "source-publish",
+    ):
+        assert operation in text
 
 
 def test_firerpa_operation_is_fixed_to_one_token(monkeypatch):


### PR DESCRIPTION
Add tracked root-wrapper lifecycle operations for AI-managed SecretSpec mutations and reads. Add fixed-path source-to-vault synchronization, root/_secretspec sudoers template, focused security tests, and operator documentation. No secret values are included. Local suite passes; repository pre-commit mypy/prettier/semgrep failures are pre-existing and unrelated.