### PR TITLE
chore: release ops-v1.3.23

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.3.22"
+  "version": "1.3.23"
 }


### PR DESCRIPTION
Version bump for coordinated ops-v1.3.23 release, following the secretspec-cleanup merges (#87/#295/#160).