### PR TITLE
chore: release ops-v1.3.18

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.3.17"
+  "version": "1.3.18"
 }


### PR DESCRIPTION
## Summary

Coordinate stayturgid for ops-v1.3.18. Manifest-only bump.

## Verification

- `just worktree-setup`
- `just test` (all tiers passed)