### PR TITLE
chore: release ops-v1.3.17

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.3.16"
+  "version": "1.3.17"
 }


### PR DESCRIPTION
## Summary

Coordinate the stayturgid repository for ops-v1.3.17. This repository has no unreleased product changes; the PR only advances the suite manifest.

## Verification

- `just worktree-setup`
- `just test`
  - local shell/unit gate: pass
  - pytest: 732 passed, 1 skipped
  - ansible-test: 108 passed across collections
  - formatting/lint/identity checks: pass