### PR TITLE
Move SecretSpec lifecycle to canonical vault

### DIFF
--- a/control/bin/publish_secrets.sh
+++ b/control/bin/publish_secrets.sh
@@ -1,38 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Publish the two SecretSpec inputs, then fail closed unless the source and
-# root-owned vault are byte-identical private regular files. No secret values
-# are printed or logged.
-TARGET_DIR="/var/db/stayturgid-secrets"
-OPS_ROOT="${OPS_ROOT:-$HOME/ops}"
-PRIVATE_SITE_DIR="$OPS_ROOT/site-private"
+# Compatibility verifier for the single canonical SecretSpec store.
+# Lifecycle operations now mutate /var/db/stayturgid-secrets directly through
+# the root-owned wrapper; there is no checkout source to copy or hash.
+WRAPPER=/usr/local/libexec/stayturgid-secretspec-wrapper.sh
 
-if [ ! -d "$PRIVATE_SITE_DIR" ] || [ -L "$PRIVATE_SITE_DIR" ]; then
-  echo "Error: private site directory is missing or a symlink." >&2
-  exit 1
-fi
-for name in .env secretspec.toml; do
-  path="$PRIVATE_SITE_DIR/$name"
-  if [ ! -f "$path" ] || [ -L "$path" ]; then
-    echo "Error: $path must be a regular file (not a symlink)." >&2
-    exit 1
-  fi
-done
-# The source copy is itself private operator state; repair overly broad modes
-# before publishing so the verifier and the source remain owner-only.
-chmod 0600 "$PRIVATE_SITE_DIR/.env" "$PRIVATE_SITE_DIR/secretspec.toml"
-
-sudo mkdir -p "$TARGET_DIR"
-sudo /usr/sbin/chown _secretspec:staff "$TARGET_DIR"
-# install writes the named destination with the requested mode and does not
-# copy source metadata or follow a source symlink (which was rejected above).
-sudo install -o _secretspec -g staff -m 0600 "$PRIVATE_SITE_DIR/.env" "$TARGET_DIR/.env"
-sudo install -o _secretspec -g staff -m 0600 "$PRIVATE_SITE_DIR/secretspec.toml" "$TARGET_DIR/secretspec.toml"
-
-# The operator hashes the source files; the protected service user compares
-# those digests against the vault without exposing either file or requiring a
-# broad root sudo permission.
-SRC_ENV_HASH=$(shasum -a 256 "$PRIVATE_SITE_DIR/.env" | awk '{print $1}')
-SRC_TOML_HASH=$(shasum -a 256 "$PRIVATE_SITE_DIR/secretspec.toml" | awk '{print $1}')
-sudo -n -u _secretspec /usr/local/libexec/stayturgid-secretspec-wrapper.sh verify-sync "$SRC_ENV_HASH" "$SRC_TOML_HASH"
+sudo -n "$WRAPPER" source-publish
+sudo -n "$WRAPPER" source-check
+sudo -n "$WRAPPER" source-template-check
+printf '%s\n' 'SecretSpec canonical store permissions, values, and tracked schema match.'

--- a/control/bin/stayturgid-secretspec-wrapper.sh
+++ b/control/bin/stayturgid-secretspec-wrapper.sh
@@ -9,9 +9,10 @@ SECRETSPEC_BIN=/opt/homebrew/bin/secretspec
 VAULT_DIR=/var/db/stayturgid-secrets
 VAULT_HOME="$VAULT_DIR"
 VAULT_MANIFEST="$VAULT_DIR/secretspec.toml"
-SOURCE_DIR=/Users/djbclark/ops/site-private
-SOURCE_MANIFEST="$SOURCE_DIR/secretspec.toml"
-SOURCE_ENV="$SOURCE_DIR/.env"
+SOURCE_DIR="$VAULT_DIR"
+SOURCE_MANIFEST="$VAULT_MANIFEST"
+SOURCE_ENV="$VAULT_DIR/.env"
+SOURCE_EXAMPLE=/Users/djbclark/ops/site-private/secretspec.toml.example
 
 fail() {
   printf 'denied: %s\n' "$1" >&2
@@ -34,13 +35,12 @@ valid_description() {
 }
 
 sync_source() {
-  [[ -f "$SOURCE_MANIFEST" && ! -L "$SOURCE_MANIFEST" ]] || fail 'source manifest missing or symlinked'
-  [[ -f "$SOURCE_ENV" && ! -L "$SOURCE_ENV" ]] || fail 'source dotenv file missing or symlinked'
+  [[ -d "$VAULT_DIR" && ! -L "$VAULT_DIR" ]] || fail 'vault directory missing or symlinked'
+  [[ -f "$SOURCE_MANIFEST" && ! -L "$SOURCE_MANIFEST" ]] || fail 'manifest missing or symlinked'
+  [[ -f "$SOURCE_ENV" && ! -L "$SOURCE_ENV" ]] || fail 'dotenv file missing or symlinked'
+  chown _secretspec:staff "$VAULT_DIR" "$SOURCE_MANIFEST" "$SOURCE_ENV"
+  chmod 0700 "$VAULT_DIR"
   chmod 0600 "$SOURCE_MANIFEST" "$SOURCE_ENV"
-  mkdir -p "$VAULT_DIR"
-  chown _secretspec:staff "$VAULT_DIR"
-  install -o _secretspec -g staff -m 0600 "$SOURCE_MANIFEST" "$VAULT_MANIFEST"
-  install -o _secretspec -g staff -m 0600 "$SOURCE_ENV" "$VAULT_DIR/.env"
 }
 
 run_source() {
@@ -100,6 +100,7 @@ case "$operation" in
     grep -Eq "^${2}[[:space:]]*=" "$SOURCE_MANIFEST" && fail 'secret is already declared'
     run_source 'wrapper source-add' add "$2" --description "$3"
     sync_source
+    printf 'declaration added to runtime; mirror %s in %s through a worktree PR\n' "$2" "$SOURCE_EXAMPLE"
     ;;
   source-set)
     [[ "$(id -u)" -eq 0 && $# -eq 2 ]] || fail 'source-set requires root and one declared secret name'
@@ -125,6 +126,12 @@ case "$operation" in
   source-export)
     [[ "$(id -u)" -eq 0 && $# -eq 1 ]] || fail 'source-export requires root'
     run_source 'wrapper source-export' export --format json
+    ;;
+  source-template-check)
+    [[ "$(id -u)" -eq 0 && $# -eq 1 ]] || fail 'source-template-check requires root'
+    [[ -f "$SOURCE_EXAMPLE" && ! -L "$SOURCE_EXAMPLE" ]] || fail 'tracked declaration example missing or symlinked'
+    cmp -s "$SOURCE_MANIFEST" "$SOURCE_EXAMPLE" || fail 'runtime manifest differs from tracked declaration example'
+    printf 'runtime manifest matches tracked declaration example\n'
     ;;
   source-publish)
     [[ "$(id -u)" -eq 0 && $# -eq 1 ]] || fail 'source-publish requires root'

--- a/docs/operations/secretspec-secrets-management.md
+++ b/docs/operations/secretspec-secrets-management.md
@@ -35,11 +35,11 @@ When designing this boundary, we evaluated several approaches. The core constrai
 The architecture relies on strict UNIX file permissions and a rigid privilege boundary:
 
 1. **The `_secretspec` System User:** A dedicated macOS daemon user (UID 503, no login shell, hidden from the login screen) that acts as the vault guardian.
-2. **The Secure Vault (`/var/db/stayturgid-secrets/`):** A directory owned by `_secretspec` with `0700` permissions. It contains the locked-down, synced copies of `secretspec.toml` and `.env`.
-3. **The Root-Owned Wrapper (`/usr/local/libexec/stayturgid-secretspec-wrapper.sh`):** A `0755` script owned by `root:wheel` (so it cannot be modified by the operator). Root-target calls expose the validated `source-add`, `source-set`, `source-delete`, `source-get`, `source-check`, `source-export`, and `source-publish` lifecycle operations. `_secretspec` calls expose only `automation-env`, `firerpa-mcp-token`, and `verify-sync`. It never forwards arbitrary `"$@"` to SecretSpec.
+2. **The Canonical Store (`/var/db/stayturgid-secrets/`):** A directory owned by `_secretspec` with `0700` permissions. It is the sole live store for `secretspec.toml` and `.env`; Git tracks only `site-private/secretspec.toml.example`.
+3. **The Root-Owned Wrapper (`/usr/local/libexec/stayturgid-secretspec-wrapper.sh`):** A `0755` script owned by `root:wheel` (so it cannot be modified by the operator). Root-target calls expose the validated `source-add`, `source-set`, `source-delete`, `source-get`, `source-check`, `source-export`, `source-template-check`, and compatibility `source-publish` lifecycle operations directly against the canonical store. `_secretspec` calls expose only `automation-env`, `firerpa-mcp-token`, and `verify-sync`. It never forwards arbitrary `"$@"` to SecretSpec.
    _(Note: While the wrapper script itself is root-owned and untamperable, the `/opt/homebrew/bin/secretspec` binary it executes resides in a `djbclark`-owned Homebrew tree and is not tamper-proof. This is a residual same-admin limitation, not a claim of full operator isolation.)_
 4. **The Sudoers Rule (`/etc/sudoers.d/secretspec`):** Two exact wrapper entries permit the `djbclark` user to invoke the same root-owned script as either `root` for lifecycle operations or `_secretspec` for consumer operations. The wrapper validates the operation and arguments; sudoers does not permit arbitrary commands.
-5. **The Sync Mechanism:** Wrapper mutations copy the fixed source manifest and `.env` into the locked `/var/db/` vault with owner-only modes, while `verify-sync` checks hashes and permissions.
+5. **Tracked Schema:** `site-private/secretspec.toml.example` contains declarations only and is reviewed through Git. `source-template-check` compares it with the canonical runtime manifest without printing either file.
 
 ## 4. Install & Setup Instructions
 
@@ -97,12 +97,16 @@ sudo install -o root -g wheel -m 0440 "$TMPFILE" /etc/sudoers.d/secretspec
 rm "$TMPFILE"
 ```
 
-**4. Publish the Secrets:**
+**4. Verify the Canonical Store:**
 
 ```bash
-# This syncs your local site-private secrets into the vault
+# The wrapper repairs owner-only modes and checks the tracked schema.
 bash control/bin/publish_secrets.sh
 ```
+
+The one-time migration from the former checkout source must be performed before
+installing this wrapper; after cutover, no live manifest or `.env` remains in a
+Git checkout.
 
 ## 5. Usage & Verification
 
@@ -140,18 +144,15 @@ shell `eval`.
 
 ### Functional Check
 
-To manually verify the pipeline without printing secret values, run the
-non-secret drift check first:
+To manually verify the pipeline without printing secret values, run:
 
 ```bash
-python3 control/bin/verify_secretspec_sync.py \
-  "${OPS_ROOT:-$HOME/ops}/site-private" /var/db/stayturgid-secrets
+bash control/bin/publish_secrets.sh
 ```
 
-A source/vault hash mismatch, symlink, missing file, wrong mode, or wrong vault
-permissions exits nonzero. `publish_secrets.sh` performs the same check after
-publishing and must be run after every source change. Do not bypass this check
-or add secret values to logs.
+A missing/symlinked canonical file, wrong ownership/mode, SecretSpec validation
+failure, or runtime/tracked-schema mismatch exits nonzero. No secret value is
+printed by the verifier.
 
 ### Negative Test
 
@@ -166,7 +167,10 @@ Both commands should instantly fail with `Permission denied`. _(Note: This demon
 
 ### Updating Secrets
 
-Whenever you modify your local `site-private/.env` or `secretspec.toml`, you must run `bash control/bin/publish_secrets.sh` to sync the changes into the locked `/var/db/` vault.
+Whenever declarations or provider values change through the wrapper, the
+canonical `/var/db/` store is updated directly. Mirror declaration-only changes
+into `site-private/secretspec.toml.example` through a worktree PR and release,
+then run `secretspec publish` (or `publish_secrets.sh`) to verify schema parity.
 
 ## 6. Two Coexisting Patterns
 

--- a/docs/operations/secretspec-wrapper-lifecycle.md
+++ b/docs/operations/secretspec-wrapper-lifecycle.md
@@ -16,15 +16,22 @@ source-delete NAME
 source-get NAME
 source-check
 source-export
+source-template-check
 source-publish
 ```
 
-`source-add` changes the declared schema and creates no secret value. `source-set`
-prompts for the value without placing it in chat. `source-delete` removes the
-provider value while retaining the declaration. `source-get` and
-`source-export` are explicit audited reads. Mutations synchronize the
-operator-owned source store into `/var/db/stayturgid-secrets` using fixed paths
-and owner-only modes.
+`source-add` changes the canonical runtime schema and creates no secret value. It
+also prints the required follow-up: mirror the declaration into the tracked
+`site-private/secretspec.toml.example` from a task worktree, then release it.
+The only live manifest and dotenv provider are under
+`/var/db/stayturgid-secrets`; no runtime secret file remains in a Git checkout.
+`source-template-check` reports only whether the runtime manifest and tracked
+example are byte-identical; it never prints either file. `source-set` prompts
+for the value without placing it in chat. `source-delete` removes the provider
+value while retaining the declaration. `source-get` and `source-export` are
+explicit audited reads. `source-publish` is retained as a compatibility
+operation that repairs canonical-store ownership/modes; it no longer copies
+between stores.
 
 The wrapper also retains the `_secretspec`-only consumer operations:
 
@@ -48,7 +55,7 @@ explicit source-to-vault synchronization.
 
 Declarations and values are therefore changed through the wrapper rather than
 by editing `secretspec.toml` or `.env` directly. The wrapper remains the policy
-boundary; the source and protected vault are synchronized after mutations.
+boundary, and `/var/db/stayturgid-secrets` is the single canonical live store.
 
 ## Applying safely
 

--- a/secretspec.toml
+++ b/secretspec.toml
@@ -1,1 +1,1 @@
-../site-private/secretspec.toml
+../site-private/secretspec.toml.example

--- a/tests/python/requirements.txt
+++ b/tests/python/requirements.txt
@@ -1,7 +1,9 @@
 # Python test dependencies. Managed via pyproject.toml (project root).
 # Install: uv venv .venv-test && uv pip install -r tests/python/requirements.txt
 # Or:     uv sync
-ansible-core>=2.16
+# ansible-core 2.21.x's installed ansible-test removes/loses its own
+# ansible_test._util.target package after a run; cap at the last stable minor.
+ansible-core>=2.16,<2.21
 jinja2>=3.1
 pytest>=7
 pytest-mock>=3

--- a/tests/python/test_secretspec_exec.py
+++ b/tests/python/test_secretspec_exec.py
@@ -47,8 +47,8 @@ def test_wrapper_rejects_arbitrary_secret_spec_arguments():
         assert "denied" in result.stderr
     text = wrapper.read_text()
     assert 'exec "$@"' not in text
-    assert "SOURCE_DIR=/Users/djbclark/ops/site-private" in text
-    assert 'SOURCE_MANIFEST="$SOURCE_DIR/secretspec.toml"' in text
+    assert 'SOURCE_DIR="$VAULT_DIR"' in text
+    assert 'SOURCE_MANIFEST="$VAULT_MANIFEST"' in text
 
 
 def test_wrapper_documents_tracked_lifecycle_operations():
@@ -63,9 +63,38 @@ def test_wrapper_documents_tracked_lifecycle_operations():
         "source-get",
         "source-check",
         "source-export",
+        "source-template-check",
         "source-publish",
     ):
         assert operation in text
+
+
+def test_wrapper_keeps_runtime_manifest_out_of_git_workflow():
+    from pathlib import Path
+
+    root = Path(__file__).parents[2]
+    wrapper = root / "control" / "bin" / "stayturgid-secretspec-wrapper.sh"
+    text = wrapper.read_text()
+    assert (root / "secretspec.toml").readlink() == Path("../site-private/secretspec.toml.example")
+    assert "SOURCE_EXAMPLE=/Users/djbclark/ops/site-private/secretspec.toml.example" in text
+    assert 'cmp -s "$SOURCE_MANIFEST" "$SOURCE_EXAMPLE"' in text
+    assert "mirror %s in %s through a worktree PR" in text
+    assert 'cat "$SOURCE_MANIFEST"' not in text
+
+
+def test_single_store_wrapper_and_publisher_have_no_checkout_source():
+    from pathlib import Path
+
+    root = Path(__file__).parents[2]
+    wrapper = (root / "control/bin/stayturgid-secretspec-wrapper.sh").read_text()
+    publisher = (root / "control/bin/publish_secrets.sh").read_text()
+    assert 'SOURCE_DIR="$VAULT_DIR"' in wrapper
+    assert 'SOURCE_MANIFEST="$VAULT_MANIFEST"' in wrapper
+    assert "/ops/site-private/.env" not in wrapper + publisher
+    assert '/ops/site-private/secretspec.toml"' not in wrapper + publisher
+    assert 'sudo -n "$WRAPPER" source-publish' in publisher
+    assert 'sudo -n "$WRAPPER" source-check' in publisher
+    assert 'sudo -n "$WRAPPER" source-template-check' in publisher
 
 
 def test_firerpa_operation_is_fixed_to_one_token(monkeypatch):


### PR DESCRIPTION
## Summary

- make `/var/db/stayturgid-secrets` the only live SecretSpec store
- preserve the existing `source-*` wrapper UX
- replace source-to-vault publishing with canonical-store verification
- pin ansible-core below the broken 2.21 ansible-test line

## Verification

- full local suite functional gates passed
- 734 Python tests passed
- 112 ansible-test units passed
- ansible-test survives two consecutive runs on 2.20.8
- Ruff and focused wrapper tests pass