### PR TITLE
ops-release: 1.3.24

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.3.23"
+  "version": "1.3.24"
 }


### PR DESCRIPTION
Coordinated suite version bump to **1.3.24**.

Payload: site-private shell-config consolidation (#89 — two-tier `~/.bashrc`, herdr self-closure-defense wrapper precedence restored + enforced by self-test). stayturgid and site-djbclark are unchanged since 1.3.23 — version bump only, required for the coordinated `ops-v1.3.24` tag.

Awaiting operator confirmation per OPS-RELEASES.md step 4 before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)