### PR TITLE
chore(release): ops-v1.4.2

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.4.1"
+  "version": "1.4.2"
 }


### PR DESCRIPTION
Coordinated suite version bump to 1.4.2, paired with site-djbclark#176 (proxy stops silently truncating; hindsight bootstrap race fixed).

Per the release contract in site-djbclark `docs/OPS-RELEASES.md`, all three repos need the same tag and a matching `ops-release.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)