### PR TITLE
chore(release): ops-v1.4.3

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.4.2"
+  "version": "1.4.3"
 }


### PR DESCRIPTION
Version bump only — `ops-release.json` 1.4.2 → 1.4.3.

## What ships in ops-v1.4.3

**ClinePass model namespace correction.** The provider module in the LiteLLM fork was re-adding `clinepass/` as Cline's catalog namespace. That namespace does not exist. It failed silently because the API validates only the *shape* of a model id — `totallybogus/deepseek-v4-flash` also returns HTTP 200 — but it was not harmless: an unrecognised namespace resolved to the date-pinned `deepseek/deepseek-v4-flash-0731`, while the correct `cline-pass/` resolves to `deepseek/deepseek-v4-flash`. The proxy had been serving a different model snapshot than Hermes.

Code fix is in `djbclark/litellm` (`feat/clinepass-provider`); this suite release carries the corrected role documentation (site-djbclark#178).

Also corrects the `max_tokens` rationale comment: the claim that the API reported `finish_reason: "stop"` on a truncated response could not be reproduced on re-probing.

Docs and comments only; no behaviour change in the ansible roles.