### PR TITLE
chore(release): ops-v1.4.0

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.3.26"
+  "version": "1.4.0"
 }


### PR DESCRIPTION
Coordinated suite version bump to 1.4.0, paired with site-djbclark#172 (LiteLLM from a git checkout, ClinePass only).

Minor rather than patch: the proxy stops serving `deepseek-chat`, `deepseek-reasoner`, `openrouter-auto`, `opencode-zen-flash` and `smart-router`. No fallback chain masks it.

No functional change in this repo — `ops-release.json` only, per the release contract in site-djbclark `docs/OPS-RELEASES.md` (same tag + matching `ops-release.json` in all three repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)