### PR TITLE
chore(release): ops-v1.3.26

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.3.25"
+  "version": "1.3.26"
 }


### PR DESCRIPTION
Coordinated suite version bump to 1.3.26.

1.3.26 ships the release-verification fix from djbclark/site-djbclark#168: `verify_github_release()` now resolves releases through `gh release list` (GraphQL) instead of REST get-release-by-tag, whose tag→release index went bad for the private repo `djbclark/site-private` and broke `ops-release-deploy`, `ops-release-status` and `ops-memory-sync`.

Version bump only in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)