### PR TITLE
chore: release ops-v1.3.19

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.3.18"
+  "version": "1.3.19"
 }


### PR DESCRIPTION
## Summary

Coordinate stayturgid for 1.3.19: canonical /var/db SecretSpec lifecycle, stable Ansible test pin, and bridge test teardown fix.

## Verification

- implementation PR CI passed
- 734 Python tests and 112 ansible units passed
- bridge unit suite passed after release-branch refresh