### PR TITLE
chore(release): ops-v1.4.4

### DIFF
--- a/ops-release.json
+++ b/ops-release.json
@@ -1,5 +1,5 @@
 {
   "schema": 1,
   "suite": "djbclark-ops",
-  "version": "1.4.3"
+  "version": "1.4.4"
 }


### PR DESCRIPTION
Version bump for coordinated release ops-v1.4.4.

site-djbclark change this release: #180 — clinepass-minimax-m3 + clinepass-kimi-k3 LiteLLM proxy models (DeepSeek pay-per-token retirement, handoff ed68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)