### PR TITLE
chore(release): ops-v1.4.1

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.4.0"
+  "version": "1.4.1"
 }


### PR DESCRIPTION
Coordinated suite version bump to 1.4.1, paired with site-djbclark#174 (Hindsight reaches its LLM through the site-local LiteLLM proxy).

Patch rather than minor: no service changes what it serves. The substantive part is repairing drift — `roles/hindsight`'s plist template had fallen out of sync with the hand-edited live LaunchAgent, so applying the role would have reverted Hindsight to `openai-codex` with no model configuration.

Per the release contract in site-djbclark `docs/OPS-RELEASES.md`, all three repos need the same tag and a matching `ops-release.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)