### PR TITLE
docs: point Shizuku references at the frdminc org

### DIFF
--- a/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
+++ b/ansible_collections/stayturgid/android_common/roles/bootstrap_apks/defaults/main.yml
@@ -86,7 +86,7 @@ stayturgid_bootstrap_apks:
     checksum: "sha256:d5235ee5ed03431a76f4b3d79d02d139e76887e1fe717cfcdc6581f7ee0eb777"
     mutable_tag_snapshot: true
   - id: moe.shizuku.privileged.api
-    gh_repo: djbclark/Shizuku
+    gh_repo: frdminc/Shizuku
     gh_tag: "v13.7.0-thedjchi+stayturgid-release25"
     gh_pattern: "shizuku-v13.7.0-thedjchi+stayturgid-release25-universal.apk"
     version_name: "13.7.0-thedjchi+stayturgid-release25"

--- a/docs/operations/sessions/handoff-2026-07-24-firerpa-ownership.md
+++ b/docs/operations/sessions/handoff-2026-07-24-firerpa-ownership.md
@@ -31,7 +31,7 @@ Also report this worktree warning immediately:
   five-minute FIRERPA readiness window for slow Fire HD 8 startup.
 - site-djbclark PR [#2](https://github.com/djbclark/site-djbclark/pull/2):
   p7a incompatible-runtime policy and hd8 recovery mode.
-- Shizuku PR [#1](https://github.com/djbclark/Shizuku/pull/1): Fire OS
+- Shizuku PR [#1](https://github.com/frdminc/Shizuku/pull/1): Fire OS
   notification-resource and native-library packaging fixes.
 - The ownership inventory is summarized publicly in issue
   [#50](https://github.com/djbclark/stayturgid/issues/50); its seven operator

--- a/docs/operations/sessions/handoff-2026-07-31-overnight-orchestration.md
+++ b/docs/operations/sessions/handoff-2026-07-31-overnight-orchestration.md
@@ -92,7 +92,7 @@ pre-existing Shizuku PRs (#2 Fire OS notification/native lib fix, #3
 HANDOFF.md/OPTIONS.md docs, #4 signing-cert trust allowlist, #5 CI signing
 secrets — #4/#5 look related to open issue `stayturgid#158` "Patch
 djbclark/Shizuku fork to permanently grant org.stayturgid.agent"). Check
-`gh pr list --repo djbclark/Shizuku --state all` for the outcome if this
+`gh pr list --repo frdminc/Shizuku --state all` for the outcome if this
 wasn't yet reported back.
 
 ## CodeRabbit feeder (self-pacing background automation)

--- a/docs/options.md
+++ b/docs/options.md
@@ -214,7 +214,7 @@ false`, "Authorized 0 applications" in the Shizuku app) twice in one
 session on hd8, including once triggered simply by restarting
 `shizuku_server` locally, with no OS reboot or app reinstall involved.
 Tracked as its own issue, [#158](https://github.com/djbclark/stayturgid/issues/158)
-(patch the `djbclark/Shizuku` fork to make `org.stayturgid.agent`'s grant
+(patch the `frdminc/Shizuku` fork to make `org.stayturgid.agent`'s grant
 permanent). **Still open**: the forced `CLOSED_NO_SHELL` soak test has not
 run.
 

--- a/docs/research/evaluations/firerpa-ai-review-prompt-deepseek-pro-2026-07-12.md
+++ b/docs/research/evaluations/firerpa-ai-review-prompt-deepseek-pro-2026-07-12.md
@@ -352,7 +352,7 @@ def repair_shizuku():
 | FIRERPA issue #138 (Android 16/Pixel 7a) | https://github.com/firerpa/lamda/issues/138                                                        |
 | scrcpy (alternative remote desktop)      | https://github.com/Genymobile/scrcpy                                                               |
 | AutoJs6 (stayturgid watchdog)            | https://github.com/djbclark/AutoJs6                                                                |
-| Shizuku (fork used by stayturgid)        | https://github.com/djbclark/Shizuku                                                                |
+| Shizuku (fork used by stayturgid)        | https://github.com/frdminc/Shizuku                                                                |
 | Obtainium (app catalog)                  | https://github.com/djbclark/Obtainium                                                              |
 | Hermes Agent (control-node gateway)      | https://github.com/anomalyco/hermes-agent                                                          |
 | OpenCode (AI coding agent)               | https://github.com/anomalyco/opencode                                                              |

--- a/docs/research/evaluations/firerpa-ai-review-prompt-deepseek-pro-2026-07-12.md
+++ b/docs/research/evaluations/firerpa-ai-review-prompt-deepseek-pro-2026-07-12.md
@@ -352,7 +352,7 @@ def repair_shizuku():
 | FIRERPA issue #138 (Android 16/Pixel 7a) | https://github.com/firerpa/lamda/issues/138                                                        |
 | scrcpy (alternative remote desktop)      | https://github.com/Genymobile/scrcpy                                                               |
 | AutoJs6 (stayturgid watchdog)            | https://github.com/djbclark/AutoJs6                                                                |
-| Shizuku (fork used by stayturgid)        | https://github.com/frdminc/Shizuku                                                                |
+| Shizuku (fork used by stayturgid)        | https://github.com/frdminc/Shizuku                                                                 |
 | Obtainium (app catalog)                  | https://github.com/djbclark/Obtainium                                                              |
 | Hermes Agent (control-node gateway)      | https://github.com/anomalyco/hermes-agent                                                          |
 | OpenCode (AI coding agent)               | https://github.com/anomalyco/opencode                                                              |


### PR DESCRIPTION
## What

Shizuku moved from `djbclark/Shizuku` to `frdminc/Shizuku` on 2026-08-15 (along with `tendcf` and `nix2cf`) as part of grouping work under the new `frdminc` org. This updates the stale references.

GitHub redirects the old URLs, so nothing was broken — this is stale-pointer cleanup.

## What changed

Things a reader or tool uses to reach the repo **today**: hyperlinks, `gh --repo` / `-R` targets, the `bootstrap_apks` `gh_repo` value, the `.store/Shizuku.git` remote table, and the fork-chain provenance line.

## What deliberately did NOT change

Lines that record a past observation or event, where a rewrite would make the statement false:

- dated session-handoff entries (`release23` published, the 2026-07-26 fork state)
- the `docs/relay/LEDGER.md` 2026-07-18 row
- the `thedjchi/Shizuku` → `djbclark/Shizuku` migration note — that migration went to `djbclark`
- a verbatim issue title quoted inside a handoff

`djbclark/Shizuku-API` is untouched — it did **not** move.

## Related

Local git remotes were updated separately (including the shared `.store/Shizuku.git` bare repo, which propagates to the `main/`, `kill-bluehost/`, and `herdr-lifecycle-reporter/` Shizuku worktrees). Context recorded in `site-private` memory as `project_frdminc_org_move.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)